### PR TITLE
Add regisseur basis setup inbox entry

### DIFF
--- a/journal/inbox/regisseur-basis-setup.md
+++ b/journal/inbox/regisseur-basis-setup.md
@@ -1,0 +1,20 @@
+# Regisseur: Basis-Setup (Vercel + Supabase) für Mockup
+
+```json
+{
+  "type": "code",
+  "title": "Basis-Setup für Mockup: Vercel-Projekt + Supabase-Datenbank",
+  "userStory": "Als Team möchten wir ein Basis-Setup mit Vercel und Supabase haben, damit wir schnell ein klickbares Mockup der App zeigen können.",
+  "acceptanceCriteria": [
+    "Es existiert ein Vercel-Projekt für die App und es ist erreichbar.",
+    "Eine Supabase-Instanz ist angelegt und mit dem Projekt verknüpft (Zugangsdaten vorhanden).",
+    "Es gibt eine lauffähige Mockup-Version (statische Seiten oder Dummy-Daten), die im Browser sichtbar ist.",
+    "Ein kurzer Setup-Guide (README oder Notiz) beschreibt, wie man lokal startet und wie das Mockup deployed wird."
+  ],
+  "priority": "high",
+  "labels": [
+    "feature",
+    "chore"
+  ]
+}
+```


### PR DESCRIPTION
### Motivation
- Capture a concise inbox entry describing a base setup (Vercel + Supabase) to enable a clickable app mockup.

### Description
- Add `journal/inbox/regisseur-basis-setup.md` containing a JSON-formatted inbox entry with title, user story, acceptance criteria, priority, and labels.

### Testing
- No automated tests were run because this is a documentation/content-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975242216908333968c82012671ff5e)