### PR TITLE
Publish BackstagePass module detail document and add docs index links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ BackstagePass ist der digitale Backstage-Bereich f√ºr die Theatergruppe Widen ‚Ä
 - [Arbeitsweise](#arbeitsweise)
 - [Kanban](#kanban)
 - [Infrastruktur](#infrastruktur)
+- [Module (Detailkonzept)](docs/backstagepass-module-details.md)
 
 ## Aktueller Status
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,12 @@
 
 Hier sammeln wir Projekt- und Fachdokumentation (z. B. Architektur, Entscheidungen, Spezifikationen).
 
+## Inhalte
+- [BackstagePass – Detailkonzept der drei Kernmodule](backstagepass-module-details.md)
+- [BackstagePass – High-Level Architecture](architecture/backstagepass-architecture.md)
+- [Teamrollen & Workflow](team.md)
+- [Kanban-Board](kanban.md)
+
 ## Strukturvorschlag
 - `architecture/` – Architekturskizzen und Diagramme
 - `decisions/` – Architektur-Entscheidungen (ADRs)

--- a/docs/backstagepass-module-details.md
+++ b/docs/backstagepass-module-details.md
@@ -1,0 +1,81 @@
+# 🎭 BackstagePass – Detailkonzept der drei Kernmodule
+
+Dieses Dokument beschreibt die drei zentralen Module von **BackstagePass** und konkretisiert deren Ziele, Kernfunktionen, Datenobjekte sowie typische Nutzerabläufe.
+
+---
+
+## 1) 👥 Modul „Mitglieder“
+
+**Ziel:** Alle Vereinsmitglieder, Rollen und Kontaktinformationen an einem Ort verwalten.
+
+### Kernfunktionen
+- Mitgliederprofil anlegen, bearbeiten, archivieren
+- Rollen & Zuständigkeiten (Ensemble, Technik, Regie, Orga)
+- Kontaktverwaltung inkl. Notfallkontakt
+- Verfügbarkeiten und Teilnahme-Status
+
+### Wichtige Datenobjekte
+- **Mitglied** (Name, Rolle, Status, Kontakt)
+- **Rollen** (Schauspiel, Technik, Regie, Produktion)
+- **Verfügbarkeit** (Datum, Zeitfenster, Status)
+
+### Typische Workflows
+1. Neues Mitglied wird angelegt (Stammdaten + Rolle).
+2. Verfügbarkeit wird pro Zeitraum gepflegt.
+3. Mitglied wird Produktionen/Terminen zugeordnet.
+
+---
+
+## 2) 🎬 Modul „Produktionen“
+
+**Ziel:** Theaterproduktionen strukturiert planen, besetzen und betreuen.
+
+### Kernfunktionen
+- Produktion anlegen mit Status (Planung, Casting, Proben, Premiere)
+- Besetzung & Teamzuweisung
+- Produktionsdokumente (Stück, Skript, Casting-Notizen)
+- Übersicht über laufende und kommende Produktionen
+
+### Wichtige Datenobjekte
+- **Produktion** (Titel, Zeitraum, Status)
+- **Rollenbesetzung** (Mitglied ↔ Rolle in Produktion)
+- **Dokumente** (Skript, Spielplan, Requisitenliste)
+
+### Typische Workflows
+1. Produktion wird geplant und im System angelegt.
+2. Rollenbesetzung wird Schritt für Schritt ergänzt.
+3. Produktion erhält einen Probenplan (Termine-Modul) und wird aktiv verfolgt.
+
+---
+
+## 3) 📅 Modul „Proben & Termine“
+
+**Ziel:** Alle Proben, Aufführungen und Meetings zentral planen und kommunizieren.
+
+### Kernfunktionen
+- Termine erstellen (Probe, Aufführung, Meeting)
+- Kalenderansicht mit Filter (Produktion, Rolle, Zeitraum)
+- Einladungen & Teilnahme-Status (Zusagen/Absagen)
+- Erinnerungen und Check-in vor Ort
+
+### Wichtige Datenobjekte
+- **Termin** (Typ, Datum, Ort, Produktion)
+- **Teilnahme** (Mitglied ↔ Termin, Status)
+- **Erinnerung** (Zeitpunkt, Versandstatus)
+
+### Typische Workflows
+1. Regie erstellt Probenplan mit wiederkehrenden Terminen.
+2. Mitglieder erhalten Einladungen und bestätigen Teilnahme.
+3. Anwesenheit wird nach Termin dokumentiert.
+
+---
+
+## 🎯 Zusammenspiel der Module
+
+Die drei Module sind eng verzahnt und bilden gemeinsam den Kern von BackstagePass:
+
+- **Mitglieder** liefern die Personenbasis.
+- **Produktionen** strukturieren die künstlerischen Projekte.
+- **Proben & Termine** steuern die konkrete Zusammenarbeit im Kalender.
+
+Damit entsteht ein klarer, praxisnaher Ablauf: **Mitglied → Produktion → Termin**.


### PR DESCRIPTION
### Motivation
- Das Projekt benötigt eine leicht auffindbare Beschreibung der drei Kernmodule von BackstagePass, damit Teammitglieder Ziele, Funktionen und Datenmodelle schnell verstehen können.

### Description
- Neue Dokumentation `docs/backstagepass-module-details.md` hinzugefügt, die Ziele, Kernfunktionen, Datenobjekte und typische Workflows der Module `Mitglieder`, `Produktionen` und `Proben & Termine` beschreibt.
- Die Dokumentations-Indexseite `docs/README.md` wurde um einen Eintrag verlinkend auf das Detailkonzept erweitert; außerdem wurde im Projekt-README ein Link zur Modulbeschreibung ergänzt.

### Testing
- Keine automatisierten Tests ausgeführt, da es sich um reine Inhalts-/Dokumentationsänderungen handelt.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975df4f7c84833390be37ecdfe6d845)