### PR TITLE
feat: implement M1 Datenmodell & Templates (#201, #202, #203)

### DIFF
--- a/apps/web/components/templates/TemplateDetailEditor.tsx
+++ b/apps/web/components/templates/TemplateDetailEditor.tsx
@@ -9,6 +9,10 @@ import {
   removeTemplateSchicht,
   addTemplateRessource,
   removeTemplateRessource,
+  addTemplateInfoBlock,
+  removeTemplateInfoBlock,
+  addTemplateSachleistung,
+  removeTemplateSachleistung,
 } from '@/lib/actions/templates'
 import type {
   TemplateMitDetails,
@@ -57,6 +61,21 @@ export function TemplateDetailEditor({
   const [ressourceId, setRessourceId] = useState('')
   const [ressourceMenge, setRessourceMenge] = useState('1')
   const [ressourceLoading, setRessourceLoading] = useState(false)
+
+  // Info-Block Form State
+  const [showInfoBlockForm, setShowInfoBlockForm] = useState(false)
+  const [ibTitel, setIbTitel] = useState('')
+  const [ibBeschreibung, setIbBeschreibung] = useState('')
+  const [ibOffset, setIbOffset] = useState('0')
+  const [ibDauer, setIbDauer] = useState('30')
+  const [ibLoading, setIbLoading] = useState(false)
+
+  // Sachleistung Form State
+  const [showSachleistungForm, setShowSachleistungForm] = useState(false)
+  const [slName, setSlName] = useState('')
+  const [slAnzahl, setSlAnzahl] = useState('1')
+  const [slBeschreibung, setSlBeschreibung] = useState('')
+  const [slLoading, setSlLoading] = useState(false)
 
   // Filter out already added ressourcen
   const addedRessourceIds = template.ressourcen.map((r) => r.ressource_id)
@@ -135,6 +154,57 @@ export function TemplateDetailEditor({
   async function handleRemoveRessource(id: string, name: string) {
     if (!confirm(`Ressource "${name}" entfernen?`)) return
     await removeTemplateRessource(id, template.id)
+    router.refresh()
+  }
+
+  // Info-Block handlers
+  async function handleAddInfoBlock(e: React.FormEvent) {
+    e.preventDefault()
+    setIbLoading(true)
+    await addTemplateInfoBlock({
+      template_id: template.id,
+      titel: ibTitel,
+      beschreibung: ibBeschreibung || null,
+      offset_minuten: parseInt(ibOffset, 10),
+      dauer_minuten: parseInt(ibDauer, 10),
+      sortierung: template.info_bloecke?.length || 0,
+    })
+    setIbTitel('')
+    setIbBeschreibung('')
+    setIbOffset('0')
+    setIbDauer('30')
+    setShowInfoBlockForm(false)
+    setIbLoading(false)
+    router.refresh()
+  }
+
+  async function handleRemoveInfoBlock(id: string, titel: string) {
+    if (!confirm(`Info-Block "${titel}" entfernen?`)) return
+    await removeTemplateInfoBlock(id, template.id)
+    router.refresh()
+  }
+
+  // Sachleistung handlers
+  async function handleAddSachleistung(e: React.FormEvent) {
+    e.preventDefault()
+    setSlLoading(true)
+    await addTemplateSachleistung({
+      template_id: template.id,
+      name: slName,
+      anzahl: parseInt(slAnzahl, 10),
+      beschreibung: slBeschreibung || null,
+    })
+    setSlName('')
+    setSlAnzahl('1')
+    setSlBeschreibung('')
+    setShowSachleistungForm(false)
+    setSlLoading(false)
+    router.refresh()
+  }
+
+  async function handleRemoveSachleistung(id: string, name: string) {
+    if (!confirm(`Sachleistung "${name}" entfernen?`)) return
+    await removeTemplateSachleistung(id, template.id)
     router.refresh()
   }
 
@@ -437,6 +507,219 @@ export function TemplateDetailEditor({
           {template.ressourcen.length === 0 && (
             <div className="p-8 text-center text-gray-500">
               Keine Ressourcen
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Info-Blöcke */}
+      <div className="rounded-lg bg-white shadow">
+        <div className="flex items-center justify-between border-b bg-amber-50 px-4 py-3">
+          <h3 className="font-medium text-gray-900">
+            Info-Blöcke ({template.info_bloecke?.length || 0})
+          </h3>
+          {!showInfoBlockForm && (
+            <button
+              onClick={() => setShowInfoBlockForm(true)}
+              className="text-sm text-amber-600 hover:text-amber-800"
+            >
+              + Hinzufügen
+            </button>
+          )}
+        </div>
+
+        {showInfoBlockForm && (
+          <form
+            onSubmit={handleAddInfoBlock}
+            className="space-y-3 border-b bg-amber-50 p-4"
+          >
+            <input
+              type="text"
+              placeholder="Titel (z.B. Helferessen, Briefing) *"
+              required
+              value={ibTitel}
+              onChange={(e) => setIbTitel(e.target.value)}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+            />
+            <textarea
+              placeholder="Beschreibung (optional)"
+              value={ibBeschreibung}
+              onChange={(e) => setIbBeschreibung(e.target.value)}
+              rows={2}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+            />
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="mb-1 block text-xs text-gray-500">
+                  Offset (Min)
+                </label>
+                <input
+                  type="number"
+                  value={ibOffset}
+                  onChange={(e) => setIbOffset(e.target.value)}
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-xs text-gray-500">
+                  Dauer (Min)
+                </label>
+                <input
+                  type="number"
+                  min="1"
+                  value={ibDauer}
+                  onChange={(e) => setIbDauer(e.target.value)}
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+                />
+              </div>
+            </div>
+            <div className="flex gap-2">
+              <button
+                type="submit"
+                disabled={ibLoading}
+                className="rounded-lg bg-amber-600 px-3 py-1.5 text-sm text-white"
+              >
+                Speichern
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowInfoBlockForm(false)}
+                className="px-3 py-1.5 text-sm text-gray-600"
+              >
+                Abbrechen
+              </button>
+            </div>
+          </form>
+        )}
+
+        <div className="divide-y divide-gray-200">
+          {template.info_bloecke?.map((ib) => (
+            <div key={ib.id} className="flex items-center justify-between p-4">
+              <div>
+                <span className="font-medium text-gray-900">{ib.titel}</span>
+                <div className="text-sm text-gray-500">
+                  Offset: {ib.offset_minuten} Min, Dauer: {ib.dauer_minuten} Min
+                </div>
+                {ib.beschreibung && (
+                  <div className="text-sm text-gray-400">{ib.beschreibung}</div>
+                )}
+              </div>
+              <button
+                onClick={() => handleRemoveInfoBlock(ib.id, ib.titel)}
+                className="text-sm text-red-600 hover:text-red-800"
+              >
+                Entfernen
+              </button>
+            </div>
+          ))}
+          {(!template.info_bloecke || template.info_bloecke.length === 0) && (
+            <div className="p-8 text-center text-gray-500">
+              Keine Info-Blöcke
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Sachleistungen */}
+      <div className="rounded-lg bg-white shadow">
+        <div className="flex items-center justify-between border-b bg-green-50 px-4 py-3">
+          <h3 className="font-medium text-gray-900">
+            Sachleistungen ({template.sachleistungen?.length || 0})
+          </h3>
+          {!showSachleistungForm && (
+            <button
+              onClick={() => setShowSachleistungForm(true)}
+              className="text-sm text-green-600 hover:text-green-800"
+            >
+              + Hinzufügen
+            </button>
+          )}
+        </div>
+
+        {showSachleistungForm && (
+          <form
+            onSubmit={handleAddSachleistung}
+            className="space-y-3 border-b bg-green-50 p-4"
+          >
+            <input
+              type="text"
+              placeholder="Name (z.B. Kuchen, Salat) *"
+              required
+              value={slName}
+              onChange={(e) => setSlName(e.target.value)}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+            />
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="mb-1 block text-xs text-gray-500">
+                  Anzahl
+                </label>
+                <input
+                  type="number"
+                  min="1"
+                  value={slAnzahl}
+                  onChange={(e) => setSlAnzahl(e.target.value)}
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-xs text-gray-500">
+                  Beschreibung
+                </label>
+                <input
+                  type="text"
+                  placeholder="Optional"
+                  value={slBeschreibung}
+                  onChange={(e) => setSlBeschreibung(e.target.value)}
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+                />
+              </div>
+            </div>
+            <div className="flex gap-2">
+              <button
+                type="submit"
+                disabled={slLoading}
+                className="rounded-lg bg-green-600 px-3 py-1.5 text-sm text-white"
+              >
+                Speichern
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowSachleistungForm(false)}
+                className="px-3 py-1.5 text-sm text-gray-600"
+              >
+                Abbrechen
+              </button>
+            </div>
+          </form>
+        )}
+
+        <div className="divide-y divide-gray-200">
+          {template.sachleistungen?.map((sl) => (
+            <div key={sl.id} className="flex items-center justify-between p-4">
+              <div>
+                <span className="font-medium text-gray-900">{sl.name}</span>
+                <span className="ml-2 text-sm text-gray-500">
+                  ({sl.anzahl}x)
+                </span>
+                {sl.beschreibung && (
+                  <span className="ml-2 text-sm text-gray-400">
+                    - {sl.beschreibung}
+                  </span>
+                )}
+              </div>
+              <button
+                onClick={() => handleRemoveSachleistung(sl.id, sl.name)}
+                className="text-sm text-red-600 hover:text-red-800"
+              >
+                Entfernen
+              </button>
+            </div>
+          ))}
+          {(!template.sachleistungen ||
+            template.sachleistungen.length === 0) && (
+            <div className="p-8 text-center text-gray-500">
+              Keine Sachleistungen
             </div>
           )}
         </div>

--- a/apps/web/lib/supabase/types.ts
+++ b/apps/web/lib/supabase/types.ts
@@ -710,6 +710,69 @@ export type TemplateRessource = {
 export type TemplateRessourceInsert = Omit<TemplateRessource, 'id'>
 export type TemplateRessourceUpdate = Partial<TemplateRessourceInsert>
 
+// =============================================================================
+// Template Info-Blöcke (Issue #203)
+// =============================================================================
+
+export type TemplateInfoBlock = {
+  id: string
+  template_id: string
+  titel: string
+  beschreibung: string | null
+  offset_minuten: number
+  dauer_minuten: number
+  sortierung: number
+  created_at: string
+}
+
+export type TemplateInfoBlockInsert = Omit<TemplateInfoBlock, 'id' | 'created_at'>
+export type TemplateInfoBlockUpdate = Partial<TemplateInfoBlockInsert>
+
+export type InfoBlock = {
+  id: string
+  veranstaltung_id: string
+  titel: string
+  beschreibung: string | null
+  startzeit: string
+  endzeit: string
+  sortierung: number
+  created_at: string
+}
+
+export type InfoBlockInsert = Omit<InfoBlock, 'id' | 'created_at'>
+export type InfoBlockUpdate = Partial<InfoBlockInsert>
+
+// =============================================================================
+// Template Sachleistungen (Issue #202)
+// =============================================================================
+
+export type TemplateSachleistung = {
+  id: string
+  template_id: string
+  name: string
+  anzahl: number
+  beschreibung: string | null
+  created_at: string
+}
+
+export type TemplateSachleistungInsert = Omit<
+  TemplateSachleistung,
+  'id' | 'created_at'
+>
+export type TemplateSachleistungUpdate = Partial<TemplateSachleistungInsert>
+
+export type Sachleistung = {
+  id: string
+  veranstaltung_id: string
+  name: string
+  anzahl: number
+  beschreibung: string | null
+  created_at: string
+}
+
+export type SachleistungInsert = Omit<Sachleistung, 'id' | 'created_at'>
+export type SachleistungUpdate = Partial<SachleistungInsert>
+
 // Extended type with all template details
 export type TemplateMitDetails = AuffuehrungTemplate & {
   zeitbloecke: TemplateZeitblock[]
@@ -717,6 +780,8 @@ export type TemplateMitDetails = AuffuehrungTemplate & {
   ressourcen: (TemplateRessource & {
     ressource: Pick<Ressource, 'id' | 'name'> | null
   })[]
+  info_bloecke: TemplateInfoBlock[]
+  sachleistungen: TemplateSachleistung[]
 }
 
 // =============================================================================
@@ -1177,6 +1242,9 @@ export type Auffuehrungsserie = {
   standard_startzeit: string | null
   standard_einlass_minuten: number | null
   template_id: string | null
+  stueck_id: string | null
+  datum_von: string | null
+  datum_bis: string | null
   created_at: string
   updated_at: string
 }
@@ -1581,6 +1649,26 @@ export type Database = {
         Row: TemplateRessource
         Insert: TemplateRessourceInsert
         Update: TemplateRessourceUpdate
+      }
+      template_info_bloecke: {
+        Row: TemplateInfoBlock
+        Insert: TemplateInfoBlockInsert
+        Update: TemplateInfoBlockUpdate
+      }
+      info_bloecke: {
+        Row: InfoBlock
+        Insert: InfoBlockInsert
+        Update: InfoBlockUpdate
+      }
+      template_sachleistungen: {
+        Row: TemplateSachleistung
+        Insert: TemplateSachleistungInsert
+        Update: TemplateSachleistungUpdate
+      }
+      sachleistungen: {
+        Row: Sachleistung
+        Insert: SachleistungInsert
+        Update: SachleistungUpdate
       }
       helfer_events: {
         Row: HelferEvent

--- a/apps/web/lib/validations/modul2.ts
+++ b/apps/web/lib/validations/modul2.ts
@@ -196,6 +196,38 @@ export const templateRessourceSchema = z.object({
 })
 
 // =============================================================================
+// Template Info-Block Validations (Issue #203)
+// =============================================================================
+
+export const templateInfoBlockSchema = z.object({
+  template_id: z.string().uuid('Ungültige Template-ID'),
+  titel: z.string().min(1, 'Titel ist erforderlich').max(100, 'Titel zu lang'),
+  beschreibung: z
+    .string()
+    .max(500, 'Beschreibung zu lang')
+    .nullable()
+    .optional(),
+  offset_minuten: z.number().int().default(0),
+  dauer_minuten: z.number().int().min(1, 'Dauer muss mindestens 1 Minute sein'),
+  sortierung: z.number().int().min(0).optional(),
+})
+
+// =============================================================================
+// Template Sachleistung Validations (Issue #202)
+// =============================================================================
+
+export const templateSachleistungSchema = z.object({
+  template_id: z.string().uuid('Ungültige Template-ID'),
+  name: z.string().min(1, 'Name ist erforderlich').max(100, 'Name zu lang'),
+  anzahl: z.number().int().min(1, 'Anzahl muss mindestens 1 sein').default(1),
+  beschreibung: z
+    .string()
+    .max(500, 'Beschreibung zu lang')
+    .nullable()
+    .optional(),
+})
+
+// =============================================================================
 // Helper function for validation
 // =============================================================================
 

--- a/supabase/migrations/20260205000000_auffuehrungsserien_erweitern.sql
+++ b/supabase/migrations/20260205000000_auffuehrungsserien_erweitern.sql
@@ -1,0 +1,47 @@
+-- Migration: Extend auffuehrungsserien (Issue #201)
+-- Adds stueck_id, datum_von, datum_bis fields for better series management
+-- Created: 2026-02-05
+
+-- =============================================================================
+-- Add new columns to auffuehrungsserien
+-- =============================================================================
+
+-- Add stueck_id for direct reference to the play (independent of produktion)
+ALTER TABLE auffuehrungsserien
+  ADD COLUMN IF NOT EXISTS stueck_id UUID REFERENCES stuecke(id) ON DELETE SET NULL;
+
+-- Add date range for the series
+ALTER TABLE auffuehrungsserien
+  ADD COLUMN IF NOT EXISTS datum_von DATE;
+
+ALTER TABLE auffuehrungsserien
+  ADD COLUMN IF NOT EXISTS datum_bis DATE;
+
+-- =============================================================================
+-- Indexes
+-- =============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_auffuehrungsserien_stueck
+  ON auffuehrungsserien(stueck_id);
+
+CREATE INDEX IF NOT EXISTS idx_auffuehrungsserien_datum_von
+  ON auffuehrungsserien(datum_von);
+
+CREATE INDEX IF NOT EXISTS idx_auffuehrungsserien_datum_bis
+  ON auffuehrungsserien(datum_bis);
+
+-- =============================================================================
+-- Validation constraint for date range
+-- =============================================================================
+
+ALTER TABLE auffuehrungsserien
+  ADD CONSTRAINT auffuehrungsserien_datum_range_check
+  CHECK (datum_bis IS NULL OR datum_von IS NULL OR datum_bis >= datum_von);
+
+-- =============================================================================
+-- Comments
+-- =============================================================================
+
+COMMENT ON COLUMN auffuehrungsserien.stueck_id IS 'Direkter Bezug zum Stück (optional, ergänzt den Bezug über produktion)';
+COMMENT ON COLUMN auffuehrungsserien.datum_von IS 'Startdatum der Aufführungsserie';
+COMMENT ON COLUMN auffuehrungsserien.datum_bis IS 'Enddatum der Aufführungsserie';

--- a/supabase/migrations/20260205000001_template_info_bloecke.sql
+++ b/supabase/migrations/20260205000001_template_info_bloecke.sql
@@ -1,0 +1,110 @@
+-- Migration: Template Info-Blöcke (Issue #203)
+-- Creates tables for info blocks (Helferessen, Briefing, Treffpunkt etc.)
+-- Both at template level (offset-based) and instance level (calculated times)
+-- Created: 2026-02-05
+
+-- =============================================================================
+-- TABLE: template_info_bloecke (Template-level info blocks, offset-based)
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS template_info_bloecke (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  template_id UUID NOT NULL REFERENCES auffuehrung_templates(id) ON DELETE CASCADE,
+  titel TEXT NOT NULL,
+  beschreibung TEXT,
+  offset_minuten INTEGER NOT NULL DEFAULT 0,
+  dauer_minuten INTEGER NOT NULL DEFAULT 30,
+  sortierung INTEGER DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Enable Row Level Security
+ALTER TABLE template_info_bloecke ENABLE ROW LEVEL SECURITY;
+
+-- Policy: All authenticated users can read template info blocks
+CREATE POLICY "template_info_bloecke_select"
+  ON template_info_bloecke FOR SELECT
+  TO authenticated
+  USING (true);
+
+-- Policy: Management can manage template info blocks
+CREATE POLICY "template_info_bloecke_insert"
+  ON template_info_bloecke FOR INSERT
+  TO authenticated
+  WITH CHECK (is_management());
+
+CREATE POLICY "template_info_bloecke_update"
+  ON template_info_bloecke FOR UPDATE
+  TO authenticated
+  USING (is_management());
+
+CREATE POLICY "template_info_bloecke_delete"
+  ON template_info_bloecke FOR DELETE
+  TO authenticated
+  USING (is_management());
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_template_info_bloecke_template
+  ON template_info_bloecke(template_id);
+
+CREATE INDEX IF NOT EXISTS idx_template_info_bloecke_sortierung
+  ON template_info_bloecke(sortierung);
+
+-- =============================================================================
+-- TABLE: info_bloecke (Instance-level info blocks with calculated times)
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS info_bloecke (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  veranstaltung_id UUID NOT NULL REFERENCES veranstaltungen(id) ON DELETE CASCADE,
+  titel TEXT NOT NULL,
+  beschreibung TEXT,
+  startzeit TIME NOT NULL,
+  endzeit TIME NOT NULL,
+  sortierung INTEGER DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Enable Row Level Security
+ALTER TABLE info_bloecke ENABLE ROW LEVEL SECURITY;
+
+-- Policy: All authenticated users can read info blocks
+CREATE POLICY "info_bloecke_select"
+  ON info_bloecke FOR SELECT
+  TO authenticated
+  USING (true);
+
+-- Policy: Management can manage info blocks
+CREATE POLICY "info_bloecke_insert"
+  ON info_bloecke FOR INSERT
+  TO authenticated
+  WITH CHECK (is_management());
+
+CREATE POLICY "info_bloecke_update"
+  ON info_bloecke FOR UPDATE
+  TO authenticated
+  USING (is_management());
+
+CREATE POLICY "info_bloecke_delete"
+  ON info_bloecke FOR DELETE
+  TO authenticated
+  USING (is_management());
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_info_bloecke_veranstaltung
+  ON info_bloecke(veranstaltung_id);
+
+CREATE INDEX IF NOT EXISTS idx_info_bloecke_sortierung
+  ON info_bloecke(sortierung);
+
+-- =============================================================================
+-- Comments
+-- =============================================================================
+
+COMMENT ON TABLE template_info_bloecke IS 'Info-Blöcke auf Template-Ebene (offset-basiert). Für Helferessen, Briefing, Treffpunkt etc.';
+COMMENT ON COLUMN template_info_bloecke.offset_minuten IS 'Offset in Minuten relativ zum Vorstellungsbeginn (negativ = vor, positiv = nach)';
+COMMENT ON COLUMN template_info_bloecke.dauer_minuten IS 'Dauer des Info-Blocks in Minuten';
+
+COMMENT ON TABLE info_bloecke IS 'Info-Blöcke für konkrete Veranstaltungen mit berechneten Zeiten';
+COMMENT ON COLUMN info_bloecke.startzeit IS 'Berechnete Startzeit des Info-Blocks';
+COMMENT ON COLUMN info_bloecke.endzeit IS 'Berechnete Endzeit des Info-Blocks';

--- a/supabase/migrations/20260205000002_template_sachleistungen.sql
+++ b/supabase/migrations/20260205000002_template_sachleistungen.sql
@@ -1,0 +1,160 @@
+-- Migration: Template Sachleistungen & Seed Data (Issue #202)
+-- Creates sachleistungen tables and seeds "Abendvorstellung" template
+-- Created: 2026-02-05
+
+-- =============================================================================
+-- TABLE: template_sachleistungen (Template-level in-kind contributions)
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS template_sachleistungen (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  template_id UUID NOT NULL REFERENCES auffuehrung_templates(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  anzahl INTEGER NOT NULL DEFAULT 1,
+  beschreibung TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Enable Row Level Security
+ALTER TABLE template_sachleistungen ENABLE ROW LEVEL SECURITY;
+
+-- Policy: All authenticated users can read template sachleistungen
+CREATE POLICY "template_sachleistungen_select"
+  ON template_sachleistungen FOR SELECT
+  TO authenticated
+  USING (true);
+
+-- Policy: Management can manage template sachleistungen
+CREATE POLICY "template_sachleistungen_insert"
+  ON template_sachleistungen FOR INSERT
+  TO authenticated
+  WITH CHECK (is_management());
+
+CREATE POLICY "template_sachleistungen_update"
+  ON template_sachleistungen FOR UPDATE
+  TO authenticated
+  USING (is_management());
+
+CREATE POLICY "template_sachleistungen_delete"
+  ON template_sachleistungen FOR DELETE
+  TO authenticated
+  USING (is_management());
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_template_sachleistungen_template
+  ON template_sachleistungen(template_id);
+
+-- =============================================================================
+-- TABLE: sachleistungen (Instance-level in-kind contributions)
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS sachleistungen (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  veranstaltung_id UUID NOT NULL REFERENCES veranstaltungen(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  anzahl INTEGER NOT NULL DEFAULT 1,
+  beschreibung TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Enable Row Level Security
+ALTER TABLE sachleistungen ENABLE ROW LEVEL SECURITY;
+
+-- Policy: All authenticated users can read sachleistungen
+CREATE POLICY "sachleistungen_select"
+  ON sachleistungen FOR SELECT
+  TO authenticated
+  USING (true);
+
+-- Policy: Management can manage sachleistungen
+CREATE POLICY "sachleistungen_insert"
+  ON sachleistungen FOR INSERT
+  TO authenticated
+  WITH CHECK (is_management());
+
+CREATE POLICY "sachleistungen_update"
+  ON sachleistungen FOR UPDATE
+  TO authenticated
+  USING (is_management());
+
+CREATE POLICY "sachleistungen_delete"
+  ON sachleistungen FOR DELETE
+  TO authenticated
+  USING (is_management());
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_sachleistungen_veranstaltung
+  ON sachleistungen(veranstaltung_id);
+
+-- =============================================================================
+-- Comments
+-- =============================================================================
+
+COMMENT ON TABLE template_sachleistungen IS 'Sachleistungen (z.B. Kuchen, Salate) auf Template-Ebene';
+COMMENT ON COLUMN template_sachleistungen.anzahl IS 'Benötigte Anzahl der Sachleistung';
+
+COMMENT ON TABLE sachleistungen IS 'Sachleistungen für konkrete Veranstaltungen';
+
+-- =============================================================================
+-- SEED DATA: "Abendvorstellung" Template
+-- =============================================================================
+
+-- Create the template
+INSERT INTO auffuehrung_templates (id, name, beschreibung)
+VALUES (
+  'a0000000-0000-0000-0000-000000000001',
+  'Abendvorstellung',
+  'Standard-Template für Abendvorstellungen mit allen Helfer-Schichten und Info-Blöcken'
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- Create Zeitblöcke (time blocks)
+-- Offset is relative to show start (19:00 = 0)
+-- Negative offset = before show start
+INSERT INTO template_zeitbloecke (template_id, name, offset_minuten, dauer_minuten, typ, sortierung)
+VALUES
+  -- Aufbau Saal: 15:00-16:45 (offset -240, duration 105)
+  ('a0000000-0000-0000-0000-000000000001', 'Aufbau Saal', -240, 105, 'aufbau', 1),
+  -- Parkplatz: 17:45-20:00 (offset -75, duration 135)
+  ('a0000000-0000-0000-0000-000000000001', 'Parkplatz', -75, 135, 'standard', 2),
+  -- Kasse: 18:00-20:00 (offset -60, duration 120)
+  ('a0000000-0000-0000-0000-000000000001', 'Kasse', -60, 120, 'einlass', 3),
+  -- Essensservice: 18:00-20:00 (offset -60, duration 120)
+  ('a0000000-0000-0000-0000-000000000001', 'Essensservice', -60, 120, 'standard', 4),
+  -- Allgemeiner Service: 18:00-23:00 (offset -60, duration 300)
+  ('a0000000-0000-0000-0000-000000000001', 'Allgemeiner Service', -60, 300, 'standard', 5),
+  -- Getränkebuffet: 18:00-23:00 (offset -60, duration 300)
+  ('a0000000-0000-0000-0000-000000000001', 'Getränkebuffet', -60, 300, 'standard', 6),
+  -- Kuchen/Kaffee-Buffet: 18:00-23:00 (offset -60, duration 300)
+  ('a0000000-0000-0000-0000-000000000001', 'Kuchen/Kaffee-Buffet', -60, 300, 'standard', 7),
+  -- Abwasch: 18:00-23:00 (offset -60, duration 300)
+  ('a0000000-0000-0000-0000-000000000001', 'Abwasch', -60, 300, 'standard', 8),
+  -- Bar: 18:00-23:00 (offset -60, duration 300)
+  ('a0000000-0000-0000-0000-000000000001', 'Bar', -60, 300, 'standard', 9),
+  -- Springer: 18:00-20:00 (offset -60, duration 120)
+  ('a0000000-0000-0000-0000-000000000001', 'Springer', -60, 120, 'standard', 10)
+ON CONFLICT DO NOTHING;
+
+-- Create Schichten (shifts) with required personnel counts
+INSERT INTO template_schichten (template_id, zeitblock_name, rolle, anzahl_benoetigt)
+VALUES
+  ('a0000000-0000-0000-0000-000000000001', 'Aufbau Saal', 'Aufbau Saal', 4),
+  ('a0000000-0000-0000-0000-000000000001', 'Parkplatz', 'Parkplatz', 1),
+  ('a0000000-0000-0000-0000-000000000001', 'Kasse', 'Kasse', 2),
+  ('a0000000-0000-0000-0000-000000000001', 'Essensservice', 'Essensservice', 3),
+  ('a0000000-0000-0000-0000-000000000001', 'Allgemeiner Service', 'Allgemeiner Service', 4),
+  ('a0000000-0000-0000-0000-000000000001', 'Getränkebuffet', 'Getränkebuffet', 2),
+  ('a0000000-0000-0000-0000-000000000001', 'Kuchen/Kaffee-Buffet', 'Kuchen/Kaffee-Buffet', 2),
+  ('a0000000-0000-0000-0000-000000000001', 'Abwasch', 'Abwasch', 3),
+  ('a0000000-0000-0000-0000-000000000001', 'Bar', 'Bar', 2),
+  ('a0000000-0000-0000-0000-000000000001', 'Springer', 'Springer', 1)
+ON CONFLICT DO NOTHING;
+
+-- Create Info-Blöcke (info blocks)
+INSERT INTO template_info_bloecke (template_id, titel, beschreibung, offset_minuten, dauer_minuten, sortierung)
+VALUES
+  -- Helferessen (Spaghetti): 16:45-17:30 (offset -135, duration 45)
+  ('a0000000-0000-0000-0000-000000000001', 'Helferessen (Spaghetti)', 'Gemeinsames Essen für alle Helfer vor der Vorstellung', -135, 45, 1),
+  -- Pflichtbriefing: 17:30-17:45 (offset -90, duration 15)
+  ('a0000000-0000-0000-0000-000000000001', 'Pflichtbriefing', 'Kurzes Briefing für alle Helfer - Anwesenheitspflicht!', -90, 15, 2)
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
- Extend auffuehrungsserien with stueck_id, datum_von, datum_bis
- Add template_info_bloecke and info_bloecke tables for info blocks
- Add template_sachleistungen and sachleistungen tables
- Seed "Abendvorstellung" template with 10 shifts and 2 info blocks
- Add TypeScript types and Zod validation schemas
- Extend TemplateDetailEditor UI with Info-Blöcke and Sachleistungen sections
- Update applyTemplate() to transfer info blocks and sachleistungen

# Kontext
- Warum ist diese Änderung nötig?

# Änderungen
- 

# Tests
- [ ] Lokal getestet

# Checkliste
- [ ] Dokumentation aktualisiert
- [ ] Keine sensiblen Daten enthalten
