### PR TITLE
feat: add Produktionen entity with CRUD, status workflow, and series …

### DIFF
--- a/apps/web/app/(protected)/produktionen/[id]/bearbeiten/page.tsx
+++ b/apps/web/app/(protected)/produktionen/[id]/bearbeiten/page.tsx
@@ -1,0 +1,67 @@
+import Link from 'next/link'
+import type { Route } from 'next'
+import { notFound } from 'next/navigation'
+import { getProduktion } from '@/lib/actions/produktionen'
+import { getActiveStuecke } from '@/lib/actions/stuecke'
+import { createClient } from '@/lib/supabase/server'
+import { ProduktionForm } from '@/components/produktionen'
+import type { Person } from '@/lib/supabase/types'
+
+interface BearbeitenPageProps {
+  params: Promise<{ id: string }>
+}
+
+export default async function ProduktionBearbeitenPage({
+  params,
+}: BearbeitenPageProps) {
+  const { id } = await params
+  const supabase = await createClient()
+
+  const [produktion, stuecke, { data: personen }] = await Promise.all([
+    getProduktion(id),
+    getActiveStuecke(),
+    supabase
+      .from('personen')
+      .select('id, vorname, nachname, email')
+      .eq('aktiv', true)
+      .order('nachname', { ascending: true }),
+  ])
+
+  if (!produktion) {
+    notFound()
+  }
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <div className="mx-auto max-w-3xl px-4 py-8">
+        {/* Back Link */}
+        <div className="mb-6">
+          <Link
+            href={`/produktionen/${id}` as Route}
+            className="text-primary-600 hover:text-primary-800"
+          >
+            &larr; Zurück zur Produktion
+          </Link>
+        </div>
+
+        {/* Header */}
+        <div className="mb-8">
+          <h1 className="text-2xl font-bold text-gray-900">
+            Produktion bearbeiten
+          </h1>
+          <p className="mt-1 text-gray-600">{produktion.titel}</p>
+        </div>
+
+        {/* Form */}
+        <div className="rounded-lg bg-white p-6 shadow">
+          <ProduktionForm
+            mode="edit"
+            produktion={produktion}
+            stuecke={stuecke}
+            personen={(personen as Person[]) || []}
+          />
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/apps/web/app/(protected)/produktionen/[id]/page.tsx
+++ b/apps/web/app/(protected)/produktionen/[id]/page.tsx
@@ -1,0 +1,268 @@
+import Link from 'next/link'
+import type { Route } from 'next'
+import { notFound } from 'next/navigation'
+import { getProduktion, getSerien } from '@/lib/actions/produktionen'
+import { getUserProfile } from '@/lib/supabase/server'
+import { hasPermission } from '@/lib/supabase/permissions'
+import { createClient } from '@/lib/supabase/server'
+import {
+  ProduktionStatusBadge,
+  ProduktionStatusSelect,
+} from '@/components/produktionen'
+import { PRODUKTION_STATUS_LABELS, SERIE_STATUS_LABELS } from '@/lib/supabase/types'
+import type { Stueck, Person, Auffuehrungsserie } from '@/lib/supabase/types'
+
+interface ProduktionDetailPageProps {
+  params: Promise<{ id: string }>
+}
+
+export default async function ProduktionDetailPage({
+  params,
+}: ProduktionDetailPageProps) {
+  const { id } = await params
+  const [produktion, serien, profile] = await Promise.all([
+    getProduktion(id),
+    getSerien(id),
+    getUserProfile(),
+  ])
+
+  if (!produktion) {
+    notFound()
+  }
+
+  const canEdit = profile
+    ? hasPermission(profile.role, 'produktionen:write')
+    : false
+
+  // Fetch related data
+  const supabase = await createClient()
+  let stueck: Pick<Stueck, 'id' | 'titel'> | null = null
+  let leitung: Pick<Person, 'id' | 'vorname' | 'nachname'> | null = null
+
+  if (produktion.stueck_id) {
+    const { data } = await supabase
+      .from('stuecke')
+      .select('id, titel')
+      .eq('id', produktion.stueck_id)
+      .single()
+    stueck = data
+  }
+
+  if (produktion.produktionsleitung_id) {
+    const { data } = await supabase
+      .from('personen')
+      .select('id, vorname, nachname')
+      .eq('id', produktion.produktionsleitung_id)
+      .single()
+    leitung = data
+  }
+
+  const formatDate = (dateStr: string | null) => {
+    if (!dateStr) return '–'
+    return new Date(dateStr).toLocaleDateString('de-CH')
+  }
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <div className="mx-auto max-w-5xl px-4 py-8">
+        {/* Back Link */}
+        <div className="mb-6">
+          <Link
+            href={'/produktionen' as Route}
+            className="text-primary-600 hover:text-primary-800"
+          >
+            &larr; Zurück zur Übersicht
+          </Link>
+        </div>
+
+        {/* Header */}
+        <div className="mb-8 flex items-start justify-between">
+          <div>
+            <div className="flex items-center gap-3">
+              <h1 className="text-2xl font-bold text-gray-900">
+                {produktion.titel}
+              </h1>
+              <ProduktionStatusBadge status={produktion.status} />
+            </div>
+            <p className="mt-1 text-gray-600">Saison {produktion.saison}</p>
+          </div>
+          {canEdit && (
+            <Link
+              href={`/produktionen/${id}/bearbeiten` as Route}
+              className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100"
+            >
+              Bearbeiten
+            </Link>
+          )}
+        </div>
+
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
+          {/* Main Content */}
+          <div className="space-y-8 lg:col-span-2">
+            {/* Beschreibung */}
+            {produktion.beschreibung && (
+              <div className="rounded-lg bg-white p-6 shadow">
+                <h2 className="mb-3 text-lg font-semibold text-gray-900">
+                  Beschreibung
+                </h2>
+                <p className="whitespace-pre-wrap text-gray-600">
+                  {produktion.beschreibung}
+                </p>
+              </div>
+            )}
+
+            {/* Status Workflow */}
+            {canEdit && (
+              <div className="rounded-lg bg-white p-6 shadow">
+                <h2 className="mb-3 text-lg font-semibold text-gray-900">
+                  Status ändern
+                </h2>
+                <ProduktionStatusSelect
+                  produktionId={produktion.id}
+                  currentStatus={produktion.status}
+                />
+              </div>
+            )}
+
+            {/* Aufführungsserien */}
+            <div className="rounded-lg bg-white p-6 shadow">
+              <div className="mb-4 flex items-center justify-between">
+                <h2 className="text-lg font-semibold text-gray-900">
+                  Aufführungsserien
+                </h2>
+              </div>
+              {serien.length === 0 ? (
+                <p className="text-gray-500">
+                  Noch keine Aufführungsserien vorhanden.
+                </p>
+              ) : (
+                <div className="space-y-3">
+                  {serien.map((serie: Auffuehrungsserie) => (
+                    <div
+                      key={serie.id}
+                      className="rounded-lg border border-gray-200 p-4"
+                    >
+                      <div className="flex items-center justify-between">
+                        <div>
+                          <h3 className="font-medium text-gray-900">
+                            {serie.name}
+                          </h3>
+                          {serie.standard_ort && (
+                            <p className="text-sm text-gray-500">
+                              {serie.standard_ort}
+                            </p>
+                          )}
+                        </div>
+                        <span className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-700">
+                          {SERIE_STATUS_LABELS[serie.status]}
+                        </span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Sidebar */}
+          <div className="space-y-6">
+            {/* Details Card */}
+            <div className="rounded-lg bg-white p-6 shadow">
+              <h2 className="mb-4 text-lg font-semibold text-gray-900">
+                Details
+              </h2>
+              <dl className="space-y-3">
+                {stueck && (
+                  <div>
+                    <dt className="text-sm font-medium text-gray-500">Stück</dt>
+                    <dd className="text-sm text-gray-900">
+                      <Link
+                        href={`/stuecke/${stueck.id}` as Route}
+                        className="text-primary-600 hover:text-primary-800"
+                      >
+                        {stueck.titel}
+                      </Link>
+                    </dd>
+                  </div>
+                )}
+                {leitung && (
+                  <div>
+                    <dt className="text-sm font-medium text-gray-500">
+                      Produktionsleitung
+                    </dt>
+                    <dd className="text-sm text-gray-900">
+                      {leitung.vorname} {leitung.nachname}
+                    </dd>
+                  </div>
+                )}
+                <div>
+                  <dt className="text-sm font-medium text-gray-500">
+                    Probenstart
+                  </dt>
+                  <dd className="text-sm text-gray-900">
+                    {formatDate(produktion.proben_start)}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-sm font-medium text-gray-500">
+                    Premiere
+                  </dt>
+                  <dd className="text-sm text-gray-900">
+                    {formatDate(produktion.premiere)}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-sm font-medium text-gray-500">
+                    Dernière
+                  </dt>
+                  <dd className="text-sm text-gray-900">
+                    {formatDate(produktion.derniere)}
+                  </dd>
+                </div>
+              </dl>
+            </div>
+
+            {/* Timeline */}
+            <div className="rounded-lg bg-white p-6 shadow">
+              <h2 className="mb-4 text-lg font-semibold text-gray-900">
+                Zeitplan
+              </h2>
+              <div className="space-y-3">
+                {[
+                  {
+                    label: 'Probenstart',
+                    date: produktion.proben_start,
+                  },
+                  { label: 'Premiere', date: produktion.premiere },
+                  { label: 'Dernière', date: produktion.derniere },
+                ]
+                  .filter((item) => item.date)
+                  .map((item) => (
+                    <div
+                      key={item.label}
+                      className="flex items-center gap-3 text-sm"
+                    >
+                      <div className="h-2 w-2 rounded-full bg-primary-500" />
+                      <span className="font-medium text-gray-700">
+                        {item.label}:
+                      </span>
+                      <span className="text-gray-600">
+                        {formatDate(item.date)}
+                      </span>
+                    </div>
+                  ))}
+                {!produktion.proben_start &&
+                  !produktion.premiere &&
+                  !produktion.derniere && (
+                    <p className="text-sm text-gray-500">
+                      Noch keine Termine festgelegt.
+                    </p>
+                  )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/apps/web/app/(protected)/produktionen/neu/page.tsx
+++ b/apps/web/app/(protected)/produktionen/neu/page.tsx
@@ -1,0 +1,54 @@
+import Link from 'next/link'
+import type { Route } from 'next'
+import { getActiveStuecke } from '@/lib/actions/stuecke'
+import { ProduktionForm } from '@/components/produktionen'
+import { createClient } from '@/lib/supabase/server'
+import type { Person } from '@/lib/supabase/types'
+
+export default async function NeueProduktionPage() {
+  const supabase = await createClient()
+
+  const [stuecke, { data: personen }] = await Promise.all([
+    getActiveStuecke(),
+    supabase
+      .from('personen')
+      .select('id, vorname, nachname, email')
+      .eq('aktiv', true)
+      .order('nachname', { ascending: true }),
+  ])
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <div className="mx-auto max-w-3xl px-4 py-8">
+        {/* Back Link */}
+        <div className="mb-6">
+          <Link
+            href={'/produktionen' as Route}
+            className="text-primary-600 hover:text-primary-800"
+          >
+            &larr; Zurück zur Übersicht
+          </Link>
+        </div>
+
+        {/* Header */}
+        <div className="mb-8">
+          <h1 className="text-2xl font-bold text-gray-900">
+            Neue Produktion
+          </h1>
+          <p className="mt-1 text-gray-600">
+            Erstelle ein neues Theaterprojekt
+          </p>
+        </div>
+
+        {/* Form */}
+        <div className="rounded-lg bg-white p-6 shadow">
+          <ProduktionForm
+            mode="create"
+            stuecke={stuecke}
+            personen={(personen as Person[]) || []}
+          />
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/apps/web/app/(protected)/produktionen/page.tsx
+++ b/apps/web/app/(protected)/produktionen/page.tsx
@@ -1,0 +1,61 @@
+import Link from 'next/link'
+import type { Route } from 'next'
+import { getProduktionen } from '@/lib/actions/produktionen'
+import { getUserProfile } from '@/lib/supabase/server'
+import { hasPermission } from '@/lib/supabase/permissions'
+import { ProduktionenTable } from '@/components/produktionen'
+
+export default async function ProduktionenPage() {
+  const [produktionen, profile] = await Promise.all([
+    getProduktionen(),
+    getUserProfile(),
+  ])
+
+  const canEdit = profile
+    ? hasPermission(profile.role, 'produktionen:write')
+    : false
+  const canDelete = profile
+    ? hasPermission(profile.role, 'produktionen:delete')
+    : false
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <div className="mx-auto max-w-7xl px-4 py-8">
+        {/* Header */}
+        <div className="mb-8 flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Produktionen</h1>
+            <p className="mt-1 text-gray-600">
+              Theaterprojekte planen und verwalten
+            </p>
+          </div>
+          {canEdit && (
+            <Link
+              href={'/produktionen/neu' as Route}
+              className="rounded-lg bg-primary-600 px-4 py-2 font-medium text-white transition-colors hover:bg-primary-700"
+            >
+              + Neue Produktion
+            </Link>
+          )}
+        </div>
+
+        {/* Table */}
+        <ProduktionenTable
+          produktionen={produktionen}
+          canEdit={canEdit}
+          canDelete={canDelete}
+        />
+
+        {/* Back Link */}
+        <div className="mt-8">
+          <Link
+            href="/dashboard"
+            className="text-primary-600 hover:text-primary-800"
+          >
+            &larr; Zurück zum Dashboard
+          </Link>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/apps/web/components/layout/NavIcons.tsx
+++ b/apps/web/components/layout/NavIcons.tsx
@@ -363,6 +363,24 @@ function EyeIcon({ className = 'h-5 w-5' }: IconProps) {
   )
 }
 
+function FilmIcon({ className = 'h-5 w-5' }: IconProps) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M7 4v16M17 4v16M3 8h4m10 0h4M3 12h18M3 16h4m10 0h4M4 20h16a1 1 0 001-1V5a1 1 0 00-1-1H4a1 1 0 00-1 1v14a1 1 0 001 1z"
+      />
+    </svg>
+  )
+}
+
 function ChevronLeftIcon({ className = 'h-5 w-5' }: IconProps) {
   return (
     <svg
@@ -458,6 +476,7 @@ const ICON_MAP: Record<NavIcon, React.ComponentType<IconProps>> = {
   list: ListIcon,
   mail: MailIcon,
   eye: EyeIcon,
+  film: FilmIcon,
 }
 
 /**

--- a/apps/web/components/produktionen/ProduktionForm.tsx
+++ b/apps/web/components/produktionen/ProduktionForm.tsx
@@ -1,0 +1,313 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import type {
+  Produktion,
+  ProduktionInsert,
+  ProduktionStatus,
+  Stueck,
+  Person,
+} from '@/lib/supabase/types'
+import { PRODUKTION_STATUS_LABELS } from '@/lib/supabase/types'
+import { createProduktion, updateProduktion } from '@/lib/actions/produktionen'
+
+interface ProduktionFormProps {
+  mode: 'create' | 'edit'
+  produktion?: Produktion
+  stuecke?: Stueck[]
+  personen?: Person[]
+}
+
+const statusOptions: { value: ProduktionStatus; label: string }[] =
+  Object.entries(PRODUKTION_STATUS_LABELS).map(([value, label]) => ({
+    value: value as ProduktionStatus,
+    label,
+  }))
+
+export function ProduktionForm({
+  mode,
+  produktion,
+  stuecke = [],
+  personen = [],
+}: ProduktionFormProps) {
+  const router = useRouter()
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const currentYear = new Date().getFullYear()
+
+  const [formData, setFormData] = useState<ProduktionInsert>({
+    titel: produktion?.titel ?? '',
+    beschreibung: produktion?.beschreibung ?? null,
+    stueck_id: produktion?.stueck_id ?? null,
+    status: produktion?.status ?? 'draft',
+    saison: produktion?.saison ?? `${currentYear}`,
+    proben_start: produktion?.proben_start ?? null,
+    premiere: produktion?.premiere ?? null,
+    derniere: produktion?.derniere ?? null,
+    produktionsleitung_id: produktion?.produktionsleitung_id ?? null,
+  })
+
+  const handleChange = (
+    e: React.ChangeEvent<
+      HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+    >
+  ) => {
+    const { name, value } = e.target
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value === '' ? null : value,
+    }))
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setIsSubmitting(true)
+    setError(null)
+
+    try {
+      if (mode === 'create') {
+        const result = await createProduktion(formData)
+        if (result.success && result.id) {
+          router.push(`/produktionen/${result.id}`)
+        } else {
+          setError(result.error || 'Fehler beim Erstellen')
+        }
+      } else if (produktion) {
+        const result = await updateProduktion(produktion.id, formData)
+        if (result.success) {
+          router.push(`/produktionen/${produktion.id}`)
+        } else {
+          setError(result.error || 'Fehler beim Aktualisieren')
+        }
+      }
+    } catch {
+      setError('Ein unerwarteter Fehler ist aufgetreten')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      {error && (
+        <div className="rounded-lg border border-error-200 bg-error-50 px-4 py-3 text-error-700">
+          {error}
+        </div>
+      )}
+
+      {/* Titel */}
+      <div>
+        <label
+          htmlFor="titel"
+          className="block text-sm font-medium text-gray-700"
+        >
+          Titel *
+        </label>
+        <input
+          type="text"
+          id="titel"
+          name="titel"
+          required
+          value={formData.titel}
+          onChange={handleChange}
+          className="mt-1 block w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-primary-500 focus:ring-2 focus:ring-primary-500"
+          placeholder="z.B. Sommernachtstraum 2026"
+        />
+      </div>
+
+      {/* Stück und Saison */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {/* Stück */}
+        <div>
+          <label
+            htmlFor="stueck_id"
+            className="block text-sm font-medium text-gray-700"
+          >
+            Stück (optional)
+          </label>
+          <select
+            id="stueck_id"
+            name="stueck_id"
+            value={formData.stueck_id ?? ''}
+            onChange={handleChange}
+            className="mt-1 block w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-primary-500 focus:ring-2 focus:ring-primary-500"
+          >
+            <option value="">– Kein Stück –</option>
+            {stuecke.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.titel}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Saison */}
+        <div>
+          <label
+            htmlFor="saison"
+            className="block text-sm font-medium text-gray-700"
+          >
+            Saison *
+          </label>
+          <input
+            type="text"
+            id="saison"
+            name="saison"
+            required
+            value={formData.saison}
+            onChange={handleChange}
+            className="mt-1 block w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-primary-500 focus:ring-2 focus:ring-primary-500"
+            placeholder="z.B. 2026 oder 2026/2027"
+          />
+        </div>
+      </div>
+
+      {/* Status und Produktionsleitung */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {/* Status */}
+        <div>
+          <label
+            htmlFor="status"
+            className="block text-sm font-medium text-gray-700"
+          >
+            Status
+          </label>
+          <select
+            id="status"
+            name="status"
+            value={formData.status}
+            onChange={handleChange}
+            className="mt-1 block w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-primary-500 focus:ring-2 focus:ring-primary-500"
+          >
+            {statusOptions.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Produktionsleitung */}
+        <div>
+          <label
+            htmlFor="produktionsleitung_id"
+            className="block text-sm font-medium text-gray-700"
+          >
+            Produktionsleitung
+          </label>
+          <select
+            id="produktionsleitung_id"
+            name="produktionsleitung_id"
+            value={formData.produktionsleitung_id ?? ''}
+            onChange={handleChange}
+            className="mt-1 block w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-primary-500 focus:ring-2 focus:ring-primary-500"
+          >
+            <option value="">– Nicht zugewiesen –</option>
+            {personen.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.vorname} {p.nachname}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* Daten */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <div>
+          <label
+            htmlFor="proben_start"
+            className="block text-sm font-medium text-gray-700"
+          >
+            Probenstart
+          </label>
+          <input
+            type="date"
+            id="proben_start"
+            name="proben_start"
+            value={formData.proben_start ?? ''}
+            onChange={handleChange}
+            className="mt-1 block w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-primary-500 focus:ring-2 focus:ring-primary-500"
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="premiere"
+            className="block text-sm font-medium text-gray-700"
+          >
+            Premiere
+          </label>
+          <input
+            type="date"
+            id="premiere"
+            name="premiere"
+            value={formData.premiere ?? ''}
+            onChange={handleChange}
+            className="mt-1 block w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-primary-500 focus:ring-2 focus:ring-primary-500"
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="derniere"
+            className="block text-sm font-medium text-gray-700"
+          >
+            Dernière
+          </label>
+          <input
+            type="date"
+            id="derniere"
+            name="derniere"
+            value={formData.derniere ?? ''}
+            onChange={handleChange}
+            className="mt-1 block w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-primary-500 focus:ring-2 focus:ring-primary-500"
+          />
+        </div>
+      </div>
+
+      {/* Beschreibung */}
+      <div>
+        <label
+          htmlFor="beschreibung"
+          className="block text-sm font-medium text-gray-700"
+        >
+          Beschreibung
+        </label>
+        <textarea
+          id="beschreibung"
+          name="beschreibung"
+          rows={4}
+          value={formData.beschreibung ?? ''}
+          onChange={handleChange}
+          className="mt-1 block w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-primary-500 focus:ring-2 focus:ring-primary-500"
+          placeholder="Kurze Beschreibung der Produktion..."
+        />
+      </div>
+
+      {/* Submit */}
+      <div className="flex justify-end gap-4">
+        <button
+          type="button"
+          onClick={() => router.back()}
+          className="px-4 py-2 text-gray-700 hover:text-gray-900"
+        >
+          Abbrechen
+        </button>
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="rounded-lg bg-primary-600 px-6 py-2 font-medium text-white transition-colors hover:bg-primary-700 disabled:bg-gray-400"
+        >
+          {isSubmitting
+            ? 'Wird gespeichert...'
+            : mode === 'create'
+              ? 'Produktion erstellen'
+              : 'Änderungen speichern'}
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/apps/web/components/produktionen/ProduktionStatusBadge.tsx
+++ b/apps/web/components/produktionen/ProduktionStatusBadge.tsx
@@ -1,0 +1,31 @@
+import type { ProduktionStatus } from '@/lib/supabase/types'
+import { PRODUKTION_STATUS_LABELS } from '@/lib/supabase/types'
+
+const statusConfig: Record<
+  ProduktionStatus,
+  { className: string }
+> = {
+  draft: { className: 'bg-gray-100 text-gray-700' },
+  planung: { className: 'bg-blue-100 text-blue-700' },
+  casting: { className: 'bg-amber-100 text-amber-700' },
+  proben: { className: 'bg-indigo-100 text-indigo-700' },
+  premiere: { className: 'bg-purple-100 text-purple-700' },
+  laufend: { className: 'bg-green-100 text-green-700' },
+  abgeschlossen: { className: 'bg-gray-100 text-gray-500' },
+  abgesagt: { className: 'bg-red-100 text-red-700' },
+}
+
+export function ProduktionStatusBadge({
+  status,
+}: {
+  status: ProduktionStatus
+}) {
+  const config = statusConfig[status]
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${config.className}`}
+    >
+      {PRODUKTION_STATUS_LABELS[status]}
+    </span>
+  )
+}

--- a/apps/web/components/produktionen/ProduktionStatusSelect.tsx
+++ b/apps/web/components/produktionen/ProduktionStatusSelect.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useState } from 'react'
+import type { ProduktionStatus } from '@/lib/supabase/types'
+import { PRODUKTION_STATUS_LABELS } from '@/lib/supabase/types'
+import {
+  updateProduktionStatus,
+  getAllowedTransitions,
+} from '@/lib/actions/produktionen'
+
+interface ProduktionStatusSelectProps {
+  produktionId: string
+  currentStatus: ProduktionStatus
+}
+
+export function ProduktionStatusSelect({
+  produktionId,
+  currentStatus,
+}: ProduktionStatusSelectProps) {
+  const [isUpdating, setIsUpdating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const allowedTransitions = getAllowedTransitions(currentStatus)
+
+  if (allowedTransitions.length === 0) {
+    return null
+  }
+
+  const handleStatusChange = async (newStatus: ProduktionStatus) => {
+    setIsUpdating(true)
+    setError(null)
+
+    const result = await updateProduktionStatus(produktionId, newStatus)
+    if (!result.success) {
+      setError(result.error || 'Fehler beim Status-Update')
+    }
+
+    setIsUpdating(false)
+  }
+
+  return (
+    <div className="space-y-2">
+      {error && (
+        <p className="text-sm text-error-600">{error}</p>
+      )}
+      <div className="flex flex-wrap gap-2">
+        {allowedTransitions.map((status) => (
+          <button
+            key={status}
+            onClick={() => handleStatusChange(status)}
+            disabled={isUpdating}
+            className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100 disabled:opacity-50"
+          >
+            {isUpdating ? '...' : `→ ${PRODUKTION_STATUS_LABELS[status]}`}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/produktionen/ProduktionenTable.tsx
+++ b/apps/web/components/produktionen/ProduktionenTable.tsx
@@ -1,0 +1,176 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import type { Route } from 'next'
+import type { Produktion, ProduktionStatus } from '@/lib/supabase/types'
+import { PRODUKTION_STATUS_LABELS } from '@/lib/supabase/types'
+import { ProduktionStatusBadge } from './ProduktionStatusBadge'
+import { deleteProduktion } from '@/lib/actions/produktionen'
+
+interface ProduktionenTableProps {
+  produktionen: Produktion[]
+  canEdit?: boolean
+  canDelete?: boolean
+}
+
+export function ProduktionenTable({
+  produktionen,
+  canEdit = false,
+  canDelete = false,
+}: ProduktionenTableProps) {
+  const [filterStatus, setFilterStatus] = useState<ProduktionStatus | 'alle'>(
+    'alle'
+  )
+  const [searchTerm, setSearchTerm] = useState('')
+
+  const filtered = produktionen.filter((p) => {
+    if (filterStatus !== 'alle' && p.status !== filterStatus) return false
+    if (
+      searchTerm &&
+      !p.titel.toLowerCase().includes(searchTerm.toLowerCase()) &&
+      !p.saison.toLowerCase().includes(searchTerm.toLowerCase())
+    ) {
+      return false
+    }
+    return true
+  })
+
+  const handleDelete = async (id: string, titel: string) => {
+    if (!confirm(`Produktion "${titel}" wirklich löschen?`)) return
+    const result = await deleteProduktion(id)
+    if (!result.success) {
+      alert(result.error || 'Fehler beim Löschen')
+    }
+  }
+
+  const formatDate = (dateStr: string | null) => {
+    if (!dateStr) return '–'
+    return new Date(dateStr).toLocaleDateString('de-CH')
+  }
+
+  if (produktionen.length === 0) {
+    return (
+      <div className="rounded-lg bg-white p-12 text-center shadow">
+        <p className="text-gray-500">Noch keine Produktionen vorhanden.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Filter Bar */}
+      <div className="flex flex-col gap-4 sm:flex-row">
+        <input
+          type="text"
+          placeholder="Suchen..."
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          className="flex-1 rounded-lg border border-gray-300 px-4 py-2 focus:border-primary-500 focus:ring-2 focus:ring-primary-500"
+        />
+        <select
+          value={filterStatus}
+          onChange={(e) =>
+            setFilterStatus(e.target.value as ProduktionStatus | 'alle')
+          }
+          className="rounded-lg border border-gray-300 px-4 py-2 focus:border-primary-500 focus:ring-2 focus:ring-primary-500"
+        >
+          <option value="alle">Alle Status</option>
+          {Object.entries(PRODUKTION_STATUS_LABELS).map(([value, label]) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-hidden rounded-lg bg-white shadow">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                Titel
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                Saison
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                Status
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                Premiere
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                Dernière
+              </th>
+              {(canEdit || canDelete) && (
+                <th className="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+                  Aktionen
+                </th>
+              )}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 bg-white">
+            {filtered.map((p) => (
+              <tr key={p.id} className="hover:bg-gray-50">
+                <td className="whitespace-nowrap px-6 py-4">
+                  <Link
+                    href={`/produktionen/${p.id}` as Route}
+                    className="font-medium text-primary-600 hover:text-primary-800"
+                  >
+                    {p.titel}
+                  </Link>
+                </td>
+                <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-600">
+                  {p.saison}
+                </td>
+                <td className="whitespace-nowrap px-6 py-4">
+                  <ProduktionStatusBadge status={p.status} />
+                </td>
+                <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-600">
+                  {formatDate(p.premiere)}
+                </td>
+                <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-600">
+                  {formatDate(p.derniere)}
+                </td>
+                {(canEdit || canDelete) && (
+                  <td className="whitespace-nowrap px-6 py-4 text-right text-sm">
+                    <div className="flex justify-end gap-2">
+                      {canEdit && (
+                        <Link
+                          href={`/produktionen/${p.id}/bearbeiten` as Route}
+                          className="text-primary-600 hover:text-primary-800"
+                        >
+                          Bearbeiten
+                        </Link>
+                      )}
+                      {canDelete && (
+                        <button
+                          onClick={() => handleDelete(p.id, p.titel)}
+                          className="text-error-600 hover:text-error-800"
+                        >
+                          Löschen
+                        </button>
+                      )}
+                    </div>
+                  </td>
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        {filtered.length === 0 && (
+          <div className="p-8 text-center text-gray-500">
+            Keine Produktionen gefunden.
+          </div>
+        )}
+      </div>
+
+      <p className="text-sm text-gray-500">
+        {filtered.length} von {produktionen.length} Produktionen
+      </p>
+    </div>
+  )
+}

--- a/apps/web/components/produktionen/index.ts
+++ b/apps/web/components/produktionen/index.ts
@@ -1,0 +1,4 @@
+export { ProduktionForm } from './ProduktionForm'
+export { ProduktionenTable } from './ProduktionenTable'
+export { ProduktionStatusBadge } from './ProduktionStatusBadge'
+export { ProduktionStatusSelect } from './ProduktionStatusSelect'

--- a/apps/web/lib/actions/produktionen.ts
+++ b/apps/web/lib/actions/produktionen.ts
@@ -1,0 +1,506 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { createClient, getUserProfile } from '../supabase/server'
+import { hasPermission } from '../supabase/auth-helpers'
+import type {
+  Produktion,
+  ProduktionInsert,
+  ProduktionUpdate,
+  ProduktionStatus,
+  Auffuehrungsserie,
+  AuffuehrungsserieInsert,
+  AuffuehrungsserieUpdate,
+  Serienauffuehrung,
+  SerienauffuehrungInsert,
+  SerienauffuehrungUpdate,
+  AuffuehrungsTyp,
+} from '../supabase/types'
+
+// =============================================================================
+// Status Workflow
+// =============================================================================
+
+const ALLOWED_TRANSITIONS: Record<ProduktionStatus, ProduktionStatus[]> = {
+  draft: ['planung', 'abgesagt'],
+  planung: ['casting', 'proben', 'abgesagt'],
+  casting: ['proben', 'planung', 'abgesagt'],
+  proben: ['premiere', 'casting', 'abgesagt'],
+  premiere: ['laufend', 'abgesagt'],
+  laufend: ['abgeschlossen', 'abgesagt'],
+  abgeschlossen: [],
+  abgesagt: [],
+}
+
+// =============================================================================
+// Produktionen
+// =============================================================================
+
+export async function getProduktionen(): Promise<Produktion[]> {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from('produktionen')
+    .select('*')
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    console.error('Error fetching produktionen:', error)
+    return []
+  }
+
+  return (data as Produktion[]) || []
+}
+
+export async function getAktiveProduktionen(): Promise<Produktion[]> {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from('produktionen')
+    .select('*')
+    .not('status', 'in', '("abgeschlossen","abgesagt")')
+    .order('premiere', { ascending: true, nullsFirst: false })
+
+  if (error) {
+    console.error('Error fetching active produktionen:', error)
+    return []
+  }
+
+  return (data as Produktion[]) || []
+}
+
+export async function getProduktion(id: string): Promise<Produktion | null> {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from('produktionen')
+    .select('*')
+    .eq('id', id)
+    .single()
+
+  if (error) {
+    console.error('Error fetching produktion:', error)
+    return null
+  }
+
+  return data as Produktion
+}
+
+export async function createProduktion(
+  data: ProduktionInsert
+): Promise<{ success: boolean; error?: string; id?: string }> {
+  const profile = await getUserProfile()
+  if (!profile || !hasPermission(profile.role, 'produktionen:write')) {
+    return {
+      success: false,
+      error: 'Keine Berechtigung. Nur Vorstand kann Produktionen erstellen.',
+    }
+  }
+
+  const supabase = await createClient()
+  const { data: result, error } = await supabase
+    .from('produktionen')
+    .insert(data as never)
+    .select('id')
+    .single()
+
+  if (error) {
+    console.error('Error creating produktion:', error)
+    return { success: false, error: error.message }
+  }
+
+  revalidatePath('/produktionen')
+  return { success: true, id: result?.id }
+}
+
+export async function updateProduktion(
+  id: string,
+  data: ProduktionUpdate
+): Promise<{ success: boolean; error?: string }> {
+  const profile = await getUserProfile()
+  if (!profile || !hasPermission(profile.role, 'produktionen:write')) {
+    return {
+      success: false,
+      error: 'Keine Berechtigung. Nur Vorstand kann Produktionen bearbeiten.',
+    }
+  }
+
+  const supabase = await createClient()
+  const { error } = await supabase
+    .from('produktionen')
+    .update(data as never)
+    .eq('id', id)
+
+  if (error) {
+    console.error('Error updating produktion:', error)
+    return { success: false, error: error.message }
+  }
+
+  revalidatePath('/produktionen')
+  revalidatePath(`/produktionen/${id}`)
+  return { success: true }
+}
+
+export async function deleteProduktion(
+  id: string
+): Promise<{ success: boolean; error?: string }> {
+  const profile = await getUserProfile()
+  if (!profile || !hasPermission(profile.role, 'produktionen:delete')) {
+    return {
+      success: false,
+      error:
+        'Keine Berechtigung. Nur Administratoren können Produktionen löschen.',
+    }
+  }
+
+  const supabase = await createClient()
+  const { error } = await supabase.from('produktionen').delete().eq('id', id)
+
+  if (error) {
+    console.error('Error deleting produktion:', error)
+    return { success: false, error: error.message }
+  }
+
+  revalidatePath('/produktionen')
+  return { success: true }
+}
+
+export async function updateProduktionStatus(
+  id: string,
+  newStatus: ProduktionStatus
+): Promise<{ success: boolean; error?: string }> {
+  const profile = await getUserProfile()
+  if (!profile || !hasPermission(profile.role, 'produktionen:write')) {
+    return {
+      success: false,
+      error: 'Keine Berechtigung.',
+    }
+  }
+
+  // Fetch current status
+  const produktion = await getProduktion(id)
+  if (!produktion) {
+    return { success: false, error: 'Produktion nicht gefunden.' }
+  }
+
+  // Validate transition
+  const allowed = ALLOWED_TRANSITIONS[produktion.status]
+  if (!allowed.includes(newStatus)) {
+    return {
+      success: false,
+      error: `Status-Übergang von "${produktion.status}" zu "${newStatus}" ist nicht erlaubt.`,
+    }
+  }
+
+  const supabase = await createClient()
+  const { error } = await supabase
+    .from('produktionen')
+    .update({ status: newStatus } as never)
+    .eq('id', id)
+
+  if (error) {
+    console.error('Error updating produktion status:', error)
+    return { success: false, error: error.message }
+  }
+
+  revalidatePath('/produktionen')
+  revalidatePath(`/produktionen/${id}`)
+  return { success: true }
+}
+
+export function getAllowedTransitions(
+  currentStatus: ProduktionStatus
+): ProduktionStatus[] {
+  return ALLOWED_TRANSITIONS[currentStatus] || []
+}
+
+// =============================================================================
+// Aufführungsserien
+// =============================================================================
+
+export async function getSerien(
+  produktionId: string
+): Promise<Auffuehrungsserie[]> {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from('auffuehrungsserien')
+    .select('*')
+    .eq('produktion_id', produktionId)
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    console.error('Error fetching serien:', error)
+    return []
+  }
+
+  return (data as Auffuehrungsserie[]) || []
+}
+
+export async function getSerie(
+  id: string
+): Promise<Auffuehrungsserie | null> {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from('auffuehrungsserien')
+    .select('*')
+    .eq('id', id)
+    .single()
+
+  if (error) {
+    console.error('Error fetching serie:', error)
+    return null
+  }
+
+  return data as Auffuehrungsserie
+}
+
+export async function createSerie(
+  data: AuffuehrungsserieInsert
+): Promise<{ success: boolean; error?: string; id?: string }> {
+  const profile = await getUserProfile()
+  if (!profile || !hasPermission(profile.role, 'produktionen:write')) {
+    return {
+      success: false,
+      error: 'Keine Berechtigung.',
+    }
+  }
+
+  const supabase = await createClient()
+  const { data: result, error } = await supabase
+    .from('auffuehrungsserien')
+    .insert(data as never)
+    .select('id')
+    .single()
+
+  if (error) {
+    console.error('Error creating serie:', error)
+    return { success: false, error: error.message }
+  }
+
+  revalidatePath(`/produktionen/${data.produktion_id}`)
+  return { success: true, id: result?.id }
+}
+
+export async function updateSerie(
+  id: string,
+  data: AuffuehrungsserieUpdate
+): Promise<{ success: boolean; error?: string }> {
+  const profile = await getUserProfile()
+  if (!profile || !hasPermission(profile.role, 'produktionen:write')) {
+    return {
+      success: false,
+      error: 'Keine Berechtigung.',
+    }
+  }
+
+  const supabase = await createClient()
+
+  const serie = await getSerie(id)
+  const produktionId = serie?.produktion_id
+
+  const { error } = await supabase
+    .from('auffuehrungsserien')
+    .update(data as never)
+    .eq('id', id)
+
+  if (error) {
+    console.error('Error updating serie:', error)
+    return { success: false, error: error.message }
+  }
+
+  if (produktionId) {
+    revalidatePath(`/produktionen/${produktionId}`)
+  }
+  return { success: true }
+}
+
+export async function deleteSerie(
+  id: string
+): Promise<{ success: boolean; error?: string }> {
+  const profile = await getUserProfile()
+  if (!profile || !hasPermission(profile.role, 'produktionen:write')) {
+    return {
+      success: false,
+      error: 'Keine Berechtigung.',
+    }
+  }
+
+  const supabase = await createClient()
+
+  const serie = await getSerie(id)
+  const produktionId = serie?.produktion_id
+
+  const { error } = await supabase
+    .from('auffuehrungsserien')
+    .delete()
+    .eq('id', id)
+
+  if (error) {
+    console.error('Error deleting serie:', error)
+    return { success: false, error: error.message }
+  }
+
+  if (produktionId) {
+    revalidatePath(`/produktionen/${produktionId}`)
+  }
+  return { success: true }
+}
+
+// =============================================================================
+// Serienaufführungen
+// =============================================================================
+
+export async function getSerienAuffuehrungen(
+  serieId: string
+): Promise<Serienauffuehrung[]> {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from('serienauffuehrungen')
+    .select('*')
+    .eq('serie_id', serieId)
+    .order('datum', { ascending: true })
+
+  if (error) {
+    console.error('Error fetching serienauffuehrungen:', error)
+    return []
+  }
+
+  return (data as Serienauffuehrung[]) || []
+}
+
+export async function generiereAuffuehrungen(
+  serieId: string,
+  termine: { datum: string; startzeit?: string; typ?: AuffuehrungsTyp }[]
+): Promise<{ success: boolean; error?: string; count?: number }> {
+  const profile = await getUserProfile()
+  if (!profile || !hasPermission(profile.role, 'produktionen:write')) {
+    return { success: false, error: 'Keine Berechtigung.' }
+  }
+
+  if (termine.length > 100) {
+    return {
+      success: false,
+      error: 'Maximal 100 Aufführungen pro Anfrage.',
+    }
+  }
+
+  const serie = await getSerie(serieId)
+  if (!serie) {
+    return { success: false, error: 'Serie nicht gefunden.' }
+  }
+
+  const inserts: SerienauffuehrungInsert[] = termine.map((t) => ({
+    serie_id: serieId,
+    datum: t.datum,
+    startzeit: t.startzeit || serie.standard_startzeit || null,
+    ort: serie.standard_ort || null,
+    typ: t.typ || 'regulaer',
+    ist_ausnahme: false,
+    veranstaltung_id: null,
+    notizen: null,
+  }))
+
+  const supabase = await createClient()
+  const { error } = await supabase
+    .from('serienauffuehrungen')
+    .insert(inserts as never)
+
+  if (error) {
+    console.error('Error generating auffuehrungen:', error)
+    return { success: false, error: error.message }
+  }
+
+  revalidatePath(`/produktionen/${serie.produktion_id}`)
+  return { success: true, count: inserts.length }
+}
+
+export async function generiereAuffuehrungenWiederholung(
+  serieId: string,
+  config: {
+    startDatum: string
+    endDatum: string
+    wochentage: number[]
+    startzeit?: string
+    ausnahmen?: string[]
+  }
+): Promise<{ success: boolean; error?: string; count?: number }> {
+  const profile = await getUserProfile()
+  if (!profile || !hasPermission(profile.role, 'produktionen:write')) {
+    return { success: false, error: 'Keine Berechtigung.' }
+  }
+
+  // Generate dates
+  const termine: { datum: string; startzeit?: string }[] = []
+  const ausnahmenSet = new Set(config.ausnahmen || [])
+  const current = new Date(config.startDatum)
+  const end = new Date(config.endDatum)
+
+  while (current <= end) {
+    const dayOfWeek = current.getDay()
+    const dateStr = current.toISOString().split('T')[0]
+
+    if (config.wochentage.includes(dayOfWeek) && !ausnahmenSet.has(dateStr)) {
+      termine.push({
+        datum: dateStr,
+        startzeit: config.startzeit,
+      })
+    }
+
+    current.setDate(current.getDate() + 1)
+  }
+
+  if (termine.length === 0) {
+    return { success: false, error: 'Keine Termine im angegebenen Zeitraum.' }
+  }
+
+  if (termine.length > 100) {
+    return {
+      success: false,
+      error: `Zu viele Termine (${termine.length}). Maximal 100 erlaubt.`,
+    }
+  }
+
+  return generiereAuffuehrungen(serieId, termine)
+}
+
+export async function updateSerienauffuehrung(
+  id: string,
+  data: SerienauffuehrungUpdate
+): Promise<{ success: boolean; error?: string }> {
+  const profile = await getUserProfile()
+  if (!profile || !hasPermission(profile.role, 'produktionen:write')) {
+    return { success: false, error: 'Keine Berechtigung.' }
+  }
+
+  const supabase = await createClient()
+  const { error } = await supabase
+    .from('serienauffuehrungen')
+    .update(data as never)
+    .eq('id', id)
+
+  if (error) {
+    console.error('Error updating serienauffuehrung:', error)
+    return { success: false, error: error.message }
+  }
+
+  return { success: true }
+}
+
+export async function deleteSerienauffuehrung(
+  id: string
+): Promise<{ success: boolean; error?: string }> {
+  const profile = await getUserProfile()
+  if (!profile || !hasPermission(profile.role, 'produktionen:write')) {
+    return { success: false, error: 'Keine Berechtigung.' }
+  }
+
+  const supabase = await createClient()
+  const { error } = await supabase
+    .from('serienauffuehrungen')
+    .delete()
+    .eq('id', id)
+
+  if (error) {
+    console.error('Error deleting serienauffuehrung:', error)
+    return { success: false, error: error.message }
+  }
+
+  return { success: true }
+}

--- a/apps/web/lib/navigation.ts
+++ b/apps/web/lib/navigation.ts
@@ -55,6 +55,7 @@ export type NavIcon =
   | 'list'
   | 'mail'
   | 'eye'
+  | 'film'
 
 // =============================================================================
 // Startseiten pro Rolle
@@ -103,6 +104,12 @@ const MANAGEMENT_NAVIGATION: NavSection[] = [
     items: [
       { href: '/veranstaltungen', label: 'Übersicht', icon: 'calendar' },
       { href: '/auffuehrungen', label: 'Aufführungen', icon: 'theater' },
+      {
+        href: '/produktionen',
+        label: 'Produktionen',
+        icon: 'film',
+        permission: 'produktionen:read',
+      },
       {
         href: '/stuecke',
         label: 'Stücke',
@@ -427,6 +434,7 @@ export const BREADCRUMB_LABELS: Record<string, string> = {
   partner: 'Partner',
   veranstaltungen: 'Veranstaltungen',
   auffuehrungen: 'Aufführungen',
+  produktionen: 'Produktionen',
   stuecke: 'Stücke',
   proben: 'Proben',
   helfereinsaetze: 'Helfereinsätze',

--- a/apps/web/lib/supabase/permissions.ts
+++ b/apps/web/lib/supabase/permissions.ts
@@ -43,6 +43,9 @@ const ROLE_PERMISSIONS: Record<UserRole, Permission[]> = {
     'raeume:write',
     'ressourcen:read',
     'ressourcen:write',
+    'produktionen:read',
+    'produktionen:write',
+    'produktionen:delete',
   ],
 
   VORSTAND: [
@@ -75,6 +78,8 @@ const ROLE_PERMISSIONS: Record<UserRole, Permission[]> = {
     'raeume:write',
     'ressourcen:read',
     'ressourcen:write',
+    'produktionen:read',
+    'produktionen:write',
   ],
 
   MITGLIED_AKTIV: [
@@ -89,6 +94,7 @@ const ROLE_PERMISSIONS: Record<UserRole, Permission[]> = {
     'stuecke:read',
     'raeume:read',
     'ressourcen:read',
+    'produktionen:read',
   ],
 
   MITGLIED_PASSIV: [

--- a/apps/web/lib/supabase/types.ts
+++ b/apps/web/lib/supabase/types.ts
@@ -264,6 +264,9 @@ export type Permission =
   | 'raeume:write'
   | 'ressourcen:read'
   | 'ressourcen:write'
+  | 'produktionen:read'
+  | 'produktionen:write'
+  | 'produktionen:delete'
 
 export type Profile = {
   id: string
@@ -1083,6 +1086,151 @@ export type HelferAnmeldungMitDetails = HelferAnmeldung & {
 }
 
 // =============================================================================
+// Produktionen (Issue #156)
+// =============================================================================
+
+export type ProduktionStatus =
+  | 'draft'
+  | 'planung'
+  | 'casting'
+  | 'proben'
+  | 'premiere'
+  | 'laufend'
+  | 'abgeschlossen'
+  | 'abgesagt'
+
+export type SerieStatus = 'draft' | 'planung' | 'publiziert' | 'abgeschlossen'
+
+export type AuffuehrungsTyp =
+  | 'regulaer'
+  | 'premiere'
+  | 'derniere'
+  | 'schulvorstellung'
+  | 'sondervorstellung'
+
+export const PRODUKTION_STATUS_LABELS: Record<ProduktionStatus, string> = {
+  draft: 'Entwurf',
+  planung: 'In Planung',
+  casting: 'Casting',
+  proben: 'Probenphase',
+  premiere: 'Premiere',
+  laufend: 'Laufend',
+  abgeschlossen: 'Abgeschlossen',
+  abgesagt: 'Abgesagt',
+}
+
+export const SERIE_STATUS_LABELS: Record<SerieStatus, string> = {
+  draft: 'Entwurf',
+  planung: 'In Planung',
+  publiziert: 'Publiziert',
+  abgeschlossen: 'Abgeschlossen',
+}
+
+export const AUFFUEHRUNG_TYP_LABELS: Record<AuffuehrungsTyp, string> = {
+  regulaer: 'Regulär',
+  premiere: 'Premiere',
+  derniere: 'Dernière',
+  schulvorstellung: 'Schulvorstellung',
+  sondervorstellung: 'Sondervorstellung',
+}
+
+export type Produktion = {
+  id: string
+  titel: string
+  beschreibung: string | null
+  stueck_id: string | null
+  status: ProduktionStatus
+  saison: string
+  proben_start: string | null
+  premiere: string | null
+  derniere: string | null
+  produktionsleitung_id: string | null
+  created_at: string
+  updated_at: string
+}
+
+export type ProduktionInsert = Omit<
+  Produktion,
+  'id' | 'created_at' | 'updated_at'
+>
+export type ProduktionUpdate = Partial<ProduktionInsert>
+
+export type Auffuehrungsserie = {
+  id: string
+  produktion_id: string
+  name: string
+  beschreibung: string | null
+  status: SerieStatus
+  standard_ort: string | null
+  standard_startzeit: string | null
+  standard_einlass_minuten: number | null
+  template_id: string | null
+  created_at: string
+  updated_at: string
+}
+
+export type AuffuehrungsserieInsert = Omit<
+  Auffuehrungsserie,
+  'id' | 'created_at' | 'updated_at'
+>
+export type AuffuehrungsserieUpdate = Partial<AuffuehrungsserieInsert>
+
+export type Serienauffuehrung = {
+  id: string
+  serie_id: string
+  veranstaltung_id: string | null
+  datum: string
+  startzeit: string | null
+  ort: string | null
+  typ: AuffuehrungsTyp
+  ist_ausnahme: boolean
+  notizen: string | null
+  created_at: string
+  updated_at: string
+}
+
+export type SerienauffuehrungInsert = Omit<
+  Serienauffuehrung,
+  'id' | 'created_at' | 'updated_at'
+>
+export type SerienauffuehrungUpdate = Partial<SerienauffuehrungInsert>
+
+export type ProduktionsStab = {
+  id: string
+  produktion_id: string
+  person_id: string
+  funktion: string
+  ist_leitung: boolean
+  von: string | null
+  bis: string | null
+  notizen: string | null
+  created_at: string
+}
+
+export type ProduktionsStabInsert = Omit<ProduktionsStab, 'id' | 'created_at'>
+export type ProduktionsStabUpdate = Partial<ProduktionsStabInsert>
+
+// Extended types for views
+export type ProduktionMitDetails = Produktion & {
+  stueck: Pick<Stueck, 'id' | 'titel'> | null
+  produktionsleitung: Pick<Person, 'id' | 'vorname' | 'nachname'> | null
+  serien_count: number
+  naechste_auffuehrung: string | null
+}
+
+export type AuffuehrungsserieMitDetails = Auffuehrungsserie & {
+  produktion: Pick<Produktion, 'id' | 'titel'>
+  auffuehrungen_count: number
+  template: Pick<AuffuehrungTemplate, 'id' | 'name'> | null
+}
+
+export type ProduktionMitStab = Produktion & {
+  stab: (ProduktionsStab & {
+    person: Pick<Person, 'id' | 'vorname' | 'nachname' | 'email'>
+  })[]
+}
+
+// =============================================================================
 // Gruppen (Teams, Gremien, Produktions-Casts) - Dashboards Milestone
 // =============================================================================
 
@@ -1312,6 +1460,26 @@ export type Database = {
         Row: HelferAnmeldung
         Insert: HelferAnmeldungInsert
         Update: HelferAnmeldungUpdate
+      }
+      produktionen: {
+        Row: Produktion
+        Insert: ProduktionInsert
+        Update: ProduktionUpdate
+      }
+      auffuehrungsserien: {
+        Row: Auffuehrungsserie
+        Insert: AuffuehrungsserieInsert
+        Update: AuffuehrungsserieUpdate
+      }
+      serienauffuehrungen: {
+        Row: Serienauffuehrung
+        Insert: SerienauffuehrungInsert
+        Update: SerienauffuehrungUpdate
+      }
+      produktions_stab: {
+        Row: ProduktionsStab
+        Insert: ProduktionsStabInsert
+        Update: ProduktionsStabUpdate
       }
       gruppen: {
         Row: Gruppe

--- a/apps/web/lib/validations/produktionen.ts
+++ b/apps/web/lib/validations/produktionen.ts
@@ -1,0 +1,112 @@
+import { z } from 'zod'
+
+// =============================================================================
+// Produktion Validations
+// =============================================================================
+
+export const produktionSchema = z.object({
+  titel: z
+    .string()
+    .min(1, 'Titel ist erforderlich')
+    .max(200, 'Titel zu lang'),
+  beschreibung: z
+    .string()
+    .max(2000, 'Beschreibung zu lang')
+    .nullable()
+    .optional(),
+  stueck_id: z.string().uuid().nullable().optional(),
+  status: z
+    .enum([
+      'draft',
+      'planung',
+      'casting',
+      'proben',
+      'premiere',
+      'laufend',
+      'abgeschlossen',
+      'abgesagt',
+    ])
+    .default('draft'),
+  saison: z
+    .string()
+    .min(1, 'Saison ist erforderlich')
+    .max(20, 'Saison zu lang'),
+  proben_start: z.string().nullable().optional(),
+  premiere: z.string().nullable().optional(),
+  derniere: z.string().nullable().optional(),
+  produktionsleitung_id: z.string().uuid().nullable().optional(),
+})
+
+export const produktionUpdateSchema = produktionSchema.partial()
+
+// =============================================================================
+// Aufführungsserie Validations
+// =============================================================================
+
+export const serieSchema = z.object({
+  produktion_id: z.string().uuid('Ungültige Produktions-ID'),
+  name: z.string().min(1, 'Name ist erforderlich').max(200, 'Name zu lang'),
+  beschreibung: z
+    .string()
+    .max(2000, 'Beschreibung zu lang')
+    .nullable()
+    .optional(),
+  status: z
+    .enum(['draft', 'planung', 'publiziert', 'abgeschlossen'])
+    .default('draft'),
+  standard_ort: z.string().max(200, 'Ort zu lang').nullable().optional(),
+  standard_startzeit: z.string().nullable().optional(),
+  standard_einlass_minuten: z
+    .number()
+    .int()
+    .min(0)
+    .max(120)
+    .nullable()
+    .optional(),
+  template_id: z.string().uuid().nullable().optional(),
+})
+
+export const serieUpdateSchema = serieSchema
+  .omit({ produktion_id: true })
+  .partial()
+
+// =============================================================================
+// Aufführung Generator Validations
+// =============================================================================
+
+export const auffuehrungGeneratorSchema = z.object({
+  termine: z
+    .array(
+      z.object({
+        datum: z.string().min(1, 'Datum ist erforderlich'),
+        startzeit: z.string().optional(),
+        typ: z
+          .enum([
+            'regulaer',
+            'premiere',
+            'derniere',
+            'schulvorstellung',
+            'sondervorstellung',
+          ])
+          .optional(),
+      })
+    )
+    .min(1, 'Mindestens ein Termin erforderlich'),
+})
+
+export const wiederholungGeneratorSchema = z
+  .object({
+    startDatum: z.string().min(1, 'Startdatum ist erforderlich'),
+    endDatum: z.string().min(1, 'Enddatum ist erforderlich'),
+    wochentage: z
+      .array(z.number().int().min(0).max(6))
+      .min(1, 'Mindestens ein Wochentag erforderlich'),
+    startzeit: z.string().optional(),
+    ausnahmen: z.array(z.string()).optional(),
+  })
+  .refine(
+    (data) => {
+      return new Date(data.endDatum) > new Date(data.startDatum)
+    },
+    { message: 'Enddatum muss nach Startdatum liegen', path: ['endDatum'] }
+  )

--- a/journal/decisions/PLAN-156-produktions-entitaet.md
+++ b/journal/decisions/PLAN-156-produktions-entitaet.md
@@ -1,0 +1,745 @@
+# Tech Plan: Produktions-Entität erstellen
+
+**Issue:** #156
+**Priority:** high
+**Author:** Martin (Bühnenmeister)
+**Date:** 2026-02-02
+
+## 1. Übersicht
+
+Eine "Produktion" ist das übergeordnete Objekt für Theaterprojekte. Sie verbindet ein Stück mit einem konkreten Aufführungszeitraum und steuert den gesamten Produktionsprozess von der Planung bis zum Abschluss.
+
+### Kernkonzepte
+
+```
+Produktion (z.B. "Sommernachtstraum 2026")
+├── verknüpft mit: Stück (optional)
+├── hat: Status-Workflow
+├── hat: Produktionsleitung (Person)
+├── enthält: Aufführungsserien
+│   └── Serie (z.B. "Hauptserie Widen")
+│       ├── Standard-Ort/Zeiten
+│       ├── Standard-Ressourcen
+│       └── generiert: Aufführungen (Einzeltermine)
+```
+
+## 2. Datenbank (Supabase)
+
+### 2.1 ENUM Types
+
+```sql
+-- supabase/migrations/20260203000000_produktionen.sql
+
+-- Produktions-Status Workflow
+CREATE TYPE produktion_status AS ENUM (
+  'draft',           -- Entwurf, noch nicht aktiv
+  'planung',         -- Aktive Planungsphase
+  'casting',         -- Besetzungsphase
+  'proben',          -- Probenphase
+  'premiere',        -- Kurz vor/nach Premiere
+  'laufend',         -- Aufführungen laufen
+  'abgeschlossen',   -- Produktion beendet
+  'abgesagt'         -- Produktion abgesagt
+);
+
+-- Aufführungsserie-Status
+CREATE TYPE serie_status AS ENUM (
+  'draft',           -- Entwurf
+  'planung',         -- In Planung
+  'publiziert',      -- Öffentlich sichtbar
+  'abgeschlossen'    -- Serie beendet
+);
+```
+
+### 2.2 Tabellen
+
+```sql
+-- =============================================================================
+-- Produktionen (Haupttabelle)
+-- =============================================================================
+
+CREATE TABLE produktionen (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  titel TEXT NOT NULL,
+  beschreibung TEXT,
+  stueck_id UUID REFERENCES stuecke(id) ON DELETE SET NULL,
+  status produktion_status NOT NULL DEFAULT 'draft',
+  saison TEXT NOT NULL,  -- z.B. "2026", "2026/2027"
+  proben_start DATE,
+  premiere DATE,
+  derniere DATE,
+  produktionsleitung_id UUID REFERENCES personen(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- =============================================================================
+-- Aufführungsserien (gruppiert Einzelaufführungen)
+-- =============================================================================
+
+CREATE TABLE auffuehrungsserien (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  produktion_id UUID NOT NULL REFERENCES produktionen(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,  -- z.B. "Hauptserie Widen", "Gastspiel Bremgarten"
+  beschreibung TEXT,
+  status serie_status NOT NULL DEFAULT 'draft',
+  -- Standard-Werte für generierte Aufführungen
+  standard_ort TEXT,
+  standard_startzeit TIME,
+  standard_einlass_minuten INTEGER DEFAULT 30,
+  -- Template für Schichten
+  template_id UUID REFERENCES auffuehrung_templates(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- =============================================================================
+-- Serienaufführungen (Einzeltermine einer Serie)
+-- =============================================================================
+
+CREATE TABLE serienaufführungen (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  serie_id UUID NOT NULL REFERENCES auffuehrungsserien(id) ON DELETE CASCADE,
+  veranstaltung_id UUID REFERENCES veranstaltungen(id) ON DELETE SET NULL,
+  datum DATE NOT NULL,
+  startzeit TIME,
+  ort TEXT,
+  typ TEXT DEFAULT 'regulaer',  -- regulaer, premiere, derniere, schulvorstellung, sondervorstellung
+  ist_ausnahme BOOLEAN DEFAULT false,  -- Manuell ausgeschlossen
+  notizen TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(serie_id, datum, startzeit)
+);
+
+-- =============================================================================
+-- Produktions-Stab (Team-Zuweisung) - für Issue #159
+-- =============================================================================
+
+CREATE TABLE produktions_stab (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  produktion_id UUID NOT NULL REFERENCES produktionen(id) ON DELETE CASCADE,
+  person_id UUID NOT NULL REFERENCES personen(id) ON DELETE CASCADE,
+  funktion TEXT NOT NULL,  -- z.B. "Regie", "Regieassistenz", "Bühnenbild"
+  ist_leitung BOOLEAN DEFAULT false,
+  von DATE,
+  bis DATE,
+  notizen TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(produktion_id, person_id, funktion)
+);
+```
+
+### 2.3 Indexes
+
+```sql
+-- Performance-Indexes
+CREATE INDEX idx_produktionen_status ON produktionen(status);
+CREATE INDEX idx_produktionen_saison ON produktionen(saison);
+CREATE INDEX idx_produktionen_stueck ON produktionen(stueck_id);
+CREATE INDEX idx_produktionen_leitung ON produktionen(produktionsleitung_id);
+
+CREATE INDEX idx_serien_produktion ON auffuehrungsserien(produktion_id);
+CREATE INDEX idx_serien_status ON auffuehrungsserien(status);
+
+CREATE INDEX idx_serienauffuehrungen_serie ON serienaufführungen(serie_id);
+CREATE INDEX idx_serienauffuehrungen_datum ON serienaufführungen(datum);
+CREATE INDEX idx_serienauffuehrungen_veranstaltung ON serienaufführungen(veranstaltung_id);
+
+CREATE INDEX idx_produktions_stab_produktion ON produktions_stab(produktion_id);
+CREATE INDEX idx_produktions_stab_person ON produktions_stab(person_id);
+```
+
+### 2.4 Triggers
+
+```sql
+-- Updated_at Triggers
+CREATE TRIGGER set_produktionen_updated_at
+  BEFORE UPDATE ON produktionen
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER set_auffuehrungsserien_updated_at
+  BEFORE UPDATE ON auffuehrungsserien
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER set_serienauffuehrungen_updated_at
+  BEFORE UPDATE ON serienaufführungen
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+```
+
+### 2.5 RLS Policies
+
+```sql
+-- =============================================================================
+-- Row Level Security
+-- =============================================================================
+
+ALTER TABLE produktionen ENABLE ROW LEVEL SECURITY;
+ALTER TABLE auffuehrungsserien ENABLE ROW LEVEL SECURITY;
+ALTER TABLE serienaufführungen ENABLE ROW LEVEL SECURITY;
+ALTER TABLE produktions_stab ENABLE ROW LEVEL SECURITY;
+
+-- Produktionen: Alle authentifizierten können lesen
+CREATE POLICY "Authenticated users can view produktionen"
+  ON produktionen FOR SELECT
+  TO authenticated
+  USING (true);
+
+-- Management kann schreiben (ADMIN, VORSTAND)
+CREATE POLICY "Management can insert produktionen"
+  ON produktionen FOR INSERT
+  TO authenticated
+  WITH CHECK (is_management());
+
+CREATE POLICY "Management can update produktionen"
+  ON produktionen FOR UPDATE
+  TO authenticated
+  USING (is_management())
+  WITH CHECK (is_management());
+
+CREATE POLICY "Admins can delete produktionen"
+  ON produktionen FOR DELETE
+  TO authenticated
+  USING (is_admin());
+
+-- Serien: Gleiche Policies
+CREATE POLICY "Authenticated users can view serien"
+  ON auffuehrungsserien FOR SELECT
+  TO authenticated
+  USING (true);
+
+CREATE POLICY "Management can insert serien"
+  ON auffuehrungsserien FOR INSERT
+  TO authenticated
+  WITH CHECK (is_management());
+
+CREATE POLICY "Management can update serien"
+  ON auffuehrungsserien FOR UPDATE
+  TO authenticated
+  USING (is_management())
+  WITH CHECK (is_management());
+
+CREATE POLICY "Admins can delete serien"
+  ON auffuehrungsserien FOR DELETE
+  TO authenticated
+  USING (is_admin());
+
+-- Serienaufführungen: Gleiche Policies
+CREATE POLICY "Authenticated users can view serienauffuehrungen"
+  ON serienaufführungen FOR SELECT
+  TO authenticated
+  USING (true);
+
+CREATE POLICY "Management can insert serienauffuehrungen"
+  ON serienaufführungen FOR INSERT
+  TO authenticated
+  WITH CHECK (is_management());
+
+CREATE POLICY "Management can update serienauffuehrungen"
+  ON serienaufführungen FOR UPDATE
+  TO authenticated
+  USING (is_management())
+  WITH CHECK (is_management());
+
+CREATE POLICY "Management can delete serienauffuehrungen"
+  ON serienaufführungen FOR DELETE
+  TO authenticated
+  USING (is_management());
+
+-- Produktions-Stab: Gleiche Policies
+CREATE POLICY "Authenticated users can view produktions_stab"
+  ON produktions_stab FOR SELECT
+  TO authenticated
+  USING (true);
+
+CREATE POLICY "Management can manage produktions_stab"
+  ON produktions_stab FOR ALL
+  TO authenticated
+  USING (is_management())
+  WITH CHECK (is_management());
+```
+
+### 2.6 Audit Logging (Status-Änderungen)
+
+```sql
+-- Audit-Log für Status-Änderungen
+CREATE OR REPLACE FUNCTION log_produktion_status_change()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF OLD.status IS DISTINCT FROM NEW.status THEN
+    INSERT INTO audit_logs (
+      table_name,
+      record_id,
+      action,
+      old_data,
+      new_data,
+      user_id
+    ) VALUES (
+      'produktionen',
+      NEW.id,
+      'status_change',
+      jsonb_build_object('status', OLD.status),
+      jsonb_build_object('status', NEW.status),
+      auth.uid()
+    );
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE TRIGGER audit_produktion_status
+  AFTER UPDATE ON produktionen
+  FOR EACH ROW
+  EXECUTE FUNCTION log_produktion_status_change();
+
+-- Gleicher Trigger für Serien
+CREATE OR REPLACE FUNCTION log_serie_status_change()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF OLD.status IS DISTINCT FROM NEW.status THEN
+    INSERT INTO audit_logs (
+      table_name,
+      record_id,
+      action,
+      old_data,
+      new_data,
+      user_id
+    ) VALUES (
+      'auffuehrungsserien',
+      NEW.id,
+      'status_change',
+      jsonb_build_object('status', OLD.status),
+      jsonb_build_object('status', NEW.status),
+      auth.uid()
+    );
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE TRIGGER audit_serie_status
+  AFTER UPDATE ON auffuehrungsserien
+  FOR EACH ROW
+  EXECUTE FUNCTION log_serie_status_change();
+```
+
+## 3. TypeScript Types
+
+```typescript
+// lib/supabase/types.ts - Neue Types hinzufügen
+
+// =============================================================================
+// Produktionen (Issue #156)
+// =============================================================================
+
+export type ProduktionStatus =
+  | 'draft'
+  | 'planung'
+  | 'casting'
+  | 'proben'
+  | 'premiere'
+  | 'laufend'
+  | 'abgeschlossen'
+  | 'abgesagt'
+
+export type SerieStatus = 'draft' | 'planung' | 'publiziert' | 'abgeschlossen'
+
+export type AuffuehrungsTyp =
+  | 'regulaer'
+  | 'premiere'
+  | 'derniere'
+  | 'schulvorstellung'
+  | 'sondervorstellung'
+
+export const PRODUKTION_STATUS_LABELS: Record<ProduktionStatus, string> = {
+  draft: 'Entwurf',
+  planung: 'In Planung',
+  casting: 'Casting',
+  proben: 'Probenphase',
+  premiere: 'Premiere',
+  laufend: 'Laufend',
+  abgeschlossen: 'Abgeschlossen',
+  abgesagt: 'Abgesagt',
+}
+
+export const SERIE_STATUS_LABELS: Record<SerieStatus, string> = {
+  draft: 'Entwurf',
+  planung: 'In Planung',
+  publiziert: 'Publiziert',
+  abgeschlossen: 'Abgeschlossen',
+}
+
+export const AUFFUEHRUNG_TYP_LABELS: Record<AuffuehrungsTyp, string> = {
+  regulaer: 'Regulär',
+  premiere: 'Premiere',
+  derniere: 'Dernière',
+  schulvorstellung: 'Schulvorstellung',
+  sondervorstellung: 'Sondervorstellung',
+}
+
+export type Produktion = {
+  id: string
+  titel: string
+  beschreibung: string | null
+  stueck_id: string | null
+  status: ProduktionStatus
+  saison: string
+  proben_start: string | null
+  premiere: string | null
+  derniere: string | null
+  produktionsleitung_id: string | null
+  created_at: string
+  updated_at: string
+}
+
+export type ProduktionInsert = Omit<Produktion, 'id' | 'created_at' | 'updated_at'>
+export type ProduktionUpdate = Partial<ProduktionInsert>
+
+export type Auffuehrungsserie = {
+  id: string
+  produktion_id: string
+  name: string
+  beschreibung: string | null
+  status: SerieStatus
+  standard_ort: string | null
+  standard_startzeit: string | null
+  standard_einlass_minuten: number | null
+  template_id: string | null
+  created_at: string
+  updated_at: string
+}
+
+export type AuffuehrungsserieInsert = Omit<Auffuehrungsserie, 'id' | 'created_at' | 'updated_at'>
+export type AuffuehrungsserieUpdate = Partial<AuffuehrungsserieInsert>
+
+export type Serienauffuehrung = {
+  id: string
+  serie_id: string
+  veranstaltung_id: string | null
+  datum: string
+  startzeit: string | null
+  ort: string | null
+  typ: AuffuehrungsTyp
+  ist_ausnahme: boolean
+  notizen: string | null
+  created_at: string
+  updated_at: string
+}
+
+export type SerienauffuehrungInsert = Omit<Serienauffuehrung, 'id' | 'created_at' | 'updated_at'>
+export type SerienauffuehrungUpdate = Partial<SerienauffuehrungInsert>
+
+export type ProduktionsStab = {
+  id: string
+  produktion_id: string
+  person_id: string
+  funktion: string
+  ist_leitung: boolean
+  von: string | null
+  bis: string | null
+  notizen: string | null
+  created_at: string
+}
+
+export type ProduktionsStabInsert = Omit<ProduktionsStab, 'id' | 'created_at'>
+export type ProduktionsStabUpdate = Partial<ProduktionsStabInsert>
+
+// Extended types for views
+export type ProduktionMitDetails = Produktion & {
+  stueck: Pick<Stueck, 'id' | 'titel'> | null
+  produktionsleitung: Pick<Person, 'id' | 'vorname' | 'nachname'> | null
+  serien_count: number
+  naechste_auffuehrung: string | null
+}
+
+export type AuffuehrungsserieMitDetails = Auffuehrungsserie & {
+  produktion: Pick<Produktion, 'id' | 'titel'>
+  auffuehrungen_count: number
+  template: Pick<AuffuehrungTemplate, 'id' | 'name'> | null
+}
+
+export type ProduktionMitStab = Produktion & {
+  stab: (ProduktionsStab & {
+    person: Pick<Person, 'id' | 'vorname' | 'nachname' | 'email'>
+  })[]
+}
+```
+
+## 4. Dateistruktur
+
+```
+apps/web/
+├── app/(protected)/produktionen/
+│   ├── page.tsx                    # Übersicht aller Produktionen
+│   ├── neu/
+│   │   └── page.tsx                # Neue Produktion erstellen
+│   └── [id]/
+│       ├── page.tsx                # Produktions-Detail/Dashboard
+│       ├── bearbeiten/
+│       │   └── page.tsx            # Produktion bearbeiten
+│       └── serien/
+│           ├── page.tsx            # Serien-Übersicht
+│           ├── neu/
+│           │   └── page.tsx        # Neue Serie erstellen
+│           └── [serieId]/
+│               ├── page.tsx        # Serie-Detail mit Aufführungen
+│               └── generieren/
+│                   └── page.tsx    # Aufführungen generieren
+├── components/produktionen/
+│   ├── ProduktionCard.tsx          # Karte für Übersicht
+│   ├── ProduktionForm.tsx          # Formular (Create/Edit)
+│   ├── ProduktionStatusBadge.tsx   # Status-Anzeige
+│   ├── ProduktionStatusSelect.tsx  # Status-Workflow Dropdown
+│   ├── SerieCard.tsx               # Serie-Karte
+│   ├── SerieForm.tsx               # Serie-Formular
+│   ├── AuffuehrungGenerator.tsx    # Termine generieren UI
+│   └── AuffuehrungListe.tsx        # Liste der Einzeltermine
+└── lib/
+    ├── actions/produktionen.ts     # Server Actions
+    └── validations/produktionen.ts # Zod Schemas
+```
+
+## 5. Server Actions
+
+```typescript
+// lib/actions/produktionen.ts
+
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { createClient, getUserProfile } from '../supabase/server'
+import { hasPermission } from '../supabase/auth-helpers'
+import type {
+  Produktion,
+  ProduktionInsert,
+  ProduktionUpdate,
+  ProduktionMitDetails,
+  Auffuehrungsserie,
+  AuffuehrungsserieInsert,
+  AuffuehrungsserieUpdate,
+  Serienauffuehrung,
+  SerienauffuehrungInsert,
+} from '../supabase/types'
+
+// =============================================================================
+// Produktionen
+// =============================================================================
+
+export async function getProduktionen(): Promise<ProduktionMitDetails[]>
+export async function getAktiveProduktionen(): Promise<ProduktionMitDetails[]>
+export async function getProduktion(id: string): Promise<ProduktionMitDetails | null>
+export async function createProduktion(data: ProduktionInsert): Promise<{ success: boolean; error?: string; id?: string }>
+export async function updateProduktion(id: string, data: ProduktionUpdate): Promise<{ success: boolean; error?: string }>
+export async function deleteProduktion(id: string): Promise<{ success: boolean; error?: string }>
+export async function updateProduktionStatus(id: string, status: ProduktionStatus): Promise<{ success: boolean; error?: string }>
+
+// =============================================================================
+// Aufführungsserien
+// =============================================================================
+
+export async function getSerien(produktionId: string): Promise<AuffuehrungsserieMitDetails[]>
+export async function getSerie(id: string): Promise<AuffuehrungsserieMitDetails | null>
+export async function createSerie(data: AuffuehrungsserieInsert): Promise<{ success: boolean; error?: string; id?: string }>
+export async function updateSerie(id: string, data: AuffuehrungsserieUpdate): Promise<{ success: boolean; error?: string }>
+export async function deleteSerie(id: string): Promise<{ success: boolean; error?: string }>
+
+// =============================================================================
+// Aufführungen generieren
+// =============================================================================
+
+export async function generiereAuffuehrungen(
+  serieId: string,
+  termine: { datum: string; startzeit?: string; typ?: AuffuehrungsTyp }[]
+): Promise<{ success: boolean; error?: string; count?: number }>
+
+export async function generiereAuffuehrungenWiederholung(
+  serieId: string,
+  config: {
+    startDatum: string
+    endDatum: string
+    wochentage: number[]  // 0=So, 1=Mo, ..., 6=Sa
+    startzeit?: string
+    ausnahmen?: string[]  // Daten die ausgeschlossen werden
+  }
+): Promise<{ success: boolean; error?: string; count?: number }>
+
+export async function getSerienAuffuehrungen(serieId: string): Promise<Serienauffuehrung[]>
+export async function updateSerienauffuehrung(id: string, data: SerienauffuehrungUpdate): Promise<{ success: boolean; error?: string }>
+export async function deleteSerienauffuehrung(id: string): Promise<{ success: boolean; error?: string }>
+```
+
+## 6. Zod Validations
+
+```typescript
+// lib/validations/produktionen.ts
+
+import { z } from 'zod'
+
+export const produktionSchema = z.object({
+  titel: z.string().min(1, 'Titel ist erforderlich').max(200),
+  beschreibung: z.string().max(2000).optional().nullable(),
+  stueck_id: z.string().uuid().optional().nullable(),
+  status: z.enum(['draft', 'planung', 'casting', 'proben', 'premiere', 'laufend', 'abgeschlossen', 'abgesagt']).default('draft'),
+  saison: z.string().min(1, 'Saison ist erforderlich').max(20),
+  proben_start: z.string().optional().nullable(),
+  premiere: z.string().optional().nullable(),
+  derniere: z.string().optional().nullable(),
+  produktionsleitung_id: z.string().uuid().optional().nullable(),
+})
+
+export const serieSchema = z.object({
+  produktion_id: z.string().uuid(),
+  name: z.string().min(1, 'Name ist erforderlich').max(200),
+  beschreibung: z.string().max(2000).optional().nullable(),
+  status: z.enum(['draft', 'planung', 'publiziert', 'abgeschlossen']).default('draft'),
+  standard_ort: z.string().max(200).optional().nullable(),
+  standard_startzeit: z.string().optional().nullable(),
+  standard_einlass_minuten: z.number().int().min(0).max(120).optional().nullable(),
+  template_id: z.string().uuid().optional().nullable(),
+})
+
+export const auffuehrungGeneratorSchema = z.object({
+  termine: z.array(z.object({
+    datum: z.string(),
+    startzeit: z.string().optional(),
+    typ: z.enum(['regulaer', 'premiere', 'derniere', 'schulvorstellung', 'sondervorstellung']).optional(),
+  })).min(1, 'Mindestens ein Termin erforderlich'),
+})
+
+export const wiederholungGeneratorSchema = z.object({
+  startDatum: z.string(),
+  endDatum: z.string(),
+  wochentage: z.array(z.number().int().min(0).max(6)).min(1, 'Mindestens ein Wochentag erforderlich'),
+  startzeit: z.string().optional(),
+  ausnahmen: z.array(z.string()).optional(),
+})
+```
+
+## 7. Data Flow
+
+### 7.1 Produktion erstellen
+
+```
+1. User → /produktionen/neu (ProduktionForm)
+2. Form Submit → createProduktion() Server Action
+3. Server Action:
+   a. getUserProfile() → Check permission 'stuecke:write'
+   b. Zod validate input
+   c. supabase.from('produktionen').insert()
+   d. revalidatePath('/produktionen')
+4. Redirect → /produktionen/[id]
+```
+
+### 7.2 Aufführungen generieren (Wiederholung)
+
+```
+1. User → /produktionen/[id]/serien/[serieId]/generieren
+2. User wählt:
+   - Zeitraum (Start/Ende)
+   - Wochentage (z.B. Fr, Sa, So)
+   - Standard-Startzeit
+   - Ausnahmen (bestimmte Termine)
+3. Preview: Zeigt generierte Termine an
+4. Bestätigen → generiereAuffuehrungenWiederholung()
+5. Server Action:
+   a. Berechnet alle Termine im Zeitraum
+   b. Filtert nach Wochentagen
+   c. Entfernt Ausnahmen
+   d. Bulk-Insert in serienaufführungen
+   e. revalidatePath()
+```
+
+## 8. Permissions
+
+Neue Permission hinzufügen in `lib/supabase/types.ts`:
+
+```typescript
+export type Permission =
+  // ... existing permissions
+  | 'produktionen:read'
+  | 'produktionen:write'
+  | 'produktionen:delete'
+```
+
+Permission Matrix in `lib/supabase/permissions.ts`:
+
+| Role | produktionen:read | produktionen:write | produktionen:delete |
+|------|-------------------|--------------------|--------------------|
+| ADMIN | ✅ | ✅ | ✅ |
+| VORSTAND | ✅ | ✅ | ❌ |
+| MITGLIED_AKTIV | ✅ | ❌ | ❌ |
+| Others | ❌ | ❌ | ❌ |
+
+## 9. UI Components
+
+### 9.1 ProduktionStatusBadge
+
+```typescript
+// Status-Farben passend zum Theater-Theme
+const STATUS_COLORS: Record<ProduktionStatus, string> = {
+  draft: 'bg-gray-100 text-gray-700',
+  planung: 'bg-info-100 text-info-700',
+  casting: 'bg-warning-100 text-warning-700',
+  proben: 'bg-stage-100 text-stage-700',
+  premiere: 'bg-curtain-100 text-curtain-700',
+  laufend: 'bg-success-100 text-success-700',
+  abgeschlossen: 'bg-gray-100 text-gray-500',
+  abgesagt: 'bg-error-100 text-error-700',
+}
+```
+
+### 9.2 Status-Workflow Validierung
+
+Erlaubte Status-Übergänge:
+
+```typescript
+const ALLOWED_TRANSITIONS: Record<ProduktionStatus, ProduktionStatus[]> = {
+  draft: ['planung', 'abgesagt'],
+  planung: ['casting', 'proben', 'abgesagt'],
+  casting: ['proben', 'planung', 'abgesagt'],
+  proben: ['premiere', 'casting', 'abgesagt'],
+  premiere: ['laufend', 'abgesagt'],
+  laufend: ['abgeschlossen', 'abgesagt'],
+  abgeschlossen: [],  // Endstatus
+  abgesagt: [],       // Endstatus
+}
+```
+
+## 10. Security Considerations
+
+- [x] RLS für alle neuen Tabellen (produktionen, auffuehrungsserien, serienaufführungen, produktions_stab)
+- [x] Permission Check in allen Server Actions
+- [x] Zod Validation für alle Inputs
+- [x] Audit-Logging für Status-Änderungen
+- [ ] Input Sanitization für Freitext-Felder (beschreibung, notizen)
+- [ ] Rate Limiting für Bulk-Generierung (max. 100 Aufführungen pro Request)
+
+## 11. Migration
+
+Vollständiges Migrations-File: `supabase/migrations/20260203000000_produktionen.sql`
+
+**Peter's Aufgaben:**
+1. Migration erstellen und testen
+2. Types in `lib/supabase/types.ts` hinzufügen
+3. Permissions in `lib/supabase/permissions.ts` erweitern
+4. Server Actions implementieren (`lib/actions/produktionen.ts`)
+5. Validations erstellen (`lib/validations/produktionen.ts`)
+6. Route `/produktionen` mit Übersicht
+7. Route `/produktionen/neu` mit Formular
+8. Route `/produktionen/[id]` mit Detail-Ansicht
+
+**Scope für Issue #156 (MVP):**
+- ✅ Produktion CRUD
+- ✅ Status-Workflow
+- ✅ Verknüpfung mit Stück
+- ✅ Produktionsleitung zuweisen
+- ⏳ Serien (Teil von #156, aber kann Folge-Issue werden)
+- ⏳ Aufführungen generieren (Teil von #156, aber kann Folge-Issue werden)
+
+---
+
+**Erstellt:** 2026-02-02
+**Status:** Ready for Implementation

--- a/supabase/migrations/20260203000000_produktionen.sql
+++ b/supabase/migrations/20260203000000_produktionen.sql
@@ -1,0 +1,295 @@
+-- Migration: Produktionen (Issue #156)
+-- Produktions-Entität als übergeordnetes Objekt für Theaterprojekte
+
+-- =============================================================================
+-- ENUM Types
+-- =============================================================================
+
+CREATE TYPE produktion_status AS ENUM (
+  'draft',
+  'planung',
+  'casting',
+  'proben',
+  'premiere',
+  'laufend',
+  'abgeschlossen',
+  'abgesagt'
+);
+
+CREATE TYPE serie_status AS ENUM (
+  'draft',
+  'planung',
+  'publiziert',
+  'abgeschlossen'
+);
+
+-- =============================================================================
+-- Tables
+-- =============================================================================
+
+-- Produktionen (Haupttabelle)
+CREATE TABLE produktionen (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  titel TEXT NOT NULL,
+  beschreibung TEXT,
+  stueck_id UUID REFERENCES stuecke(id) ON DELETE SET NULL,
+  status produktion_status NOT NULL DEFAULT 'draft',
+  saison TEXT NOT NULL,
+  proben_start DATE,
+  premiere DATE,
+  derniere DATE,
+  produktionsleitung_id UUID REFERENCES personen(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Aufführungsserien (gruppiert Einzelaufführungen)
+CREATE TABLE auffuehrungsserien (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  produktion_id UUID NOT NULL REFERENCES produktionen(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  beschreibung TEXT,
+  status serie_status NOT NULL DEFAULT 'draft',
+  standard_ort TEXT,
+  standard_startzeit TIME,
+  standard_einlass_minuten INTEGER DEFAULT 30,
+  template_id UUID REFERENCES auffuehrung_templates(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Serienaufführungen (Einzeltermine einer Serie)
+CREATE TABLE serienauffuehrungen (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  serie_id UUID NOT NULL REFERENCES auffuehrungsserien(id) ON DELETE CASCADE,
+  veranstaltung_id UUID REFERENCES veranstaltungen(id) ON DELETE SET NULL,
+  datum DATE NOT NULL,
+  startzeit TIME,
+  ort TEXT,
+  typ TEXT NOT NULL DEFAULT 'regulaer',
+  ist_ausnahme BOOLEAN NOT NULL DEFAULT false,
+  notizen TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(serie_id, datum, startzeit)
+);
+
+-- Produktions-Stab (Team-Zuweisung)
+CREATE TABLE produktions_stab (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  produktion_id UUID NOT NULL REFERENCES produktionen(id) ON DELETE CASCADE,
+  person_id UUID NOT NULL REFERENCES personen(id) ON DELETE CASCADE,
+  funktion TEXT NOT NULL,
+  ist_leitung BOOLEAN NOT NULL DEFAULT false,
+  von DATE,
+  bis DATE,
+  notizen TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(produktion_id, person_id, funktion)
+);
+
+-- =============================================================================
+-- Indexes
+-- =============================================================================
+
+CREATE INDEX idx_produktionen_status ON produktionen(status);
+CREATE INDEX idx_produktionen_saison ON produktionen(saison);
+CREATE INDEX idx_produktionen_stueck ON produktionen(stueck_id);
+CREATE INDEX idx_produktionen_leitung ON produktionen(produktionsleitung_id);
+
+CREATE INDEX idx_serien_produktion ON auffuehrungsserien(produktion_id);
+CREATE INDEX idx_serien_status ON auffuehrungsserien(status);
+
+CREATE INDEX idx_serienauffuehrungen_serie ON serienauffuehrungen(serie_id);
+CREATE INDEX idx_serienauffuehrungen_datum ON serienauffuehrungen(datum);
+CREATE INDEX idx_serienauffuehrungen_veranstaltung ON serienauffuehrungen(veranstaltung_id);
+
+CREATE INDEX idx_produktions_stab_produktion ON produktions_stab(produktion_id);
+CREATE INDEX idx_produktions_stab_person ON produktions_stab(person_id);
+
+-- =============================================================================
+-- Updated_at Triggers
+-- =============================================================================
+
+CREATE TRIGGER set_produktionen_updated_at
+  BEFORE UPDATE ON produktionen
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER set_auffuehrungsserien_updated_at
+  BEFORE UPDATE ON auffuehrungsserien
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER set_serienauffuehrungen_updated_at
+  BEFORE UPDATE ON serienauffuehrungen
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+
+-- =============================================================================
+-- Audit Logging (Status-Änderungen)
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION log_produktion_status_change()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF OLD.status IS DISTINCT FROM NEW.status THEN
+    INSERT INTO audit_logs (
+      table_name,
+      record_id,
+      action,
+      old_data,
+      new_data,
+      user_id
+    ) VALUES (
+      'produktionen',
+      NEW.id,
+      'status_change',
+      jsonb_build_object('status', OLD.status),
+      jsonb_build_object('status', NEW.status),
+      auth.uid()
+    );
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE TRIGGER audit_produktion_status
+  AFTER UPDATE ON produktionen
+  FOR EACH ROW
+  EXECUTE FUNCTION log_produktion_status_change();
+
+CREATE OR REPLACE FUNCTION log_serie_status_change()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF OLD.status IS DISTINCT FROM NEW.status THEN
+    INSERT INTO audit_logs (
+      table_name,
+      record_id,
+      action,
+      old_data,
+      new_data,
+      user_id
+    ) VALUES (
+      'auffuehrungsserien',
+      NEW.id,
+      'status_change',
+      jsonb_build_object('status', OLD.status),
+      jsonb_build_object('status', NEW.status),
+      auth.uid()
+    );
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE TRIGGER audit_serie_status
+  AFTER UPDATE ON auffuehrungsserien
+  FOR EACH ROW
+  EXECUTE FUNCTION log_serie_status_change();
+
+-- =============================================================================
+-- Row Level Security
+-- =============================================================================
+
+ALTER TABLE produktionen ENABLE ROW LEVEL SECURITY;
+ALTER TABLE auffuehrungsserien ENABLE ROW LEVEL SECURITY;
+ALTER TABLE serienauffuehrungen ENABLE ROW LEVEL SECURITY;
+ALTER TABLE produktions_stab ENABLE ROW LEVEL SECURITY;
+
+-- Produktionen
+CREATE POLICY "Authenticated users can view produktionen"
+  ON produktionen FOR SELECT
+  TO authenticated
+  USING (true);
+
+CREATE POLICY "Management can insert produktionen"
+  ON produktionen FOR INSERT
+  TO authenticated
+  WITH CHECK (is_management());
+
+CREATE POLICY "Management can update produktionen"
+  ON produktionen FOR UPDATE
+  TO authenticated
+  USING (is_management())
+  WITH CHECK (is_management());
+
+CREATE POLICY "Admins can delete produktionen"
+  ON produktionen FOR DELETE
+  TO authenticated
+  USING (is_admin());
+
+-- Aufführungsserien
+CREATE POLICY "Authenticated users can view serien"
+  ON auffuehrungsserien FOR SELECT
+  TO authenticated
+  USING (true);
+
+CREATE POLICY "Management can insert serien"
+  ON auffuehrungsserien FOR INSERT
+  TO authenticated
+  WITH CHECK (is_management());
+
+CREATE POLICY "Management can update serien"
+  ON auffuehrungsserien FOR UPDATE
+  TO authenticated
+  USING (is_management())
+  WITH CHECK (is_management());
+
+CREATE POLICY "Admins can delete serien"
+  ON auffuehrungsserien FOR DELETE
+  TO authenticated
+  USING (is_admin());
+
+-- Serienaufführungen
+CREATE POLICY "Authenticated users can view serienauffuehrungen"
+  ON serienauffuehrungen FOR SELECT
+  TO authenticated
+  USING (true);
+
+CREATE POLICY "Management can insert serienauffuehrungen"
+  ON serienauffuehrungen FOR INSERT
+  TO authenticated
+  WITH CHECK (is_management());
+
+CREATE POLICY "Management can update serienauffuehrungen"
+  ON serienauffuehrungen FOR UPDATE
+  TO authenticated
+  USING (is_management())
+  WITH CHECK (is_management());
+
+CREATE POLICY "Management can delete serienauffuehrungen"
+  ON serienauffuehrungen FOR DELETE
+  TO authenticated
+  USING (is_management());
+
+-- Produktions-Stab
+CREATE POLICY "Authenticated users can view produktions_stab"
+  ON produktions_stab FOR SELECT
+  TO authenticated
+  USING (true);
+
+CREATE POLICY "Management can insert produktions_stab"
+  ON produktions_stab FOR INSERT
+  TO authenticated
+  WITH CHECK (is_management());
+
+CREATE POLICY "Management can update produktions_stab"
+  ON produktions_stab FOR UPDATE
+  TO authenticated
+  USING (is_management())
+  WITH CHECK (is_management());
+
+CREATE POLICY "Management can delete produktions_stab"
+  ON produktions_stab FOR DELETE
+  TO authenticated
+  USING (is_management());
+
+-- =============================================================================
+-- Comments
+-- =============================================================================
+
+COMMENT ON TABLE produktionen IS 'Theaterprojekte/Produktionen mit Status-Workflow';
+COMMENT ON TABLE auffuehrungsserien IS 'Aufführungsserien als Master-Planungsebene';
+COMMENT ON TABLE serienauffuehrungen IS 'Einzeltermine einer Aufführungsserie';
+COMMENT ON TABLE produktions_stab IS 'Team-Zuweisungen für Produktionen (Regie, Technik, etc.)';


### PR DESCRIPTION
…(#156)

Introduces the Produktion module as the top-level object for theater projects, connecting plays (Stücke) with concrete performance periods.

- Database: produktionen, auffuehrungsserien, serienauffuehrungen, produktions_stab tables with RLS, audit logging, status triggers
- Types: 12 new types with status labels and Database schema entries
- Permissions: produktionen:read/write/delete for ADMIN, VORSTAND, MITGLIED_AKTIV
- Server Actions: full CRUD, status workflow validation, series management, performance date generation (manual + recurring)
- UI: table with filter/search, create/edit form, detail page with sidebar, status workflow buttons, series overview
- Navigation: added Produktionen to sidebar with film icon

# Kontext
- Warum ist diese Änderung nötig?

# Änderungen
- 

# Tests
- [ ] Lokal getestet

# Checkliste
- [ ] Dokumentation aktualisiert
- [ ] Keine sensiblen Daten enthalten
