### PR TITLE
Rename 'Proben & Termine' to 'Künstlerische Produktion' and add Milestones transcript

### DIFF
--- a/docs/backstagepass-module-details.md
+++ b/docs/backstagepass-module-details.md
@@ -44,11 +44,11 @@ Dieses Dokument beschreibt die drei zentralen Module von **BackstagePass** und k
 ### Typische Workflows
 1. Produktion wird geplant und im System angelegt.
 2. Rollenbesetzung wird Schritt für Schritt ergänzt.
-3. Produktion erhält einen Probenplan (Termine-Modul) und wird aktiv verfolgt.
+3. Produktion erhält einen Probenplan (Künstlerische Produktion) und wird aktiv verfolgt.
 
 ---
 
-## 3) 📅 Modul „Proben & Termine“
+## 3) 🎭 Modul „Künstlerische Produktion“
 
 **Ziel:** Alle Proben, Aufführungen und Meetings zentral planen und kommunizieren.
 
@@ -76,6 +76,29 @@ Die drei Module sind eng verzahnt und bilden gemeinsam den Kern von BackstagePas
 
 - **Mitglieder** liefern die Personenbasis.
 - **Produktionen** strukturieren die künstlerischen Projekte.
-- **Proben & Termine** steuern die konkrete Zusammenarbeit im Kalender.
+- **Künstlerische Produktion** steuert die konkrete Zusammenarbeit im Kalender.
 
 Damit entsteht ein klarer, praxisnaher Ablauf: **Mitglied → Produktion → Termin**.
+
+---
+
+## 🗂️ Milestones-Transkript (für Springer)
+
+**Ziel:** Die Modul-Ideen als Milestone-Grundlage festhalten und an den Bühnenmeister zur Ausformulierung übergeben.
+
+### Milestone 1: Mitglieder
+- Fokus: Mitgliederprofil, Rollen/Zuständigkeiten, Kontaktverwaltung, Verfügbarkeiten.
+- Kernobjekte: Mitglied, Rollen, Verfügbarkeit.
+- Workflow: Mitglied anlegen → Verfügbarkeit pflegen → Zuordnung zu Produktion/Terminen.
+
+### Milestone 2: Produktionen
+- Fokus: Produktion anlegen, Besetzung & Teamzuweisung, Dokumente, Status-Tracking.
+- Kernobjekte: Produktion, Rollenbesetzung, Dokumente.
+- Workflow: Produktion planen → Rollenbesetzung ergänzen → Probenplan anlegen.
+
+### Milestone 3: Künstlerische Produktion
+- Fokus: Terminplanung (Probe/Aufführung/Meeting), Kalenderansicht, Einladungen, Erinnerungen.
+- Kernobjekte: Termin, Teilnahme, Erinnerung.
+- Workflow: Regie erstellt Probenplan → Einladungen/Teilnahmen → Anwesenheit dokumentieren.
+
+**Übergabe an Bühnenmeister:** Bitte die obigen Milestones technisch ausformulieren (Datenmodelle, Schnittstellen, RLS, Komponentenstruktur).


### PR DESCRIPTION
### Motivation
- The module name was updated to better reflect the artistic scope and avoid the ambiguous label "Proben & Termine".
- A concise Milestones-Transkript was added to capture module ideas as a basis for a technical handoff to the Bühnenmeister.

### Description
- Renamed the third core module and aligned all references from `Proben & Termine` to `Künstlerische Produktion` in `docs/backstagepass-module-details.md`.
- Adjusted the production workflow line that referenced the old module name so it now points to `Künstlerische Produktion`.
- Appended a `Milestones-Transkript` section containing three milestone outlines (Mitglieder, Produktionen, Künstlerische Produktion) and a request to the Bühnenmeister to technically elaborate data models, interfaces, RLS and component structure.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975e323c40c8333b052adc49f05ba76)