### PR TITLE
Clarify Springer guidance for Regie inputs

### DIFF
--- a/docs/mitarbeiter-beschreibungen.md
+++ b/docs/mitarbeiter-beschreibungen.md
@@ -38,6 +38,7 @@ Der Springer hält den operativen Betrieb stabil. Er priorisiert, organisiert un
 - Triage von Issues und Bugs inkl. Labels (Severity/Priority).
 - Erkennt Engpässe, stößt Eskalationen an und koordiniert Blocker-Resolution.
 - Sichert den Status-Abgleich zwischen Rollen.
+- Stellt sicher, dass die Regie Ideen im `journal/00_inbox/` erfasst und Aufträge als Backlog-Issues sauber einordnet.
 
 **Wo das erledigt wird (Arbeitsorte/Artefakte)**
 - Eingang: Backlog-Ideen, laufende Issues, Release-Ziele.
@@ -102,6 +103,7 @@ Der Springer hält den operativen Betrieb stabil. Er priorisiert, organisiert un
 - Issue-Triage und Priorisierung
 - Blocker erkennen und eskalieren
 - Team-Koordination zwischen Rollen
+- Die Regie anleiten, Ideen im Journal-Posteingang zu dokumentieren und Aufträge im Backlog zu platzieren
 
 ### Arbeitsort / Artefakte
 - **Input:** Backlog-Issues, Release-Ziele


### PR DESCRIPTION
### Motivation
- Ensure the Springer role explicitly coordinates that the Regie records ideas in the `journal/00_inbox/` and places resulting tasks as Backlog issues so ideas and requests are routed to the correct pipeline.

### Description
- Add two short guidance lines in `docs/mitarbeiter-beschreibungen.md` under the Springer section: one in "Was diese Rolle tut" and one in "Verantwortlichkeiten" to instruct the Springer to ensure the Regie documents ideas and files backlog issues.

### Testing
- Documentation-only change; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975ef4b92a08333b8c4ec1f732a7fc0)