### PR TITLE
chore: add docu and journal folders

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,19 @@
+---
+name: Bug Report
+about: Fehler melden
+labels: bug
+---
+
+## Beschreibung
+
+## Schritte zum Reproduzieren
+1.
+2.
+3.
+
+## Erwartetes Verhalten
+
+## Tatsächliches Verhalten
+
+## Zusätzliche Infos
+- Logs/Screenshots

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,13 @@
+---
+name: Feature Request
+about: Neue Funktion vorschlagen
+labels: enhancement
+---
+
+## Ziel
+
+## Nutzen
+
+## Vorschlag
+
+## Alternativen

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+# Kontext
+- Warum ist diese Änderung nötig?
+
+# Änderungen
+- 
+
+# Tests
+- [ ] Lokal getestet
+
+# Checkliste
+- [ ] Dokumentation aktualisiert
+- [ ] Keine sensiblen Daten enthalten

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# Editors
+.vscode/
+.idea/
+
+# Logs
+*.log
+
+# Dependencies
+node_modules/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,15 @@
+# Code of Conduct
+
+Wir verpflichten uns zu einem respektvollen, inklusiven und professionellen Umgang.
+
+## Erwartetes Verhalten
+- Respektvoll und konstruktiv kommunizieren.
+- Kritik sachlich und lösungsorientiert äußern.
+- Unterschiedliche Perspektiven anerkennen.
+
+## Unerwünschtes Verhalten
+- Beleidigungen, Herabwürdigungen oder Diskriminierung.
+- Belästigung in jeglicher Form.
+
+## Durchsetzung
+Bei Verstößen bitte an die Projektverantwortlichen wenden.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing
+
+Vielen Dank für deinen Beitrag!
+
+## Workflow
+1. Issue erstellen oder einem Issue zuordnen.
+2. Feature-Branch anlegen.
+3. Änderungen implementieren und lokal prüfen.
+4. Pull Request mit klarer Beschreibung öffnen.
+
+## Commit-Konvention
+- Präfix nach Typ verwenden: `feat:`, `fix:`, `docs:`, `chore:`.
+- Beispiel: `feat: initiale projektstruktur`.
+
+## Review
+- Mindestens ein Review vor Merge.
+- PRs sollen klein und nachvollziehbar sein.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Argus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Argus
+
+Grundkonfiguration für das Projekt **Argus**. Dieses Repository enthält Basiskonventionen, Prozessdokumentation und ein schlankes Kanban-Board als Ausgangspunkt.
+
+## Inhalt
+- [Projekt-Setup](#projekt-setup)
+- [Arbeitsweise](#arbeitsweise)
+- [Kanban](#kanban)
+
+## Projekt-Setup
+- Editor- und Stilregeln: siehe `.editorconfig`.
+- Git-Konventionen: siehe `.gitattributes` und `.gitignore`.
+- Zusammenarbeit: siehe `CONTRIBUTING.md` und `CODE_OF_CONDUCT.md`.
+- Pull Requests: Vorlage in `.github/PULL_REQUEST_TEMPLATE.md`.
+- Issues: Templates in `.github/ISSUE_TEMPLATE/`.
+- Doku- und Journal-Ordner: siehe `docu/` und `journal/`.
+
+## Arbeitsweise
+- Plane Arbeit als kleine, überprüfbare Einheiten (Issues/Tasks).
+- Nutze Labels für Priorität und Status (z. B. `prio:high`, `status:in-progress`).
+- Jede Änderung erfolgt via Pull Request und Review.
+
+## Kanban
+Das initiale Kanban-Board findest du hier: [`docs/kanban.md`](docs/kanban.md).

--- a/docs/kanban.md
+++ b/docs/kanban.md
@@ -1,0 +1,21 @@
+# Kanban Board (Start)
+
+Dieses Board ist als schlanker Startpunkt gedacht und kann später in GitHub Projects übertragen werden.
+
+## Backlog
+- Projektziel und Scope definieren
+- Stakeholder und Rollen klären
+- Technische Architektur skizzieren
+
+## Ready
+- Repositorium initial aufsetzen
+- Basis-Dokumentation erstellen
+
+## In Progress
+- 
+
+## Review
+- 
+
+## Done
+- 

--- a/docu/README.md
+++ b/docu/README.md
@@ -1,0 +1,8 @@
+# Dokumentation
+
+Hier sammeln wir Projekt- und Fachdokumentation (z. B. Architektur, Entscheidungen, Spezifikationen).
+
+## Strukturvorschlag
+- `architecture/` – Architekturskizzen und Diagramme
+- `decisions/` – Architektur-Entscheidungen (ADRs)
+- `specs/` – Fachliche/technische Spezifikationen

--- a/journal/README.md
+++ b/journal/README.md
@@ -1,0 +1,7 @@
+# Journal
+
+Dieses Journal dient als laufendes Projektlogbuch (z. B. Meeting-Notizen, Status-Updates, Entscheidungen).
+
+## Strukturvorschlag
+- `YYYY-MM/` – Monatliche Ordner
+- `YYYY-MM-DD.md` – Tagesnotizen


### PR DESCRIPTION
### Motivation
- Projektstruktur um dedizierte Ordner für Projektdokumentation und ein laufendes Journal erweitern, damit Architektur-, Spezifikations- und Tagesnotizen zentral abgelegt werden können.

### Description
- Neue Ordner und Starter-Dateien hinzugefügt: `docu/README.md` und `journal/README.md` mit Strukturvorschlägen für Dokumentation und Projektjournal. 
- Haupt-`README.md` um Verweis auf die neuen Ordner ergänzt (`docu/` und `journal/`).
- Keine Code-Änderungen; nur Dokumentations- und Strukturdateien wurden hinzugefügt.

### Testing
- Es wurden keine automatisierten Tests ausgeführt, da die Änderungen rein dokumentarisch sind.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697501f4184483338fac317e7ab86882)