### PR TITLE
Update homepage: project status page with Supabase connectivity check

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,70 +1,116 @@
-import Link from 'next/link'
+import { createClient } from '@/lib/supabase/server'
 
-export default function HomePage() {
+export default async function HomePage() {
+  const supabase = await createClient()
+  const { error } = await supabase.from('personen').select('id').limit(1)
+
+  const connectionStatus = error
+    ? {
+        label: 'Fehlgeschlagen',
+        detail: error.message,
+      }
+    : {
+        label: 'Verbunden',
+        detail: 'Supabase ist erreichbar und antwortet.',
+      }
+
   return (
-    <main className="min-h-screen bg-gradient-to-b from-gray-50 to-gray-100">
-      <div className="mx-auto max-w-4xl px-4 py-16 sm:px-6 lg:px-8">
-        <div className="text-center">
-          <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
+    <main className="min-h-screen bg-slate-950 text-slate-100">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-12 px-6 py-16">
+        <header className="flex flex-col gap-4">
+          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-400">
             BackstagePass
+          </p>
+          <h1 className="text-4xl font-semibold text-white sm:text-5xl">
+            Vereinsverwaltung, die Proben, Mitglieder und Produktionen an einem Ort
+            zusammenbringt.
           </h1>
-          <p className="mt-4 text-xl text-gray-600">
-            Vereinsverwaltung für Theatergruppen
+          <p className="max-w-2xl text-lg text-slate-300">
+            Dieses Deployment liefert eine schlanke Statusseite für das BackstagePass-
+            Projekt. Sie zeigt den aktuellen Stand der Supabase-Anbindung sowie den
+            geplanten Technologie-Stack.
           </p>
-        </div>
+        </header>
 
-        <div className="mt-16 grid gap-6 sm:grid-cols-2">
-          <Link
-            href="/mockup"
-            className="card hover:shadow-md transition-shadow"
-          >
-            <h2 className="text-xl font-semibold text-gray-900">
-              Mockup-Seiten
-            </h2>
-            <p className="mt-2 text-gray-600">
-              Klickbare Prototypen für Design-Feedback
+        <section className="grid gap-6 md:grid-cols-[2fr_1fr]">
+          <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg">
+            <h2 className="text-xl font-semibold">Projektbeschreibung</h2>
+            <p className="mt-3 text-slate-300">
+              BackstagePass unterstützt Theatervereine dabei, Mitglieder zu verwalten,
+              Kommunikationswege zu bündeln und Produktionsdaten zentral zu speichern.
+              Das Ziel ist ein übersichtliches Dashboard, das den Vereinsalltag von der
+              Probenplanung bis zur Premiere begleitet.
             </p>
-          </Link>
-
-          <div className="card opacity-60">
-            <h2 className="text-xl font-semibold text-gray-900">
-              Dashboard
-            </h2>
-            <p className="mt-2 text-gray-600">
-              Kommt in Phase 1 (nach Auth-Setup)
-            </p>
+            <div className="mt-6 rounded-xl border border-slate-800 bg-slate-950/80 p-4">
+              <p className="text-sm uppercase tracking-[0.2em] text-slate-400">
+                Supabase Status
+              </p>
+              <div className="mt-2 flex flex-wrap items-center gap-3">
+                <span
+                  className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-medium ${
+                    error
+                      ? 'bg-rose-500/20 text-rose-200'
+                      : 'bg-emerald-500/20 text-emerald-200'
+                  }`}
+                >
+                  {connectionStatus.label}
+                </span>
+                <span className="text-sm text-slate-300">
+                  {connectionStatus.detail}
+                </span>
+              </div>
+              {error && (
+                <p className="mt-3 text-xs text-slate-400">
+                  Hinweis: Die Tabelle <span className="font-semibold">personen</span>{' '}
+                  ist per RLS geschützt. Für einen erfolgreichen Check ist ein gültiger
+                  Auth-Session erforderlich.
+                </p>
+              )}
+            </div>
           </div>
 
-          <div className="card opacity-60">
-            <h2 className="text-xl font-semibold text-gray-900">
-              Mitglieder
-            </h2>
-            <p className="mt-2 text-gray-600">
-              Kommt in Phase 1 (MVP Core)
-            </p>
+          <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+            <h2 className="text-xl font-semibold">Tech Stack</h2>
+            <ul className="mt-4 space-y-3 text-slate-300">
+              <li className="flex items-start gap-3">
+                <span className="mt-1 h-2 w-2 rounded-full bg-slate-500" />
+                <div>
+                  <p className="font-medium text-slate-100">Next.js 14</p>
+                  <p className="text-sm text-slate-400">
+                    App Router, Server Components und Layouts für schnelle Iteration.
+                  </p>
+                </div>
+              </li>
+              <li className="flex items-start gap-3">
+                <span className="mt-1 h-2 w-2 rounded-full bg-slate-500" />
+                <div>
+                  <p className="font-medium text-slate-100">Supabase</p>
+                  <p className="text-sm text-slate-400">
+                    Postgres, Auth und Storage als zentrale Datenplattform.
+                  </p>
+                </div>
+              </li>
+              <li className="flex items-start gap-3">
+                <span className="mt-1 h-2 w-2 rounded-full bg-slate-500" />
+                <div>
+                  <p className="font-medium text-slate-100">Tailwind CSS</p>
+                  <p className="text-sm text-slate-400">
+                    Utility-First Styling für konsistente UI-Bausteine.
+                  </p>
+                </div>
+              </li>
+              <li className="flex items-start gap-3">
+                <span className="mt-1 h-2 w-2 rounded-full bg-slate-500" />
+                <div>
+                  <p className="font-medium text-slate-100">Vercel</p>
+                  <p className="text-sm text-slate-400">
+                    Automatisierte Deployments und Preview-Umgebungen.
+                  </p>
+                </div>
+              </li>
+            </ul>
           </div>
-
-          <div className="card opacity-60">
-            <h2 className="text-xl font-semibold text-gray-900">
-              Produktionen
-            </h2>
-            <p className="mt-2 text-gray-600">
-              Kommt in Phase 2 (MVP Extended)
-            </p>
-          </div>
-        </div>
-
-        <div className="mt-16 rounded-lg border border-yellow-200 bg-yellow-50 p-6">
-          <h3 className="font-semibold text-yellow-800">Phase 0: Foundation</h3>
-          <p className="mt-2 text-sm text-yellow-700">
-            Diese App befindet sich in der Entwicklung. Aktuell wird die
-            Infrastruktur aufgebaut (Next.js + Supabase + Vercel).
-          </p>
-        </div>
-
-        <footer className="mt-16 text-center text-sm text-gray-400">
-          BackstagePass &copy; 2026
-        </footer>
+        </section>
       </div>
     </main>
   )


### PR DESCRIPTION
### Motivation
- Die Startseite sollte durch eine einfache Status-/Infoseite ersetzt werden, die Projektbeschreibung und Tech-Stack zeigt und das Deployment-Setup vereinfacht.
- Zusätzlich sollte die Supabase-Anbindung direkt geprüft werden, um frühzeitig Probleme mit RLS oder fehlenden Credentials sichtbar zu machen.

### Description
- Ersetzte die Datei `apps/web/app/page.tsx` durch eine einseitige Status- und Info-Seite mit Projektbeschreibung und Tech-Stack-Übersicht.
- Fügte eine serverseitige Supabase-Verbindung mittels `createClient` aus `@/lib/supabase/server` hinzu und führte eine Testabfrage gegen die `personen`-Tabelle durch, um den Verbindungsstatus zu bestimmen.
- Zeigt einen Status-Badge (Verbunden / Fehlgeschlagen) samt Fehler-Detail und einen Hinweis zur Row-Level-Security (RLS) an.
- Aktualisierte Layout- und Tailwind-Styling für die neue Statusseite und committed die Änderungen.

### Testing
- Startete den Dev-Server mit `npm run dev` im Verzeichnis `apps/web`, der erfolgreich startete und `http://localhost:3000` anbot.
- Führte ein automatisiertes Playwright-Skript aus, das die Seite aufrief und einen Screenshot (`artifacts/backstagepass-home.png`) erzeugte.
- Änderungen wurden mit Git committed (`git commit`) und sind im Arbeitszweig vorhanden.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697628a180fc833393f2e2795de8686d)