### PR TITLE
Remove docu folder and add GitHub Projects setup to Kanban docs

### DIFF
--- a/docs/kanban.md
+++ b/docs/kanban.md
@@ -2,6 +2,25 @@
 
 Dieses Board ist als schlanker Startpunkt gedacht und kann später in GitHub Projects übertragen werden.
 
+## GitHub Projects Einrichtung (empfohlen)
+
+1. **GitHub → Projects → New Project**
+   - Typ: *Board*
+   - Name: *BackstagePass Kanban*
+2. **Spalten anlegen** (entsprechend diesem Dokument):
+   - Backlog
+   - Ready
+   - In Progress
+   - Review
+   - Done
+3. **Issue-Integration aktivieren**
+   - Repository: `/workspace/Argus` (GitHub Repo)
+   - Automations: Optional (z. B. „Item moved to In Progress when assigned“)
+4. **Initiale Karten anlegen**
+   - Die Einträge aus den Listen unten als Issues anlegen und dem Project hinzufügen.
+
+> Hinweis: Dieses Dokument bleibt als „Single Source of Truth“ für die initiale Struktur.
+
 ## Backlog
 - Projektziel und Scope definieren
 - Stakeholder und Rollen klären

--- a/docu/README.md
+++ b/docu/README.md
@@ -1,8 +1,0 @@
-# Dokumentation
-
-Hier sammeln wir Projekt- und Fachdokumentation (z. B. Architektur, Entscheidungen, Spezifikationen).
-
-## Strukturvorschlag
-- `architecture/` – Architekturskizzen und Diagramme
-- `decisions/` – Architektur-Entscheidungen (ADRs)
-- `specs/` – Fachliche/technische Spezifikationen


### PR DESCRIPTION
### Motivation
- Consolidate documentation by removing the legacy `docu/` directory so the repository uses the primary `docs/` area as the single source of truth. 
- Provide explicit, reproducible guidance for creating the Kanban board via GitHub Projects by adding a short setup section to `docs/kanban.md`.

### Description
- Remove the `docu/` documentation folder and its contents, including `docu/README.md` and `docu/architecture/backstagepass-architecture.md`.
- Update `docs/kanban.md` to add a `GitHub Projects Einrichtung (empfohlen)` section with recommended project type, column names, issue-integration hints, and initial card creation steps.
- Ensure the repository documentation surface is consolidated under `docs/` and that the Kanban doc serves as the initial template for a GitHub Projects board.

### Testing
- No automated tests were run because this change only modifies and removes documentation files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697508d3dae88333a46e30f7d8b91255)