### PR TITLE
Fix mockup detail params handling

### DIFF
--- a/apps/web/app/mockup/[slug]/page.tsx
+++ b/apps/web/app/mockup/[slug]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from 'next/navigation'
 import { getMockupPage, getAllMockupPages } from '../../../lib/mockup/data'
 
 interface MockupPageProps {
-  params: Promise<{ slug: string }>
+  params: { slug: string }
 }
 
 export async function generateStaticParams() {
@@ -11,8 +11,8 @@ export async function generateStaticParams() {
   return pages.map((page) => ({ slug: page.slug }))
 }
 
-export default async function MockupDetailPage({ params }: MockupPageProps) {
-  const { slug } = await params
+export default function MockupDetailPage({ params }: MockupPageProps) {
+  const { slug } = params
   const page = getMockupPage(slug)
 
   if (!page) {


### PR DESCRIPTION
### Motivation
- Fix incorrect typing and usage of `params` on the mockup detail page so it matches the Next.js App Router contract and avoids async/Promise misuse that can break rendering or static generation.

### Description
- Update `apps/web/app/mockup/[slug]/page.tsx` to change `MockupPageProps.params` from `Promise<{ slug: string }>` to `{ slug: string }` and convert the page component from `async` to a synchronous function, removing the unnecessary `await` when reading `slug`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975fd46a4888333bd619787c110156e)