### PR TITLE
feat(mockup): add mockup pages and dummy data layer

### DIFF
--- a/apps/web/app/mockup/[slug]/page.tsx
+++ b/apps/web/app/mockup/[slug]/page.tsx
@@ -1,0 +1,59 @@
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { getMockupPage, getAllMockupPages } from '../../../lib/mockup/data'
+
+interface MockupPageProps {
+  params: Promise<{ slug: string }>
+}
+
+export async function generateStaticParams() {
+  const pages = getAllMockupPages()
+  return pages.map((page) => ({ slug: page.slug }))
+}
+
+export default async function MockupDetailPage({ params }: MockupPageProps) {
+  const { slug } = await params
+  const page = getMockupPage(slug)
+
+  if (!page) {
+    notFound()
+  }
+
+  return (
+    <main className="min-h-screen bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-3xl mx-auto">
+        <nav className="mb-8">
+          <Link
+            href="/mockup"
+            className="text-blue-600 hover:text-blue-800 flex items-center gap-2"
+          >
+            <span>&larr;</span>
+            <span>Zurück zur Übersicht</span>
+          </Link>
+        </nav>
+
+        <article className="bg-white rounded-lg shadow p-8 border border-gray-200">
+          <h1 className="text-3xl font-bold text-gray-900 mb-6">
+            {page.title}
+          </h1>
+
+          <div
+            className="prose prose-gray max-w-none"
+            dangerouslySetInnerHTML={{ __html: page.body }}
+          />
+        </article>
+
+        <div className="mt-8 p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
+          <p className="text-sm text-yellow-800">
+            <strong>Mockup-Hinweis:</strong> Dies ist eine Vorschau-Seite für Design-Feedback.
+            Die Inhalte sind Platzhalter.
+          </p>
+        </div>
+
+        <div className="mt-12 text-center text-sm text-gray-400">
+          BackstagePass Mockup Preview
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/apps/web/app/mockup/page.tsx
+++ b/apps/web/app/mockup/page.tsx
@@ -1,0 +1,40 @@
+import Link from 'next/link'
+import { getAllMockupPages } from '../../lib/mockup/data'
+
+export default function MockupOverviewPage() {
+  const pages = getAllMockupPages()
+
+  return (
+    <main className="min-h-screen bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-3xl mx-auto">
+        <h1 className="text-3xl font-bold text-gray-900 mb-8">
+          Mockup-Seiten
+        </h1>
+        <p className="text-gray-600 mb-8">
+          Klickbare Mockups für Design-Feedback. Wähle eine Seite aus:
+        </p>
+
+        <div className="grid gap-4">
+          {pages.map((page) => (
+            <Link
+              key={page.id}
+              href={`/mockup/${page.slug}`}
+              className="block p-6 bg-white rounded-lg shadow hover:shadow-md transition-shadow border border-gray-200"
+            >
+              <h2 className="text-xl font-semibold text-gray-900">
+                {page.title}
+              </h2>
+              <p className="text-gray-500 mt-1">
+                /mockup/{page.slug}
+              </p>
+            </Link>
+          ))}
+        </div>
+
+        <div className="mt-12 text-center text-sm text-gray-400">
+          BackstagePass Mockup Preview
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/apps/web/lib/mockup/data.ts
+++ b/apps/web/lib/mockup/data.ts
@@ -1,0 +1,75 @@
+/**
+ * Mockup Data Layer
+ * Dummy-Daten für Mockup-Seiten (ohne Supabase-Anbindung)
+ */
+
+export type MockupPage = {
+  id: string
+  slug: string
+  title: string
+  body: string
+}
+
+export const mockupPages: MockupPage[] = [
+  {
+    id: '1',
+    slug: 'dashboard',
+    title: 'Dashboard',
+    body: `
+      <h2>Willkommen im Theater-Dashboard</h2>
+      <p>Hier siehst du eine Übersicht aller aktuellen Produktionen,
+      anstehenden Proben und offenen Aufgaben.</p>
+      <ul>
+        <li>3 aktive Produktionen</li>
+        <li>12 Proben diese Woche</li>
+        <li>5 offene Aufgaben</li>
+      </ul>
+    `,
+  },
+  {
+    id: '2',
+    slug: 'produktionen',
+    title: 'Produktionen',
+    body: `
+      <h2>Aktuelle Produktionen</h2>
+      <div>
+        <h3>Hamlet</h3>
+        <p>Premiere: 15. März 2026</p>
+        <p>Status: In Proben</p>
+      </div>
+      <div>
+        <h3>Der Kirschgarten</h3>
+        <p>Premiere: 20. April 2026</p>
+        <p>Status: Casting</p>
+      </div>
+      <div>
+        <h3>Sommernachtstraum</h3>
+        <p>Premiere: 1. Juni 2026</p>
+        <p>Status: Planung</p>
+      </div>
+    `,
+  },
+  {
+    id: '3',
+    slug: 'mitglieder',
+    title: 'Mitglieder',
+    body: `
+      <h2>Ensemble & Crew</h2>
+      <p>Übersicht aller Vereinsmitglieder mit Rollen und Kontaktdaten.</p>
+      <table>
+        <tr><th>Name</th><th>Rolle</th><th>Aktiv seit</th></tr>
+        <tr><td>Anna Müller</td><td>Schauspielerin</td><td>2020</td></tr>
+        <tr><td>Max Schmidt</td><td>Regisseur</td><td>2018</td></tr>
+        <tr><td>Lisa Weber</td><td>Bühnenbildnerin</td><td>2021</td></tr>
+      </table>
+    `,
+  },
+]
+
+export function getMockupPage(slug: string): MockupPage | undefined {
+  return mockupPages.find((page) => page.slug === slug)
+}
+
+export function getAllMockupPages(): MockupPage[] {
+  return mockupPages
+}


### PR DESCRIPTION
Implements Issues #14 and #15:
- Add MockupPage type and dummy data in lib/mockup/data.ts
- Create /mockup overview page with Server Components
- Create /mockup/[slug] dynamic route for individual pages
- Style with Tailwind CSS
- Include 3 sample mockups: Dashboard, Produktionen, Mitglieder

# Kontext
- Warum ist diese Änderung nötig?

# Änderungen
- 

# Tests
- [ ] Lokal getestet

# Checkliste
- [ ] Dokumentation aktualisiert
- [ ] Keine sensiblen Daten enthalten
