### PR TITLE
chore(journal): add mockup basis-setup tech plan (Vercel + Supabase)

### DIFF
--- a/journal/2026-01-24.md
+++ b/journal/2026-01-24.md
@@ -1,0 +1,78 @@
+# Tech Plan: Basis-Setup für Mockup (Vercel + Supabase)
+
+**Issue:** TBD
+**Priority:** high
+
+## 1. Datenbank (Supabase)
+
+Für ein klickbares Mockup reichen minimalistische Tabellen mit Dummy-Daten. Fokus liegt auf sauberem Setup und RLS, nicht auf produktiven Datenmodellen.
+
+### Migrationen
+```sql
+-- supabase/migrations/20260124000000_mockup_seed.sql
+create table if not exists public.mockup_pages (
+  id uuid primary key default gen_random_uuid(),
+  slug text not null unique,
+  title text not null,
+  body text not null,
+  created_at timestamptz not null default now()
+);
+```
+
+### RLS Policies
+```sql
+alter table public.mockup_pages enable row level security;
+
+create policy "mockup_pages_read"
+  on public.mockup_pages
+  for select
+  to anon
+  using (true);
+```
+
+## 2. Dateistruktur
+
+```
+apps/web/
+  ├── app/
+  │   ├── page.tsx
+  │   └── mockup/
+  │       ├── page.tsx
+  │       └── [slug]/
+  │           └── page.tsx
+  ├── lib/
+  │   └── mockup/
+  │       └── data.ts
+  └── README.md
+```
+
+## 3. Data Flow
+
+1. User navigiert auf `/mockup` oder `/mockup/[slug]`.
+2. Server Component lädt Daten aus `lib/mockup/data.ts` (Dummy-Daten) oder optional Supabase.
+3. Seite rendert statisch die Mockup-Inhalte.
+4. (Optional) Deployment auf Vercel zeigt Mockup öffentlich.
+
+## 4. Schnittstellen
+
+### Component Props
+```typescript
+interface MockupPageProps {
+  slug: string
+}
+```
+
+### API Types
+```typescript
+type MockupPage = {
+  id: string
+  slug: string
+  title: string
+  body: string
+}
+```
+
+## 5. Security Considerations
+- [ ] Supabase RLS aktivieren (auch für Dummy-Tabellen).
+- [ ] Secrets nur via `.env` / Vercel Environment Variables.
+- [ ] Keine sensiblen Daten im Mockup-Inhalt.


### PR DESCRIPTION
### Motivation
- Document a minimal tech plan for a clickable mockup deployed on Vercel with a Supabase backend, focusing on a simple schema, RLS, file layout and data flow.

### Description
- Add `journal/2026-01-24.md` containing a sample migration (`supabase/migrations/20260124000000_mockup_seed.sql`), example RLS policy, suggested `apps/web` file structure, data flow, component/API types and a security checklist.

### Testing
- No automated tests were run; this change is documentation-only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697522e15be48333a4a736f85f98c4f9)