### PR TITLE
feat: M1 Datenmodell & Templates

### DIFF
--- a/apps/web/app/(protected)/admin/schicht-templates/[id]/page.tsx
+++ b/apps/web/app/(protected)/admin/schicht-templates/[id]/page.tsx
@@ -1,0 +1,105 @@
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { getTemplate } from '@/lib/actions/templates'
+import { TemplateForm } from '@/components/admin/templates/TemplateForm'
+import { ZeitbloeckeEditor } from '@/components/admin/templates/ZeitbloeckeEditor'
+import { SchichtenEditor } from '@/components/admin/templates/SchichtenEditor'
+import { InfoBloeckeEditor } from '@/components/admin/templates/InfoBloeckeEditor'
+import { SachleistungenEditor } from '@/components/admin/templates/SachleistungenEditor'
+import { TemplatePreview } from '@/components/admin/templates/TemplatePreview'
+
+interface PageProps {
+  params: Promise<{ id: string }>
+}
+
+export async function generateMetadata({ params }: PageProps) {
+  const { id } = await params
+  const template = await getTemplate(id)
+  return {
+    title: template ? `${template.name} - Template` : 'Template nicht gefunden',
+    description: template?.beschreibung ?? 'Template-Details',
+  }
+}
+
+export default async function TemplateDetailPage({ params }: PageProps) {
+  const { id } = await params
+  const template = await getTemplate(id)
+
+  if (!template) {
+    notFound()
+  }
+
+  // Calculate preview stats
+  const totalSchichten = template.schichten.length
+  const totalSlots = template.schichten.reduce((sum, s) => sum + s.anzahl_benoetigt, 0)
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <Link
+              href={'/admin/schicht-templates' as never}
+              className="text-sm text-neutral-500 hover:text-neutral-700"
+            >
+              Schicht-Templates
+            </Link>
+            <span className="text-neutral-400">/</span>
+            <span className="text-sm font-medium text-neutral-900">{template.name}</span>
+          </div>
+          <h1 className="mt-2 text-2xl font-semibold text-neutral-900">
+            {template.name}
+          </h1>
+          {template.beschreibung && (
+            <p className="mt-1 text-neutral-600">{template.beschreibung}</p>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          {template.archiviert && (
+            <span className="inline-flex rounded-full bg-neutral-200 px-3 py-1 text-sm font-medium text-neutral-800">
+              Archiviert
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Preview Card */}
+      <TemplatePreview
+        zeitbloeckeCount={template.zeitbloecke.length}
+        schichtenCount={totalSchichten}
+        slotsCount={totalSlots}
+        infoBloeckeCount={template.info_bloecke.length}
+        sachleistungenCount={template.sachleistungen.length}
+      />
+
+      {/* Edit Grunddaten */}
+      <TemplateForm template={template} />
+
+      {/* Zeitbloecke */}
+      <ZeitbloeckeEditor
+        templateId={template.id}
+        zeitbloecke={template.zeitbloecke}
+      />
+
+      {/* Schichten */}
+      <SchichtenEditor
+        templateId={template.id}
+        schichten={template.schichten}
+        zeitbloecke={template.zeitbloecke}
+      />
+
+      {/* Info-Bloecke */}
+      <InfoBloeckeEditor
+        templateId={template.id}
+        infoBloecke={template.info_bloecke}
+      />
+
+      {/* Sachleistungen */}
+      <SachleistungenEditor
+        templateId={template.id}
+        sachleistungen={template.sachleistungen}
+      />
+    </div>
+  )
+}

--- a/apps/web/app/(protected)/admin/schicht-templates/neu/page.tsx
+++ b/apps/web/app/(protected)/admin/schicht-templates/neu/page.tsx
@@ -1,0 +1,23 @@
+import { TemplateForm } from '@/components/admin/templates/TemplateForm'
+
+export const metadata = {
+  title: 'Neues Schicht-Template',
+  description: 'Erstellen Sie ein neues Schicht-Template',
+}
+
+export default function NeuTemplateSeite() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold text-neutral-900">
+          Neues Schicht-Template
+        </h1>
+        <p className="mt-1 text-neutral-600">
+          Erstellen Sie eine neue Vorlage fuer Helfer-Schichten
+        </p>
+      </div>
+
+      <TemplateForm />
+    </div>
+  )
+}

--- a/apps/web/app/(protected)/admin/schicht-templates/page.tsx
+++ b/apps/web/app/(protected)/admin/schicht-templates/page.tsx
@@ -1,0 +1,56 @@
+import Link from 'next/link'
+import { getAllTemplates, getTemplate } from '@/lib/actions/templates'
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, Button } from '@/components/ui'
+import { TemplateList } from '@/components/admin/templates/TemplateList'
+
+export const metadata = {
+  title: 'Schicht-Templates',
+  description: 'Verwaltung von Schicht-Templates fuer Auffuehrungen',
+}
+
+export default async function SchichtTemplatesPage() {
+  const templates = await getAllTemplates()
+
+  // Fetch details for each template to get counts
+  const templatesWithDetails = await Promise.all(
+    templates.map(async (template) => {
+      const details = await getTemplate(template.id)
+      return {
+        ...template,
+        zeitbloeckeCount: details?.zeitbloecke?.length ?? 0,
+        schichtenCount: details?.schichten?.length ?? 0,
+        totalSlots: details?.schichten?.reduce((sum, s) => sum + s.anzahl_benoetigt, 0) ?? 0,
+      }
+    })
+  )
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-neutral-900">
+            Schicht-Templates
+          </h1>
+          <p className="mt-1 text-neutral-600">
+            Vorlagen fuer Helfer-Schichten bei Auffuehrungen
+          </p>
+        </div>
+        <Link href={'/admin/schicht-templates/neu' as never}>
+          <Button>Neues Template</Button>
+        </Link>
+      </div>
+
+      <Card padding="none">
+        <CardHeader className="px-6 pt-6">
+          <CardTitle>Alle Templates</CardTitle>
+          <CardDescription>
+            {templates.length} Template{templates.length !== 1 ? 's' : ''} vorhanden
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <TemplateList templates={templatesWithDetails} />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/apps/web/app/(protected)/auffuehrungen/[id]/schichten/page.tsx
+++ b/apps/web/app/(protected)/auffuehrungen/[id]/schichten/page.tsx
@@ -1,0 +1,196 @@
+import Link from 'next/link'
+import { redirect, notFound } from 'next/navigation'
+import { getUserProfile } from '@/lib/supabase/server'
+import { hasPermission } from '@/lib/supabase/auth-helpers'
+import { getVeranstaltung } from '@/lib/actions/veranstaltungen'
+import { getTemplates } from '@/lib/actions/templates'
+import { getSchichtenStatus } from '@/lib/actions/schicht-generator'
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui'
+import { TemplateSelector } from '@/components/auffuehrungen/TemplateSelector'
+import { SchichtenStatusBanner } from '@/components/auffuehrungen/SchichtenStatusBanner'
+
+interface PageProps {
+  params: Promise<{ id: string }>
+}
+
+export async function generateMetadata({ params }: PageProps) {
+  const { id } = await params
+  const veranstaltung = await getVeranstaltung(id)
+  return {
+    title: veranstaltung ? `Schichten - ${veranstaltung.titel}` : 'Schichten',
+    description: 'Schichten aus Template generieren',
+  }
+}
+
+export default async function SchichtenPage({ params }: PageProps) {
+  const profile = await getUserProfile()
+
+  if (!profile) {
+    redirect('/login')
+  }
+
+  // Check permission
+  if (!hasPermission(profile.role, 'veranstaltungen:write')) {
+    redirect('/dashboard')
+  }
+
+  const { id } = await params
+  const veranstaltung = await getVeranstaltung(id)
+
+  if (!veranstaltung || veranstaltung.typ !== 'auffuehrung') {
+    notFound()
+  }
+
+  // Fetch templates and current status in parallel
+  const [templates, schichtenStatus] = await Promise.all([
+    getTemplates(),
+    getSchichtenStatus(id),
+  ])
+
+  const isAdmin = profile.role === 'ADMIN'
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleDateString('de-CH', {
+      weekday: 'long',
+      day: '2-digit',
+      month: 'long',
+      year: 'numeric',
+    })
+  }
+
+  const formatTime = (timeStr: string | null) => {
+    if (!timeStr) return '-'
+    return timeStr.slice(0, 5)
+  }
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <div className="mx-auto max-w-4xl px-4 py-8">
+        {/* Breadcrumb */}
+        <div className="mb-6">
+          <nav className="flex items-center gap-2 text-sm text-neutral-500">
+            <Link href="/auffuehrungen" className="hover:text-neutral-700">
+              Auffuehrungen
+            </Link>
+            <span>/</span>
+            <Link href={`/auffuehrungen/${id}` as never} className="hover:text-neutral-700">
+              {veranstaltung.titel}
+            </Link>
+            <span>/</span>
+            <span className="text-neutral-900">Schichten</span>
+          </nav>
+        </div>
+
+        {/* Header */}
+        <div className="mb-8">
+          <h1 className="text-2xl font-bold text-gray-900">
+            Schichten konfigurieren
+          </h1>
+          <p className="mt-1 text-gray-600">
+            {formatDate(veranstaltung.datum)}
+            {veranstaltung.startzeit && (
+              <span className="ml-2">
+                um {formatTime(veranstaltung.startzeit)} Uhr
+              </span>
+            )}
+            {veranstaltung.ort && (
+              <span className="ml-2">- {veranstaltung.ort}</span>
+            )}
+          </p>
+        </div>
+
+        {/* Status Banner */}
+        <SchichtenStatusBanner
+          status={schichtenStatus}
+          veranstaltungId={id}
+          isAdmin={isAdmin}
+        />
+
+        {/* Template Selection */}
+        {!schichtenStatus.hasSchichten ? (
+          <Card className="mt-6">
+            <CardHeader>
+              <CardTitle>Template auswaehlen</CardTitle>
+              <CardDescription>
+                Waehlen Sie ein Template, um automatisch Zeitbloecke und Schichten zu erstellen.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {!veranstaltung.startzeit ? (
+                <div className="rounded-lg bg-warning-50 p-4 text-warning-800">
+                  <p className="font-medium">Keine Startzeit gesetzt</p>
+                  <p className="mt-1 text-sm">
+                    Bitte setzen Sie zuerst eine Startzeit fuer die Veranstaltung, damit die
+                    Schicht-Zeiten korrekt berechnet werden koennen.
+                  </p>
+                  <Link
+                    href={`/veranstaltungen/${id}/bearbeiten` as never}
+                    className="mt-3 inline-block text-sm font-medium text-warning-700 underline hover:text-warning-900"
+                  >
+                    Veranstaltung bearbeiten
+                  </Link>
+                </div>
+              ) : templates.length === 0 ? (
+                <div className="rounded-lg bg-neutral-100 p-4 text-neutral-700">
+                  <p className="font-medium">Keine Templates verfuegbar</p>
+                  <p className="mt-1 text-sm">
+                    Es sind noch keine Schicht-Templates definiert.
+                  </p>
+                  {isAdmin && (
+                    <Link
+                      href={'/admin/schicht-templates/neu' as never}
+                      className="mt-3 inline-block text-sm font-medium text-neutral-900 underline hover:text-neutral-700"
+                    >
+                      Erstes Template erstellen
+                    </Link>
+                  )}
+                </div>
+              ) : (
+                <TemplateSelector
+                  veranstaltungId={id}
+                  templates={templates}
+                  startzeit={veranstaltung.startzeit}
+                />
+              )}
+            </CardContent>
+          </Card>
+        ) : (
+          <Card className="mt-6">
+            <CardHeader>
+              <CardTitle>Schichten verwalten</CardTitle>
+              <CardDescription>
+                Die Schichten wurden bereits generiert. Sie koennen diese jetzt koordinieren.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="flex gap-4">
+                <Link
+                  href={`/auffuehrungen/${id}` as never}
+                  className="rounded-lg bg-black px-4 py-2 text-sm font-medium text-white hover:bg-neutral-800"
+                >
+                  Zur Helfer-Koordination
+                </Link>
+                <Link
+                  href={`/auffuehrungen/${id}` as never}
+                  className="rounded-lg border border-neutral-300 px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+                >
+                  Auffuehrung anzeigen
+                </Link>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Back Link */}
+        <div className="mt-8">
+          <Link
+            href={`/auffuehrungen/${id}` as never}
+            className="text-blue-600 hover:text-blue-800"
+          >
+            &larr; Zurueck zur Auffuehrung
+          </Link>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/apps/web/components/admin/AdminSidebar.tsx
+++ b/apps/web/components/admin/AdminSidebar.tsx
@@ -58,6 +58,24 @@ function AuditIcon() {
   )
 }
 
+function TemplateIcon() {
+  return (
+    <svg
+      className="h-5 w-5"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z"
+      />
+    </svg>
+  )
+}
+
 function NavLinkContent({
   icon,
   label,
@@ -110,6 +128,13 @@ export function AdminSidebar() {
               icon={<AuditIcon />}
               label="Audit Log"
               isActive={pathname === '/admin/audit'}
+            />
+          </Link>
+          <Link href={'/admin/schicht-templates' as never}>
+            <NavLinkContent
+              icon={<TemplateIcon />}
+              label="Schicht-Templates"
+              isActive={pathname?.startsWith('/admin/schicht-templates') ?? false}
             />
           </Link>
         </nav>

--- a/apps/web/components/admin/templates/InfoBloeckeEditor.tsx
+++ b/apps/web/components/admin/templates/InfoBloeckeEditor.tsx
@@ -1,0 +1,272 @@
+'use client'
+
+import { useState } from 'react'
+import { addTemplateInfoBlock, removeTemplateInfoBlock } from '@/lib/actions/templates'
+import type { TemplateInfoBlock } from '@/lib/supabase/types'
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, Button, Input, ConfirmDialog } from '@/components/ui'
+
+interface InfoBloeckeEditorProps {
+  templateId: string
+  infoBloecke: TemplateInfoBlock[]
+}
+
+function formatOffset(minutes: number): string {
+  const hours = Math.floor(Math.abs(minutes) / 60)
+  const mins = Math.abs(minutes) % 60
+  const sign = minutes < 0 ? '-' : '+'
+  if (hours === 0) return `${sign}${mins}min`
+  if (mins === 0) return `${sign}${hours}h`
+  return `${sign}${hours}h ${mins}min`
+}
+
+export function InfoBloeckeEditor({ templateId, infoBloecke }: InfoBloeckeEditorProps) {
+  const [isAdding, setIsAdding] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const [formData, setFormData] = useState({
+    titel: '',
+    beschreibung: '',
+    offset_minuten: -60,
+    dauer_minuten: 30,
+    sortierung: infoBloecke.length,
+  })
+
+  const resetForm = () => {
+    setFormData({
+      titel: '',
+      beschreibung: '',
+      offset_minuten: -60,
+      dauer_minuten: 30,
+      sortierung: infoBloecke.length,
+    })
+    setError(null)
+  }
+
+  const handleAdd = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setIsSubmitting(true)
+    setError(null)
+
+    try {
+      const result = await addTemplateInfoBlock({
+        template_id: templateId,
+        titel: formData.titel.trim(),
+        beschreibung: formData.beschreibung.trim() || null,
+        offset_minuten: formData.offset_minuten,
+        dauer_minuten: formData.dauer_minuten,
+        sortierung: formData.sortierung,
+      })
+
+      if (!result.success) {
+        setError(result.error ?? 'Fehler beim Hinzufuegen')
+        return
+      }
+
+      resetForm()
+      setIsAdding(false)
+    } catch (err) {
+      console.error('Error adding info block:', err)
+      setError('Ein unerwarteter Fehler ist aufgetreten')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!deletingId) return
+
+    setIsDeleting(true)
+    try {
+      const result = await removeTemplateInfoBlock(deletingId, templateId)
+      if (!result.success) {
+        console.error('Failed to delete info block:', result.error)
+      }
+    } catch (err) {
+      console.error('Error deleting info block:', err)
+    } finally {
+      setIsDeleting(false)
+      setDeletingId(null)
+    }
+  }
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle>Info-Bloecke</CardTitle>
+              <CardDescription>
+                Helferessen, Briefing, Treffpunkte und andere Informationen
+              </CardDescription>
+            </div>
+            {!isAdding && (
+              <Button variant="secondary" size="sm" onClick={() => setIsAdding(true)}>
+                Info-Block hinzufuegen
+              </Button>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          {/* Add Form */}
+          {isAdding && (
+            <form onSubmit={handleAdd} className="mb-6 rounded-lg border border-neutral-200 bg-neutral-50 p-4">
+              <h4 className="mb-4 font-medium text-neutral-900">Neuer Info-Block</h4>
+
+              {error && (
+                <div className="mb-4 rounded-lg bg-error-50 p-3 text-sm text-error-700">
+                  {error}
+                </div>
+              )}
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <Input
+                  label="Titel"
+                  name="titel"
+                  value={formData.titel}
+                  onChange={(e) => setFormData((prev) => ({ ...prev, titel: e.target.value }))}
+                  placeholder="z.B. Helferessen, Pflichtbriefing"
+                  required
+                />
+
+                <div className="w-full">
+                  <label
+                    htmlFor="beschreibung"
+                    className="mb-1 block text-sm font-medium text-neutral-700"
+                  >
+                    Beschreibung
+                  </label>
+                  <input
+                    id="beschreibung"
+                    name="beschreibung"
+                    value={formData.beschreibung}
+                    onChange={(e) => setFormData((prev) => ({ ...prev, beschreibung: e.target.value }))}
+                    className="block w-full rounded-md border border-neutral-300 px-3 py-2 text-neutral-900 placeholder-neutral-400 focus:border-black focus:outline-none focus:ring-2 focus:ring-black"
+                    placeholder="Optionale Beschreibung..."
+                  />
+                </div>
+
+                <Input
+                  label="Offset (Minuten)"
+                  name="offset_minuten"
+                  type="number"
+                  value={formData.offset_minuten}
+                  onChange={(e) => setFormData((prev) => ({ ...prev, offset_minuten: parseInt(e.target.value) || 0 }))}
+                  helperText="Negativ = vor Beginn"
+                />
+
+                <Input
+                  label="Dauer (Minuten)"
+                  name="dauer_minuten"
+                  type="number"
+                  min={1}
+                  value={formData.dauer_minuten}
+                  onChange={(e) => setFormData((prev) => ({ ...prev, dauer_minuten: parseInt(e.target.value) || 30 }))}
+                  required
+                />
+              </div>
+
+              <div className="mt-4 flex justify-end gap-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    resetForm()
+                    setIsAdding(false)
+                  }}
+                  disabled={isSubmitting}
+                >
+                  Abbrechen
+                </Button>
+                <Button type="submit" size="sm" loading={isSubmitting}>
+                  Hinzufuegen
+                </Button>
+              </div>
+            </form>
+          )}
+
+          {/* List */}
+          {infoBloecke.length === 0 ? (
+            <div className="py-8 text-center text-neutral-500">
+              Noch keine Info-Bloecke definiert.
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b border-neutral-200">
+                    <th className="pb-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500">
+                      Nr.
+                    </th>
+                    <th className="pb-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500">
+                      Titel
+                    </th>
+                    <th className="pb-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500">
+                      Beschreibung
+                    </th>
+                    <th className="pb-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500">
+                      Offset
+                    </th>
+                    <th className="pb-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500">
+                      Dauer
+                    </th>
+                    <th className="pb-3 text-right text-xs font-medium uppercase tracking-wider text-neutral-500">
+                      Aktionen
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-neutral-100">
+                  {infoBloecke
+                    .sort((a, b) => a.sortierung - b.sortierung)
+                    .map((ib, index) => (
+                      <tr key={ib.id} className="hover:bg-neutral-50">
+                        <td className="py-3 text-sm text-neutral-600">
+                          {index + 1}
+                        </td>
+                        <td className="py-3 font-medium text-neutral-900">
+                          {ib.titel}
+                        </td>
+                        <td className="max-w-xs truncate py-3 text-sm text-neutral-600">
+                          {ib.beschreibung ?? '-'}
+                        </td>
+                        <td className="py-3 text-sm text-neutral-600">
+                          {formatOffset(ib.offset_minuten)}
+                        </td>
+                        <td className="py-3 text-sm text-neutral-600">
+                          {ib.dauer_minuten} min
+                        </td>
+                        <td className="py-3 text-right">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="text-error-600 hover:text-error-700"
+                            onClick={() => setDeletingId(ib.id)}
+                          >
+                            Entfernen
+                          </Button>
+                        </td>
+                      </tr>
+                    ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <ConfirmDialog
+        open={!!deletingId}
+        onCancel={() => setDeletingId(null)}
+        onConfirm={handleDelete}
+        title="Info-Block entfernen"
+        message="Sind Sie sicher, dass Sie diesen Info-Block entfernen moechten?"
+        confirmLabel={isDeleting ? 'Entfernen...' : 'Entfernen'}
+        variant="danger"
+      />
+    </>
+  )
+}

--- a/apps/web/components/admin/templates/SachleistungenEditor.tsx
+++ b/apps/web/components/admin/templates/SachleistungenEditor.tsx
@@ -1,0 +1,236 @@
+'use client'
+
+import { useState } from 'react'
+import { addTemplateSachleistung, removeTemplateSachleistung } from '@/lib/actions/templates'
+import type { TemplateSachleistung } from '@/lib/supabase/types'
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, Button, Input, ConfirmDialog } from '@/components/ui'
+
+interface SachleistungenEditorProps {
+  templateId: string
+  sachleistungen: TemplateSachleistung[]
+}
+
+export function SachleistungenEditor({ templateId, sachleistungen }: SachleistungenEditorProps) {
+  const [isAdding, setIsAdding] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const [formData, setFormData] = useState({
+    name: '',
+    anzahl: 1,
+    beschreibung: '',
+  })
+
+  const resetForm = () => {
+    setFormData({
+      name: '',
+      anzahl: 1,
+      beschreibung: '',
+    })
+    setError(null)
+  }
+
+  const handleAdd = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setIsSubmitting(true)
+    setError(null)
+
+    try {
+      const result = await addTemplateSachleistung({
+        template_id: templateId,
+        name: formData.name.trim(),
+        anzahl: formData.anzahl,
+        beschreibung: formData.beschreibung.trim() || null,
+      })
+
+      if (!result.success) {
+        setError(result.error ?? 'Fehler beim Hinzufuegen')
+        return
+      }
+
+      resetForm()
+      setIsAdding(false)
+    } catch (err) {
+      console.error('Error adding sachleistung:', err)
+      setError('Ein unerwarteter Fehler ist aufgetreten')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!deletingId) return
+
+    setIsDeleting(true)
+    try {
+      const result = await removeTemplateSachleistung(deletingId, templateId)
+      if (!result.success) {
+        console.error('Failed to delete sachleistung:', result.error)
+      }
+    } catch (err) {
+      console.error('Error deleting sachleistung:', err)
+    } finally {
+      setIsDeleting(false)
+      setDeletingId(null)
+    }
+  }
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle>Sachleistungen</CardTitle>
+              <CardDescription>
+                Kuchen, Salate und andere Spenden von Helfern
+              </CardDescription>
+            </div>
+            {!isAdding && (
+              <Button variant="secondary" size="sm" onClick={() => setIsAdding(true)}>
+                Sachleistung hinzufuegen
+              </Button>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          {/* Add Form */}
+          {isAdding && (
+            <form onSubmit={handleAdd} className="mb-6 rounded-lg border border-neutral-200 bg-neutral-50 p-4">
+              <h4 className="mb-4 font-medium text-neutral-900">Neue Sachleistung</h4>
+
+              {error && (
+                <div className="mb-4 rounded-lg bg-error-50 p-3 text-sm text-error-700">
+                  {error}
+                </div>
+              )}
+
+              <div className="grid gap-4 sm:grid-cols-3">
+                <Input
+                  label="Name"
+                  name="name"
+                  value={formData.name}
+                  onChange={(e) => setFormData((prev) => ({ ...prev, name: e.target.value }))}
+                  placeholder="z.B. Kuchen, Salat, Brot"
+                  required
+                />
+
+                <Input
+                  label="Anzahl benoetigt"
+                  name="anzahl"
+                  type="number"
+                  min={1}
+                  value={formData.anzahl}
+                  onChange={(e) => setFormData((prev) => ({ ...prev, anzahl: parseInt(e.target.value) || 1 }))}
+                  required
+                />
+
+                <div className="w-full">
+                  <label
+                    htmlFor="beschreibung"
+                    className="mb-1 block text-sm font-medium text-neutral-700"
+                  >
+                    Beschreibung
+                  </label>
+                  <input
+                    id="beschreibung"
+                    name="beschreibung"
+                    value={formData.beschreibung}
+                    onChange={(e) => setFormData((prev) => ({ ...prev, beschreibung: e.target.value }))}
+                    className="block w-full rounded-md border border-neutral-300 px-3 py-2 text-neutral-900 placeholder-neutral-400 focus:border-black focus:outline-none focus:ring-2 focus:ring-black"
+                    placeholder="Optionale Details..."
+                  />
+                </div>
+              </div>
+
+              <div className="mt-4 flex justify-end gap-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    resetForm()
+                    setIsAdding(false)
+                  }}
+                  disabled={isSubmitting}
+                >
+                  Abbrechen
+                </Button>
+                <Button type="submit" size="sm" loading={isSubmitting}>
+                  Hinzufuegen
+                </Button>
+              </div>
+            </form>
+          )}
+
+          {/* List */}
+          {sachleistungen.length === 0 ? (
+            <div className="py-8 text-center text-neutral-500">
+              Noch keine Sachleistungen definiert.
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b border-neutral-200">
+                    <th className="pb-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500">
+                      Name
+                    </th>
+                    <th className="pb-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500">
+                      Anzahl
+                    </th>
+                    <th className="pb-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500">
+                      Beschreibung
+                    </th>
+                    <th className="pb-3 text-right text-xs font-medium uppercase tracking-wider text-neutral-500">
+                      Aktionen
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-neutral-100">
+                  {sachleistungen.map((sl) => (
+                    <tr key={sl.id} className="hover:bg-neutral-50">
+                      <td className="py-3 font-medium text-neutral-900">
+                        {sl.name}
+                      </td>
+                      <td className="py-3">
+                        <span className="inline-flex items-center justify-center rounded-full bg-green-100 px-2.5 py-0.5 text-sm font-medium text-green-800">
+                          {sl.anzahl}
+                        </span>
+                      </td>
+                      <td className="max-w-xs truncate py-3 text-sm text-neutral-600">
+                        {sl.beschreibung ?? '-'}
+                      </td>
+                      <td className="py-3 text-right">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="text-error-600 hover:text-error-700"
+                          onClick={() => setDeletingId(sl.id)}
+                        >
+                          Entfernen
+                        </Button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <ConfirmDialog
+        open={!!deletingId}
+        onCancel={() => setDeletingId(null)}
+        onConfirm={handleDelete}
+        title="Sachleistung entfernen"
+        message="Sind Sie sicher, dass Sie diese Sachleistung entfernen moechten?"
+        confirmLabel={isDeleting ? 'Entfernen...' : 'Entfernen'}
+        variant="danger"
+      />
+    </>
+  )
+}

--- a/apps/web/components/admin/templates/SchichtenEditor.tsx
+++ b/apps/web/components/admin/templates/SchichtenEditor.tsx
@@ -1,0 +1,261 @@
+'use client'
+
+import { useState } from 'react'
+import { addTemplateSchicht, removeTemplateSchicht } from '@/lib/actions/templates'
+import type { TemplateSchicht, TemplateZeitblock } from '@/lib/supabase/types'
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, Button, Input, ConfirmDialog } from '@/components/ui'
+
+interface SchichtenEditorProps {
+  templateId: string
+  schichten: TemplateSchicht[]
+  zeitbloecke: TemplateZeitblock[]
+}
+
+export function SchichtenEditor({ templateId, schichten, zeitbloecke }: SchichtenEditorProps) {
+  const [isAdding, setIsAdding] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const [formData, setFormData] = useState({
+    rolle: '',
+    zeitblock_name: '',
+    anzahl_benoetigt: 1,
+  })
+
+  const resetForm = () => {
+    setFormData({
+      rolle: '',
+      zeitblock_name: '',
+      anzahl_benoetigt: 1,
+    })
+    setError(null)
+  }
+
+  const handleAdd = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setIsSubmitting(true)
+    setError(null)
+
+    try {
+      const result = await addTemplateSchicht({
+        template_id: templateId,
+        rolle: formData.rolle.trim(),
+        zeitblock_name: formData.zeitblock_name || null,
+        anzahl_benoetigt: formData.anzahl_benoetigt,
+      })
+
+      if (!result.success) {
+        setError(result.error ?? 'Fehler beim Hinzufuegen')
+        return
+      }
+
+      resetForm()
+      setIsAdding(false)
+    } catch (err) {
+      console.error('Error adding schicht:', err)
+      setError('Ein unerwarteter Fehler ist aufgetreten')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!deletingId) return
+
+    setIsDeleting(true)
+    try {
+      const result = await removeTemplateSchicht(deletingId, templateId)
+      if (!result.success) {
+        console.error('Failed to delete schicht:', result.error)
+      }
+    } catch (err) {
+      console.error('Error deleting schicht:', err)
+    } finally {
+      setIsDeleting(false)
+      setDeletingId(null)
+    }
+  }
+
+  // Group schichten by zeitblock_name
+  const groupedSchichten = schichten.reduce(
+    (acc, schicht) => {
+      const key = schicht.zeitblock_name ?? 'Ohne Zeitblock'
+      if (!acc[key]) {
+        acc[key] = []
+      }
+      acc[key].push(schicht)
+      return acc
+    },
+    {} as Record<string, TemplateSchicht[]>
+  )
+
+  const totalHelfer = schichten.reduce((sum, s) => sum + s.anzahl_benoetigt, 0)
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle>Schichten / Rollen</CardTitle>
+              <CardDescription>
+                {schichten.length} Schichten mit insgesamt {totalHelfer} Helfer-Slots
+              </CardDescription>
+            </div>
+            {!isAdding && (
+              <Button variant="secondary" size="sm" onClick={() => setIsAdding(true)}>
+                Schicht hinzufuegen
+              </Button>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          {/* Add Form */}
+          {isAdding && (
+            <form onSubmit={handleAdd} className="mb-6 rounded-lg border border-neutral-200 bg-neutral-50 p-4">
+              <h4 className="mb-4 font-medium text-neutral-900">Neue Schicht</h4>
+
+              {error && (
+                <div className="mb-4 rounded-lg bg-error-50 p-3 text-sm text-error-700">
+                  {error}
+                </div>
+              )}
+
+              <div className="grid gap-4 sm:grid-cols-3">
+                <Input
+                  label="Rolle / Taetigkeit"
+                  name="rolle"
+                  value={formData.rolle}
+                  onChange={(e) => setFormData((prev) => ({ ...prev, rolle: e.target.value }))}
+                  placeholder="z.B. Kasse, Garderobe, Bar"
+                  required
+                />
+
+                <div className="w-full">
+                  <label className="mb-1 block text-sm font-medium text-neutral-700">
+                    Zeitblock (optional)
+                  </label>
+                  <select
+                    value={formData.zeitblock_name}
+                    onChange={(e) => setFormData((prev) => ({ ...prev, zeitblock_name: e.target.value }))}
+                    className="block w-full rounded-md border border-neutral-300 px-3 py-2 text-neutral-900 focus:border-black focus:outline-none focus:ring-2 focus:ring-black"
+                  >
+                    <option value="">Kein Zeitblock</option>
+                    {zeitbloecke
+                      .sort((a, b) => a.sortierung - b.sortierung)
+                      .map((zb) => (
+                        <option key={zb.id} value={zb.name}>
+                          {zb.name}
+                        </option>
+                      ))}
+                  </select>
+                </div>
+
+                <Input
+                  label="Anzahl benoetigt"
+                  name="anzahl_benoetigt"
+                  type="number"
+                  min={1}
+                  value={formData.anzahl_benoetigt}
+                  onChange={(e) => setFormData((prev) => ({ ...prev, anzahl_benoetigt: parseInt(e.target.value) || 1 }))}
+                  required
+                />
+              </div>
+
+              <div className="mt-4 flex justify-end gap-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    resetForm()
+                    setIsAdding(false)
+                  }}
+                  disabled={isSubmitting}
+                >
+                  Abbrechen
+                </Button>
+                <Button type="submit" size="sm" loading={isSubmitting}>
+                  Hinzufuegen
+                </Button>
+              </div>
+            </form>
+          )}
+
+          {/* List */}
+          {schichten.length === 0 ? (
+            <div className="py-8 text-center text-neutral-500">
+              Noch keine Schichten definiert.
+            </div>
+          ) : (
+            <div className="space-y-6">
+              {Object.entries(groupedSchichten).map(([zeitblockName, groupSchichten]) => (
+                <div key={zeitblockName}>
+                  <h4 className="mb-3 flex items-center gap-2 text-sm font-medium text-neutral-700">
+                    <span className="rounded bg-neutral-100 px-2 py-0.5">{zeitblockName}</span>
+                    <span className="text-neutral-400">
+                      ({groupSchichten.reduce((sum, s) => sum + s.anzahl_benoetigt, 0)} Helfer)
+                    </span>
+                  </h4>
+                  <div className="overflow-x-auto">
+                    <table className="w-full">
+                      <thead>
+                        <tr className="border-b border-neutral-200">
+                          <th className="pb-2 text-left text-xs font-medium uppercase tracking-wider text-neutral-500">
+                            Rolle
+                          </th>
+                          <th className="pb-2 text-left text-xs font-medium uppercase tracking-wider text-neutral-500">
+                            Anzahl
+                          </th>
+                          <th className="pb-2 text-right text-xs font-medium uppercase tracking-wider text-neutral-500">
+                            Aktionen
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-neutral-100">
+                        {groupSchichten.map((schicht) => (
+                          <tr key={schicht.id} className="hover:bg-neutral-50">
+                            <td className="py-2 font-medium text-neutral-900">
+                              {schicht.rolle}
+                            </td>
+                            <td className="py-2">
+                              <span className="inline-flex items-center justify-center rounded-full bg-blue-100 px-2.5 py-0.5 text-sm font-medium text-blue-800">
+                                {schicht.anzahl_benoetigt}
+                              </span>
+                            </td>
+                            <td className="py-2 text-right">
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                className="text-error-600 hover:text-error-700"
+                                onClick={() => setDeletingId(schicht.id)}
+                              >
+                                Entfernen
+                              </Button>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <ConfirmDialog
+        open={!!deletingId}
+        onCancel={() => setDeletingId(null)}
+        onConfirm={handleDelete}
+        title="Schicht entfernen"
+        message="Sind Sie sicher, dass Sie diese Schicht entfernen moechten?"
+        confirmLabel={isDeleting ? 'Entfernen...' : 'Entfernen'}
+        variant="danger"
+      />
+    </>
+  )
+}

--- a/apps/web/components/admin/templates/TemplateForm.tsx
+++ b/apps/web/components/admin/templates/TemplateForm.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { createTemplate, updateTemplate } from '@/lib/actions/templates'
+import type { AuffuehrungTemplate } from '@/lib/supabase/types'
+import { Card, CardHeader, CardTitle, CardContent, CardFooter, Button, Input } from '@/components/ui'
+
+interface TemplateFormProps {
+  template?: AuffuehrungTemplate
+}
+
+export function TemplateForm({ template }: TemplateFormProps) {
+  const router = useRouter()
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const [formData, setFormData] = useState({
+    name: template?.name ?? '',
+    beschreibung: template?.beschreibung ?? '',
+  })
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setIsSubmitting(true)
+    setError(null)
+
+    try {
+      if (template) {
+        const updateData = {
+          name: formData.name.trim(),
+          beschreibung: formData.beschreibung.trim() || null,
+        }
+        const result = await updateTemplate(template.id, updateData)
+        if (!result.success) {
+          setError(result.error ?? 'Fehler beim Aktualisieren')
+          return
+        }
+        router.push(`/admin/schicht-templates/${template.id}` as never)
+      } else {
+        const createData = {
+          name: formData.name.trim(),
+          beschreibung: formData.beschreibung.trim() || null,
+          archiviert: false,
+        }
+        const result = await createTemplate(createData)
+        if (!result.success) {
+          setError(result.error ?? 'Fehler beim Erstellen')
+          return
+        }
+        router.push(`/admin/schicht-templates/${result.id}` as never)
+      }
+    } catch (err) {
+      console.error('Error saving template:', err)
+      setError('Ein unerwarteter Fehler ist aufgetreten')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Card>
+        <CardHeader>
+          <CardTitle>{template ? 'Template bearbeiten' : 'Grunddaten'}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {error && (
+            <div className="rounded-lg bg-error-50 p-4 text-sm text-error-700">
+              {error}
+            </div>
+          )}
+
+          <Input
+            label="Name"
+            name="name"
+            value={formData.name}
+            onChange={(e) => setFormData((prev) => ({ ...prev, name: e.target.value }))}
+            placeholder="z.B. Abendvorstellung, Brunch, Generalprobe"
+            required
+          />
+
+          <div className="w-full">
+            <label
+              htmlFor="beschreibung"
+              className="mb-1 block text-sm font-medium text-neutral-700"
+            >
+              Beschreibung
+            </label>
+            <textarea
+              id="beschreibung"
+              name="beschreibung"
+              value={formData.beschreibung}
+              onChange={(e) =>
+                setFormData((prev) => ({ ...prev, beschreibung: e.target.value }))
+              }
+              rows={3}
+              className="block w-full rounded-md border border-neutral-300 px-3 py-2 text-neutral-900 placeholder-neutral-400 transition-colors focus:border-black focus:outline-none focus:ring-2 focus:ring-black focus:ring-offset-0"
+              placeholder="Optionale Beschreibung des Templates..."
+            />
+          </div>
+        </CardContent>
+        <CardFooter className="flex justify-between border-t border-neutral-200 px-6 py-4">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => router.back()}
+            disabled={isSubmitting}
+          >
+            Abbrechen
+          </Button>
+          <Button type="submit" loading={isSubmitting}>
+            {template ? 'Speichern' : 'Template erstellen'}
+          </Button>
+        </CardFooter>
+      </Card>
+    </form>
+  )
+}

--- a/apps/web/components/admin/templates/TemplateList.tsx
+++ b/apps/web/components/admin/templates/TemplateList.tsx
@@ -1,0 +1,200 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+import { archiveTemplate, deleteTemplate } from '@/lib/actions/templates'
+import type { AuffuehrungTemplate } from '@/lib/supabase/types'
+import { Button, ConfirmDialog } from '@/components/ui'
+
+type TemplateWithCounts = AuffuehrungTemplate & {
+  zeitbloeckeCount: number
+  schichtenCount: number
+  totalSlots: number
+}
+
+interface TemplateListProps {
+  templates: TemplateWithCounts[]
+}
+
+export function TemplateList({ templates }: TemplateListProps) {
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [isDeleting, setIsDeleting] = useState(false)
+
+  const handleDelete = async () => {
+    if (!deletingId) return
+
+    setIsDeleting(true)
+    try {
+      const result = await deleteTemplate(deletingId)
+      if (!result.success) {
+        console.error('Failed to delete template:', result.error)
+      }
+    } catch (error) {
+      console.error('Error deleting template:', error)
+    } finally {
+      setIsDeleting(false)
+      setDeletingId(null)
+    }
+  }
+
+  const handleArchive = async (id: string) => {
+    try {
+      const result = await archiveTemplate(id)
+      if (!result.success) {
+        console.error('Failed to archive template:', result.error)
+      }
+    } catch (error) {
+      console.error('Error archiving template:', error)
+    }
+  }
+
+  if (templates.length === 0) {
+    return (
+      <div className="px-6 py-12 text-center">
+        <svg
+          className="mx-auto h-12 w-12 text-neutral-400"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z"
+          />
+        </svg>
+        <h3 className="mt-4 text-lg font-medium text-neutral-900">
+          Keine Templates vorhanden
+        </h3>
+        <p className="mt-2 text-neutral-500">
+          Erstellen Sie ein neues Template, um Helfer-Schichten fuer Auffuehrungen zu definieren.
+        </p>
+        <div className="mt-6">
+          <Link href={'/admin/schicht-templates/neu' as never}>
+            <Button>Erstes Template erstellen</Button>
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <div className="overflow-x-auto">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b border-neutral-200 bg-neutral-50">
+              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500">
+                Name
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500">
+                Zeitbloecke
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500">
+                Schichten
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500">
+                Slots
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500">
+                Status
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500">
+                Erstellt
+              </th>
+              <th className="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-neutral-500">
+                Aktionen
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-neutral-200">
+            {templates.map((template) => (
+              <tr
+                key={template.id}
+                className={`hover:bg-neutral-50 ${template.archiviert ? 'bg-neutral-100 opacity-75' : ''}`}
+              >
+                <td className="whitespace-nowrap px-6 py-4">
+                  <Link
+                    href={`/admin/schicht-templates/${template.id}` as never}
+                    className="font-medium text-neutral-900 hover:text-neutral-700"
+                  >
+                    {template.name}
+                  </Link>
+                  {template.beschreibung && (
+                    <p className="mt-1 max-w-xs truncate text-sm text-neutral-500">
+                      {template.beschreibung}
+                    </p>
+                  )}
+                </td>
+                <td className="whitespace-nowrap px-6 py-4 text-sm text-neutral-600">
+                  {template.zeitbloeckeCount}
+                </td>
+                <td className="whitespace-nowrap px-6 py-4 text-sm text-neutral-600">
+                  {template.schichtenCount}
+                </td>
+                <td className="whitespace-nowrap px-6 py-4 text-sm text-neutral-600">
+                  {template.totalSlots}
+                </td>
+                <td className="whitespace-nowrap px-6 py-4">
+                  {template.archiviert ? (
+                    <span className="inline-flex rounded-full bg-neutral-200 px-2.5 py-0.5 text-xs font-medium text-neutral-800">
+                      Archiviert
+                    </span>
+                  ) : (
+                    <span className="inline-flex rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800">
+                      Aktiv
+                    </span>
+                  )}
+                </td>
+                <td className="whitespace-nowrap px-6 py-4 text-sm text-neutral-600">
+                  {new Date(template.created_at).toLocaleDateString('de-CH', {
+                    day: '2-digit',
+                    month: '2-digit',
+                    year: 'numeric',
+                  })}
+                </td>
+                <td className="whitespace-nowrap px-6 py-4 text-right">
+                  <div className="flex items-center justify-end gap-2">
+                    <Link href={`/admin/schicht-templates/${template.id}` as never}>
+                      <Button variant="ghost" size="sm">
+                        Bearbeiten
+                      </Button>
+                    </Link>
+                    {!template.archiviert && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleArchive(template.id)}
+                      >
+                        Archivieren
+                      </Button>
+                    )}
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-error-600 hover:text-error-700"
+                      onClick={() => setDeletingId(template.id)}
+                    >
+                      Loeschen
+                    </Button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <ConfirmDialog
+        open={!!deletingId}
+        onCancel={() => setDeletingId(null)}
+        onConfirm={handleDelete}
+        title="Template loeschen"
+        message="Sind Sie sicher, dass Sie dieses Template loeschen moechten? Diese Aktion kann nicht rueckgaengig gemacht werden."
+        confirmLabel={isDeleting ? 'Loeschen...' : 'Loeschen'}
+        variant="danger"
+      />
+    </>
+  )
+}

--- a/apps/web/components/admin/templates/TemplatePreview.tsx
+++ b/apps/web/components/admin/templates/TemplatePreview.tsx
@@ -1,0 +1,48 @@
+interface TemplatePreviewProps {
+  zeitbloeckeCount: number
+  schichtenCount: number
+  slotsCount: number
+  infoBloeckeCount: number
+  sachleistungenCount: number
+}
+
+export function TemplatePreview({
+  zeitbloeckeCount,
+  schichtenCount,
+  slotsCount,
+  infoBloeckeCount,
+  sachleistungenCount,
+}: TemplatePreviewProps) {
+  return (
+    <div className="rounded-xl border border-neutral-200 bg-gradient-to-r from-neutral-50 to-white p-6">
+      <h2 className="text-sm font-medium uppercase tracking-wider text-neutral-500">
+        Template-Vorschau
+      </h2>
+      <p className="mt-2 text-neutral-700">
+        Dieses Template generiert:
+      </p>
+      <div className="mt-4 grid grid-cols-2 gap-4 sm:grid-cols-5">
+        <div className="rounded-lg bg-white p-4 shadow-sm">
+          <p className="text-2xl font-semibold text-neutral-900">{zeitbloeckeCount}</p>
+          <p className="text-sm text-neutral-500">Zeitbloecke</p>
+        </div>
+        <div className="rounded-lg bg-white p-4 shadow-sm">
+          <p className="text-2xl font-semibold text-neutral-900">{schichtenCount}</p>
+          <p className="text-sm text-neutral-500">Schichten</p>
+        </div>
+        <div className="rounded-lg bg-white p-4 shadow-sm">
+          <p className="text-2xl font-semibold text-neutral-900">{slotsCount}</p>
+          <p className="text-sm text-neutral-500">Helfer-Slots</p>
+        </div>
+        <div className="rounded-lg bg-white p-4 shadow-sm">
+          <p className="text-2xl font-semibold text-neutral-900">{infoBloeckeCount}</p>
+          <p className="text-sm text-neutral-500">Info-Bloecke</p>
+        </div>
+        <div className="rounded-lg bg-white p-4 shadow-sm">
+          <p className="text-2xl font-semibold text-neutral-900">{sachleistungenCount}</p>
+          <p className="text-sm text-neutral-500">Sachleistungen</p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/admin/templates/ZeitbloeckeEditor.tsx
+++ b/apps/web/components/admin/templates/ZeitbloeckeEditor.tsx
@@ -1,0 +1,283 @@
+'use client'
+
+import { useState } from 'react'
+import { addTemplateZeitblock, removeTemplateZeitblock } from '@/lib/actions/templates'
+import type { TemplateZeitblock, ZeitblockTyp } from '@/lib/supabase/types'
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, Button, Input, ConfirmDialog } from '@/components/ui'
+
+const ZEITBLOCK_TYPEN: { value: ZeitblockTyp; label: string }[] = [
+  { value: 'aufbau', label: 'Aufbau' },
+  { value: 'einlass', label: 'Einlass' },
+  { value: 'vorfuehrung', label: 'Vorfuehrung' },
+  { value: 'pause', label: 'Pause' },
+  { value: 'abbau', label: 'Abbau' },
+  { value: 'standard', label: 'Standard' },
+]
+
+interface ZeitbloeckeEditorProps {
+  templateId: string
+  zeitbloecke: TemplateZeitblock[]
+}
+
+function formatOffset(minutes: number): string {
+  const hours = Math.floor(Math.abs(minutes) / 60)
+  const mins = Math.abs(minutes) % 60
+  const sign = minutes < 0 ? '-' : '+'
+  if (hours === 0) return `${sign}${mins}min`
+  if (mins === 0) return `${sign}${hours}h`
+  return `${sign}${hours}h ${mins}min`
+}
+
+export function ZeitbloeckeEditor({ templateId, zeitbloecke }: ZeitbloeckeEditorProps) {
+  const [isAdding, setIsAdding] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const [formData, setFormData] = useState({
+    name: '',
+    offset_minuten: 0,
+    dauer_minuten: 60,
+    typ: 'standard' as ZeitblockTyp,
+    sortierung: zeitbloecke.length,
+  })
+
+  const resetForm = () => {
+    setFormData({
+      name: '',
+      offset_minuten: 0,
+      dauer_minuten: 60,
+      typ: 'standard',
+      sortierung: zeitbloecke.length,
+    })
+    setError(null)
+  }
+
+  const handleAdd = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setIsSubmitting(true)
+    setError(null)
+
+    try {
+      const result = await addTemplateZeitblock({
+        template_id: templateId,
+        name: formData.name.trim(),
+        offset_minuten: formData.offset_minuten,
+        dauer_minuten: formData.dauer_minuten,
+        typ: formData.typ,
+        sortierung: formData.sortierung,
+      })
+
+      if (!result.success) {
+        setError(result.error ?? 'Fehler beim Hinzufuegen')
+        return
+      }
+
+      resetForm()
+      setIsAdding(false)
+    } catch (err) {
+      console.error('Error adding zeitblock:', err)
+      setError('Ein unerwarteter Fehler ist aufgetreten')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!deletingId) return
+
+    setIsDeleting(true)
+    try {
+      const result = await removeTemplateZeitblock(deletingId, templateId)
+      if (!result.success) {
+        console.error('Failed to delete zeitblock:', result.error)
+      }
+    } catch (err) {
+      console.error('Error deleting zeitblock:', err)
+    } finally {
+      setIsDeleting(false)
+      setDeletingId(null)
+    }
+  }
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle>Zeitbloecke</CardTitle>
+              <CardDescription>
+                Zeitraeume relativ zum Vorstellungsbeginn (Offset 0 = Beginn)
+              </CardDescription>
+            </div>
+            {!isAdding && (
+              <Button variant="secondary" size="sm" onClick={() => setIsAdding(true)}>
+                Zeitblock hinzufuegen
+              </Button>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          {/* Add Form */}
+          {isAdding && (
+            <form onSubmit={handleAdd} className="mb-6 rounded-lg border border-neutral-200 bg-neutral-50 p-4">
+              <h4 className="mb-4 font-medium text-neutral-900">Neuer Zeitblock</h4>
+
+              {error && (
+                <div className="mb-4 rounded-lg bg-error-50 p-3 text-sm text-error-700">
+                  {error}
+                </div>
+              )}
+
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                <Input
+                  label="Name"
+                  name="name"
+                  value={formData.name}
+                  onChange={(e) => setFormData((prev) => ({ ...prev, name: e.target.value }))}
+                  placeholder="z.B. Aufbau Saal"
+                  required
+                />
+
+                <div className="w-full">
+                  <label className="mb-1 block text-sm font-medium text-neutral-700">
+                    Typ
+                  </label>
+                  <select
+                    value={formData.typ}
+                    onChange={(e) => setFormData((prev) => ({ ...prev, typ: e.target.value as ZeitblockTyp }))}
+                    className="block w-full rounded-md border border-neutral-300 px-3 py-2 text-neutral-900 focus:border-black focus:outline-none focus:ring-2 focus:ring-black"
+                  >
+                    {ZEITBLOCK_TYPEN.map((typ) => (
+                      <option key={typ.value} value={typ.value}>
+                        {typ.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <Input
+                  label="Offset (Minuten)"
+                  name="offset_minuten"
+                  type="number"
+                  value={formData.offset_minuten}
+                  onChange={(e) => setFormData((prev) => ({ ...prev, offset_minuten: parseInt(e.target.value) || 0 }))}
+                  helperText="Negativ = vor Beginn"
+                />
+
+                <Input
+                  label="Dauer (Minuten)"
+                  name="dauer_minuten"
+                  type="number"
+                  min={1}
+                  value={formData.dauer_minuten}
+                  onChange={(e) => setFormData((prev) => ({ ...prev, dauer_minuten: parseInt(e.target.value) || 60 }))}
+                  required
+                />
+              </div>
+
+              <div className="mt-4 flex justify-end gap-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    resetForm()
+                    setIsAdding(false)
+                  }}
+                  disabled={isSubmitting}
+                >
+                  Abbrechen
+                </Button>
+                <Button type="submit" size="sm" loading={isSubmitting}>
+                  Hinzufuegen
+                </Button>
+              </div>
+            </form>
+          )}
+
+          {/* List */}
+          {zeitbloecke.length === 0 ? (
+            <div className="py-8 text-center text-neutral-500">
+              Noch keine Zeitbloecke definiert.
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b border-neutral-200">
+                    <th className="pb-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500">
+                      Sortierung
+                    </th>
+                    <th className="pb-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500">
+                      Name
+                    </th>
+                    <th className="pb-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500">
+                      Typ
+                    </th>
+                    <th className="pb-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500">
+                      Offset
+                    </th>
+                    <th className="pb-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500">
+                      Dauer
+                    </th>
+                    <th className="pb-3 text-right text-xs font-medium uppercase tracking-wider text-neutral-500">
+                      Aktionen
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-neutral-100">
+                  {zeitbloecke
+                    .sort((a, b) => a.sortierung - b.sortierung)
+                    .map((zb) => (
+                      <tr key={zb.id} className="hover:bg-neutral-50">
+                        <td className="py-3 text-sm text-neutral-600">
+                          {zb.sortierung}
+                        </td>
+                        <td className="py-3 font-medium text-neutral-900">
+                          {zb.name}
+                        </td>
+                        <td className="py-3">
+                          <span className="inline-flex rounded-full bg-neutral-100 px-2 py-0.5 text-xs font-medium text-neutral-700">
+                            {ZEITBLOCK_TYPEN.find((t) => t.value === zb.typ)?.label ?? zb.typ}
+                          </span>
+                        </td>
+                        <td className="py-3 text-sm text-neutral-600">
+                          {formatOffset(zb.offset_minuten)}
+                        </td>
+                        <td className="py-3 text-sm text-neutral-600">
+                          {zb.dauer_minuten} min
+                        </td>
+                        <td className="py-3 text-right">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="text-error-600 hover:text-error-700"
+                            onClick={() => setDeletingId(zb.id)}
+                          >
+                            Entfernen
+                          </Button>
+                        </td>
+                      </tr>
+                    ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <ConfirmDialog
+        open={!!deletingId}
+        onCancel={() => setDeletingId(null)}
+        onConfirm={handleDelete}
+        title="Zeitblock entfernen"
+        message="Sind Sie sicher, dass Sie diesen Zeitblock entfernen moechten?"
+        confirmLabel={isDeleting ? 'Entfernen...' : 'Entfernen'}
+        variant="danger"
+      />
+    </>
+  )
+}

--- a/apps/web/components/auffuehrungen/SchichtenStatusBanner.tsx
+++ b/apps/web/components/auffuehrungen/SchichtenStatusBanner.tsx
@@ -1,0 +1,175 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { resetSchichten } from '@/lib/actions/schicht-generator'
+import { Button, ConfirmDialog } from '@/components/ui'
+
+interface SchichtenStatus {
+  hasSchichten: boolean
+  zeitbloeckeCount: number
+  schichtenCount: number
+  slotsCount: number
+  zugewiesenCount: number
+  templateId: string | null
+  status: string | null
+}
+
+interface SchichtenStatusBannerProps {
+  status: SchichtenStatus
+  veranstaltungId: string
+  isAdmin: boolean
+}
+
+const STATUS_LABELS: Record<string, { label: string; color: string }> = {
+  entwurf: { label: 'Entwurf', color: 'bg-yellow-100 text-yellow-800' },
+  veroeffentlicht: { label: 'Veroeffentlicht', color: 'bg-green-100 text-green-800' },
+  abgeschlossen: { label: 'Abgeschlossen', color: 'bg-neutral-200 text-neutral-700' },
+}
+
+export function SchichtenStatusBanner({ status, veranstaltungId, isAdmin }: SchichtenStatusBannerProps) {
+  const router = useRouter()
+  const [showResetConfirm, setShowResetConfirm] = useState(false)
+  const [isResetting, setIsResetting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleReset = async () => {
+    setIsResetting(true)
+    setError(null)
+
+    try {
+      const result = await resetSchichten(veranstaltungId)
+
+      if (!result.success) {
+        setError(result.error ?? 'Fehler beim Zuruecksetzen')
+        setShowResetConfirm(false)
+        return
+      }
+
+      setShowResetConfirm(false)
+      router.refresh()
+    } catch (err) {
+      console.error('Error resetting schichten:', err)
+      setError('Ein unerwarteter Fehler ist aufgetreten')
+      setShowResetConfirm(false)
+    } finally {
+      setIsResetting(false)
+    }
+  }
+
+  if (!status.hasSchichten) {
+    return (
+      <div className="rounded-lg bg-neutral-100 p-4">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-neutral-200">
+            <svg
+              className="h-5 w-5 text-neutral-500"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+              />
+            </svg>
+          </div>
+          <div>
+            <p className="font-medium text-neutral-900">Noch keine Schichten</p>
+            <p className="text-sm text-neutral-500">
+              Waehlen Sie unten ein Template aus, um Schichten zu generieren.
+            </p>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  const statusInfo = status.status ? STATUS_LABELS[status.status] : null
+  const filledPercentage = status.slotsCount > 0
+    ? Math.round((status.zugewiesenCount / status.slotsCount) * 100)
+    : 0
+
+  return (
+    <>
+      <div className="rounded-lg border border-neutral-200 bg-white p-4">
+        {error && (
+          <div className="mb-4 rounded-lg bg-error-50 p-3 text-sm text-error-700">
+            {error}
+          </div>
+        )}
+
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-green-100">
+              <svg
+                className="h-5 w-5 text-green-600"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+            </div>
+            <div>
+              <div className="flex items-center gap-2">
+                <p className="font-medium text-neutral-900">Schichten generiert</p>
+                {statusInfo && (
+                  <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${statusInfo.color}`}>
+                    {statusInfo.label}
+                  </span>
+                )}
+              </div>
+              <p className="text-sm text-neutral-500">
+                {status.zeitbloeckeCount} Zeitbloecke, {status.schichtenCount} Schichten,{' '}
+                {status.zugewiesenCount}/{status.slotsCount} Slots besetzt ({filledPercentage}%)
+              </p>
+            </div>
+          </div>
+
+          {isAdmin && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-error-600 hover:text-error-700"
+              onClick={() => setShowResetConfirm(true)}
+            >
+              Zuruecksetzen
+            </Button>
+          )}
+        </div>
+
+        {/* Progress Bar */}
+        <div className="mt-4">
+          <div className="flex items-center justify-between text-xs text-neutral-500">
+            <span>Besetzungsfortschritt</span>
+            <span>{filledPercentage}%</span>
+          </div>
+          <div className="mt-1 h-2 overflow-hidden rounded-full bg-neutral-100">
+            <div
+              className="h-full bg-green-500 transition-all"
+              style={{ width: `${filledPercentage}%` }}
+            />
+          </div>
+        </div>
+      </div>
+
+      <ConfirmDialog
+        open={showResetConfirm}
+        onCancel={() => setShowResetConfirm(false)}
+        onConfirm={handleReset}
+        title="Schichten zuruecksetzen"
+        message={`Sind Sie sicher, dass Sie alle ${status.schichtenCount} Schichten und ${status.zugewiesenCount} Zuweisungen loeschen moechten? Diese Aktion kann nicht rueckgaengig gemacht werden.`}
+        confirmLabel={isResetting ? 'Zuruecksetzen...' : 'Zuruecksetzen'}
+        variant="danger"
+      />
+    </>
+  )
+}

--- a/apps/web/components/auffuehrungen/TemplateSelector.tsx
+++ b/apps/web/components/auffuehrungen/TemplateSelector.tsx
@@ -1,0 +1,236 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { generateSchichtenFromTemplate } from '@/lib/actions/schicht-generator'
+import { getTemplate } from '@/lib/actions/templates'
+import type { AuffuehrungTemplate, TemplateMitDetails } from '@/lib/supabase/types'
+import { Button, ConfirmDialog } from '@/components/ui'
+
+interface TemplateSelectorProps {
+  veranstaltungId: string
+  templates: AuffuehrungTemplate[]
+  startzeit: string
+}
+
+export function TemplateSelector({ veranstaltungId, templates, startzeit }: TemplateSelectorProps) {
+  const router = useRouter()
+  const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(null)
+  const [templateDetails, setTemplateDetails] = useState<TemplateMitDetails | null>(null)
+  const [isLoadingDetails, setIsLoadingDetails] = useState(false)
+  const [showConfirm, setShowConfirm] = useState(false)
+  const [isGenerating, setIsGenerating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSelectTemplate = async (templateId: string) => {
+    setSelectedTemplateId(templateId)
+    setIsLoadingDetails(true)
+    setError(null)
+
+    try {
+      const details = await getTemplate(templateId)
+      setTemplateDetails(details)
+    } catch (err) {
+      console.error('Error loading template details:', err)
+      setError('Fehler beim Laden der Template-Details')
+    } finally {
+      setIsLoadingDetails(false)
+    }
+  }
+
+  const handleGenerate = async () => {
+    if (!selectedTemplateId) return
+
+    setIsGenerating(true)
+    setError(null)
+
+    try {
+      const result = await generateSchichtenFromTemplate(veranstaltungId, selectedTemplateId)
+
+      if (!result.success) {
+        setError(result.error ?? 'Fehler beim Generieren der Schichten')
+        setShowConfirm(false)
+        return
+      }
+
+      // Success - redirect to the auffuehrung page
+      router.push(`/auffuehrungen/${veranstaltungId}` as never)
+      router.refresh()
+    } catch (err) {
+      console.error('Error generating schichten:', err)
+      setError('Ein unerwarteter Fehler ist aufgetreten')
+      setShowConfirm(false)
+    } finally {
+      setIsGenerating(false)
+    }
+  }
+
+  // Helper to format time
+  const formatOffset = (minutes: number): string => {
+    const hours = Math.floor(Math.abs(minutes) / 60)
+    const mins = Math.abs(minutes) % 60
+    const sign = minutes < 0 ? '-' : '+'
+    if (hours === 0) return `${sign}${mins}min`
+    if (mins === 0) return `${sign}${hours}h`
+    return `${sign}${hours}h ${mins}min`
+  }
+
+  // Calculate preview times based on startzeit
+  const calculateTime = (offsetMinutes: number): string => {
+    const [startH, startM] = startzeit.split(':').map(Number)
+    const totalMinutes = startH * 60 + startM + offsetMinutes
+    const normalizedMinutes = ((totalMinutes % 1440) + 1440) % 1440
+    const hours = Math.floor(normalizedMinutes / 60)
+    const minutes = normalizedMinutes % 60
+    return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`
+  }
+
+  return (
+    <div className="space-y-6">
+      {error && (
+        <div className="rounded-lg bg-error-50 p-4 text-sm text-error-700">
+          {error}
+        </div>
+      )}
+
+      {/* Template Selection Dropdown */}
+      <div>
+        <label className="mb-2 block text-sm font-medium text-neutral-700">
+          Template auswaehlen
+        </label>
+        <select
+          value={selectedTemplateId ?? ''}
+          onChange={(e) => handleSelectTemplate(e.target.value)}
+          className="block w-full rounded-lg border border-neutral-300 px-3 py-2 text-neutral-900 focus:border-black focus:outline-none focus:ring-2 focus:ring-black"
+        >
+          <option value="">-- Bitte waehlen --</option>
+          {templates.map((template) => (
+            <option key={template.id} value={template.id}>
+              {template.name}
+              {template.beschreibung && ` - ${template.beschreibung}`}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Loading State */}
+      {isLoadingDetails && (
+        <div className="flex items-center gap-2 text-neutral-500">
+          <svg
+            className="h-5 w-5 animate-spin"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+            />
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+            />
+          </svg>
+          <span>Lade Template-Details...</span>
+        </div>
+      )}
+
+      {/* Template Preview */}
+      {templateDetails && !isLoadingDetails && (
+        <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-4">
+          <h4 className="font-medium text-neutral-900">{templateDetails.name}</h4>
+          {templateDetails.beschreibung && (
+            <p className="mt-1 text-sm text-neutral-600">{templateDetails.beschreibung}</p>
+          )}
+
+          {/* Stats */}
+          <div className="mt-4 grid grid-cols-2 gap-4 sm:grid-cols-4">
+            <div className="rounded bg-white p-3 shadow-sm">
+              <p className="text-lg font-semibold text-neutral-900">
+                {templateDetails.zeitbloecke.length}
+              </p>
+              <p className="text-xs text-neutral-500">Zeitbloecke</p>
+            </div>
+            <div className="rounded bg-white p-3 shadow-sm">
+              <p className="text-lg font-semibold text-neutral-900">
+                {templateDetails.schichten.length}
+              </p>
+              <p className="text-xs text-neutral-500">Schichten</p>
+            </div>
+            <div className="rounded bg-white p-3 shadow-sm">
+              <p className="text-lg font-semibold text-neutral-900">
+                {templateDetails.schichten.reduce((sum, s) => sum + s.anzahl_benoetigt, 0)}
+              </p>
+              <p className="text-xs text-neutral-500">Helfer-Slots</p>
+            </div>
+            <div className="rounded bg-white p-3 shadow-sm">
+              <p className="text-lg font-semibold text-neutral-900">
+                {templateDetails.info_bloecke.length}
+              </p>
+              <p className="text-xs text-neutral-500">Info-Bloecke</p>
+            </div>
+          </div>
+
+          {/* Zeitbloecke Preview */}
+          {templateDetails.zeitbloecke.length > 0 && (
+            <div className="mt-4">
+              <h5 className="mb-2 text-sm font-medium text-neutral-700">
+                Zeitbloecke (Vorschau mit Start {startzeit} Uhr)
+              </h5>
+              <div className="space-y-1">
+                {templateDetails.zeitbloecke
+                  .sort((a, b) => a.sortierung - b.sortierung)
+                  .slice(0, 5)
+                  .map((zb) => (
+                    <div
+                      key={zb.id}
+                      className="flex items-center justify-between rounded bg-white px-3 py-2 text-sm"
+                    >
+                      <span className="font-medium text-neutral-900">{zb.name}</span>
+                      <span className="text-neutral-500">
+                        {calculateTime(zb.offset_minuten)} - {calculateTime(zb.offset_minuten + zb.dauer_minuten)}
+                        <span className="ml-2 text-neutral-400">
+                          ({formatOffset(zb.offset_minuten)})
+                        </span>
+                      </span>
+                    </div>
+                  ))}
+                {templateDetails.zeitbloecke.length > 5 && (
+                  <p className="text-xs text-neutral-500">
+                    ... und {templateDetails.zeitbloecke.length - 5} weitere
+                  </p>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Generate Button */}
+          <div className="mt-6">
+            <Button onClick={() => setShowConfirm(true)} className="w-full sm:w-auto">
+              Schichten generieren
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Confirmation Dialog */}
+      <ConfirmDialog
+        open={showConfirm}
+        onCancel={() => setShowConfirm(false)}
+        onConfirm={handleGenerate}
+        title="Schichten generieren"
+        message={
+          templateDetails
+            ? `Moechten Sie ${templateDetails.zeitbloecke.length} Zeitbloecke mit ${templateDetails.schichten.length} Schichten und ${templateDetails.schichten.reduce((sum, s) => sum + s.anzahl_benoetigt, 0)} Helfer-Slots aus dem Template "${templateDetails.name}" erstellen?`
+            : 'Moechten Sie die Schichten generieren?'
+        }
+        confirmLabel={isGenerating ? 'Generieren...' : 'Generieren'}
+      />
+    </div>
+  )
+}

--- a/apps/web/lib/actions/produktions-serien-templates.ts
+++ b/apps/web/lib/actions/produktions-serien-templates.ts
@@ -1,0 +1,285 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { createClient } from '../supabase/server'
+import { requirePermission } from '../supabase/auth-helpers'
+import { generateSchichtenFromTemplate } from './schicht-generator'
+import type {
+  ProduktionsSerieTemplateMitDetails,
+  Wochentag,
+} from '../supabase/types'
+
+// =============================================================================
+// Get Serie Template Mappings
+// =============================================================================
+
+/**
+ * Get all template mappings for a series
+ */
+export async function getSerieTemplateMappings(
+  serieId: string
+): Promise<ProduktionsSerieTemplateMitDetails[]> {
+  const supabase = await createClient()
+
+  const { data, error } = await supabase
+    .from('produktions_serie_templates')
+    .select(`
+      *,
+      template:auffuehrung_templates(id, name)
+    `)
+    .eq('serie_id', serieId)
+    .order('wochentag', { ascending: true })
+
+  if (error) {
+    console.error('Error fetching serie template mappings:', error)
+    return []
+  }
+
+  return (data as ProduktionsSerieTemplateMitDetails[]) || []
+}
+
+// =============================================================================
+// Assign Templates to Serie (by Weekday)
+// =============================================================================
+
+export type WeekdayMapping = {
+  wochentag: Wochentag
+  template_id: string
+}
+
+/**
+ * Assign templates to a series based on weekday
+ * Replaces all existing mappings
+ */
+export async function assignTemplatesZurSerie(
+  serieId: string,
+  mappings: WeekdayMapping[]
+): Promise<{ success: boolean; error?: string }> {
+  await requirePermission('produktionen:write')
+
+  const supabase = await createClient()
+
+  // First, delete all existing mappings for this series
+  const { error: deleteError } = await supabase
+    .from('produktions_serie_templates')
+    .delete()
+    .eq('serie_id', serieId)
+
+  if (deleteError) {
+    console.error('Error deleting existing mappings:', deleteError)
+    return { success: false, error: 'Fehler beim Aktualisieren der Zuordnungen' }
+  }
+
+  // If no new mappings, we're done
+  if (mappings.length === 0) {
+    revalidatePath(`/produktionen`)
+    return { success: true }
+  }
+
+  // Insert new mappings
+  const inserts = mappings.map((m) => ({
+    serie_id: serieId,
+    wochentag: m.wochentag,
+    template_id: m.template_id,
+  }))
+
+  const { error: insertError } = await supabase
+    .from('produktions_serie_templates')
+    .insert(inserts as never[])
+
+  if (insertError) {
+    console.error('Error inserting new mappings:', insertError)
+    return { success: false, error: 'Fehler beim Speichern der Zuordnungen' }
+  }
+
+  revalidatePath(`/produktionen`)
+  return { success: true }
+}
+
+// =============================================================================
+// Bulk Generate Schichten
+// =============================================================================
+
+export type BulkGenerateResult = {
+  veranstaltungId: string
+  titel: string
+  datum: string
+  wochentag: Wochentag
+  templateName: string
+  success: boolean
+  error?: string
+  zeitbloecke?: number
+  schichten?: number
+  slots?: number
+}
+
+/**
+ * Get preview of what will be generated for a series
+ */
+export async function getBulkGeneratePreview(serieId: string): Promise<{
+  auffuehrungen: {
+    id: string
+    veranstaltungId: string | null
+    titel: string
+    datum: string
+    wochentag: Wochentag
+    templateId: string | null
+    templateName: string | null
+    hasSchichten: boolean
+    helferStatus: string | null
+  }[]
+  mappings: ProduktionsSerieTemplateMitDetails[]
+}> {
+  const supabase = await createClient()
+
+  // Get series with auffuehrungen
+  const { data: serienauffuehrungen } = await supabase
+    .from('serienauffuehrungen')
+    .select(`
+      id,
+      datum,
+      veranstaltung_id,
+      veranstaltung:veranstaltungen(
+        id,
+        titel,
+        helfer_template_id,
+        helfer_status
+      )
+    `)
+    .eq('serie_id', serieId)
+    .order('datum', { ascending: true })
+
+  // Get template mappings
+  const mappings = await getSerieTemplateMappings(serieId)
+
+  // Build preview data
+  const auffuehrungen = await Promise.all(
+    (serienauffuehrungen || []).map(async (sa) => {
+      const datum = new Date(sa.datum)
+      const wochentag = datum.getDay() as Wochentag
+
+      // Find template for this weekday
+      const mapping = mappings.find((m) => m.wochentag === wochentag)
+
+      // Check if schichten already exist
+      let hasSchichten = false
+      if (sa.veranstaltung_id) {
+        const { count } = await supabase
+          .from('auffuehrung_schichten')
+          .select('id', { count: 'exact', head: true })
+          .eq('veranstaltung_id', sa.veranstaltung_id)
+        hasSchichten = (count ?? 0) > 0
+      }
+
+      // Handle the joined veranstaltung data - Supabase returns single object for 1:1 joins
+      const veranstaltung = sa.veranstaltung as unknown as {
+        id: string
+        titel: string
+        helfer_template_id: string | null
+        helfer_status: string | null
+      } | null
+
+      return {
+        id: sa.id,
+        veranstaltungId: sa.veranstaltung_id,
+        titel: veranstaltung?.titel ?? `Auffuehrung am ${sa.datum}`,
+        datum: sa.datum,
+        wochentag,
+        templateId: mapping?.template_id ?? null,
+        templateName: mapping?.template?.name ?? null,
+        hasSchichten,
+        helferStatus: veranstaltung?.helfer_status ?? null,
+      }
+    })
+  )
+
+  return { auffuehrungen, mappings }
+}
+
+/**
+ * Bulk generate schichten for all (or selected) auffuehrungen in a series
+ */
+export async function bulkGenerateSchichten(
+  serieId: string,
+  veranstaltungIds: string[]
+): Promise<{
+  success: boolean
+  results: BulkGenerateResult[]
+  successCount: number
+  errorCount: number
+}> {
+  await requirePermission('produktionen:write')
+
+  // Get preview to have all the data we need
+  const preview = await getBulkGeneratePreview(serieId)
+
+  const results: BulkGenerateResult[] = []
+  let successCount = 0
+  let errorCount = 0
+
+  // Filter to only selected veranstaltungen that have templates
+  const toProcess = preview.auffuehrungen.filter(
+    (a) =>
+      a.veranstaltungId &&
+      veranstaltungIds.includes(a.veranstaltungId) &&
+      a.templateId &&
+      !a.hasSchichten
+  )
+
+  // Process each veranstaltung
+  for (const auff of toProcess) {
+    try {
+      const result = await generateSchichtenFromTemplate(
+        auff.veranstaltungId!,
+        auff.templateId!
+      )
+
+      if (result.success) {
+        successCount++
+        results.push({
+          veranstaltungId: auff.veranstaltungId!,
+          titel: auff.titel,
+          datum: auff.datum,
+          wochentag: auff.wochentag,
+          templateName: auff.templateName ?? 'Unbekannt',
+          success: true,
+          zeitbloecke: result.zeitbloecke,
+          schichten: result.schichten,
+          slots: result.slots,
+        })
+      } else {
+        errorCount++
+        results.push({
+          veranstaltungId: auff.veranstaltungId!,
+          titel: auff.titel,
+          datum: auff.datum,
+          wochentag: auff.wochentag,
+          templateName: auff.templateName ?? 'Unbekannt',
+          success: false,
+          error: result.error,
+        })
+      }
+    } catch (error) {
+      errorCount++
+      results.push({
+        veranstaltungId: auff.veranstaltungId!,
+        titel: auff.titel,
+        datum: auff.datum,
+        wochentag: auff.wochentag,
+        templateName: auff.templateName ?? 'Unbekannt',
+        success: false,
+        error: error instanceof Error ? error.message : 'Unbekannter Fehler',
+      })
+    }
+  }
+
+  revalidatePath(`/produktionen`)
+  revalidatePath(`/auffuehrungen`)
+
+  return {
+    success: errorCount === 0,
+    results,
+    successCount,
+    errorCount,
+  }
+}

--- a/apps/web/lib/actions/schicht-generator.ts
+++ b/apps/web/lib/actions/schicht-generator.ts
@@ -1,0 +1,407 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { createClient } from '../supabase/server'
+import { requirePermission } from '../supabase/auth-helpers'
+import { getTemplate } from './templates'
+import type {
+  ZeitblockInsert,
+  AuffuehrungSchichtInsert,
+  InfoBlockInsert,
+  SachleistungInsert,
+} from '../supabase/types'
+
+/**
+ * Result of generating shifts from a template
+ */
+export type GenerateSchichtenResult = {
+  success: boolean
+  error?: string
+  zeitbloecke?: number
+  schichten?: number
+  slots?: number
+  infoBloecke?: number
+  sachleistungen?: number
+}
+
+/**
+ * Generate shifts from a template for a specific performance
+ *
+ * This is the core function of the shift generation system.
+ * It copies all template data (time blocks, shifts, info blocks, sachleistungen)
+ * and creates concrete instances with calculated times.
+ *
+ * @param veranstaltungId - The performance to generate shifts for
+ * @param templateId - The template to use
+ * @returns Result with counts of created items or error
+ */
+export async function generateSchichtenFromTemplate(
+  veranstaltungId: string,
+  templateId: string
+): Promise<GenerateSchichtenResult> {
+  // Check permission
+  await requirePermission('veranstaltungen:write')
+
+  const supabase = await createClient()
+
+  // Get the template with all details
+  const template = await getTemplate(templateId)
+  if (!template) {
+    return { success: false, error: 'Template nicht gefunden' }
+  }
+
+  // Get the veranstaltung to check start time and existing shifts
+  const { data: veranstaltung, error: veranstaltungError } = await supabase
+    .from('veranstaltungen')
+    .select('id, titel, datum, startzeit, helfer_status')
+    .eq('id', veranstaltungId)
+    .single()
+
+  if (veranstaltungError || !veranstaltung) {
+    console.error('Error fetching veranstaltung:', veranstaltungError)
+    return { success: false, error: 'Veranstaltung nicht gefunden' }
+  }
+
+  if (!veranstaltung.startzeit) {
+    return { success: false, error: 'Veranstaltung hat keine Startzeit' }
+  }
+
+  // Check if shifts already exist
+  const { count: existingSchichtenCount } = await supabase
+    .from('auffuehrung_schichten')
+    .select('id', { count: 'exact', head: true })
+    .eq('veranstaltung_id', veranstaltungId)
+
+  if (existingSchichtenCount && existingSchichtenCount > 0) {
+    return {
+      success: false,
+      error: `Diese Veranstaltung hat bereits ${existingSchichtenCount} Schichten. Bitte zuerst zuruecksetzen.`,
+    }
+  }
+
+  // Parse the start time
+  const [startHours, startMinutes] = veranstaltung.startzeit.split(':').map(Number)
+  const startTotalMinutes = startHours * 60 + startMinutes
+
+  // Helper function to convert offset minutes to TIME string
+  const minutesToTime = (totalMinutes: number): string => {
+    // Handle wrap-around for times past midnight
+    const normalizedMinutes = ((totalMinutes % 1440) + 1440) % 1440
+    const hours = Math.floor(normalizedMinutes / 60)
+    const minutes = normalizedMinutes % 60
+    return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`
+  }
+
+  let createdZeitbloecke = 0
+  let createdSchichten = 0
+  let createdSlots = 0
+  let createdInfoBloecke = 0
+  let createdSachleistungen = 0
+
+  // Map zeitblock name to created zeitblock ID
+  const zeitblockMap: Record<string, string> = {}
+
+  try {
+    // 1. Create zeitbloecke from template
+    if (template.zeitbloecke.length > 0) {
+      const zeitblockInserts: ZeitblockInsert[] = template.zeitbloecke.map((tz) => ({
+        veranstaltung_id: veranstaltungId,
+        name: tz.name,
+        startzeit: minutesToTime(startTotalMinutes + tz.offset_minuten),
+        endzeit: minutesToTime(startTotalMinutes + tz.offset_minuten + tz.dauer_minuten),
+        typ: tz.typ,
+        sortierung: tz.sortierung,
+      }))
+
+      const { data: createdZeitblockData, error: zeitblockError } = await supabase
+        .from('zeitbloecke')
+        .insert(zeitblockInserts as never[])
+        .select('id, name')
+
+      if (zeitblockError) {
+        console.error('Error creating zeitbloecke:', zeitblockError)
+        throw new Error('Fehler beim Erstellen der Zeitbloecke')
+      }
+
+      // Build name -> id mapping
+      createdZeitblockData?.forEach((zb) => {
+        zeitblockMap[zb.name] = zb.id
+      })
+
+      createdZeitbloecke = createdZeitblockData?.length ?? 0
+    }
+
+    // 2. Create schichten from template
+    if (template.schichten.length > 0) {
+      const schichtInserts: AuffuehrungSchichtInsert[] = template.schichten.map((ts) => ({
+        veranstaltung_id: veranstaltungId,
+        zeitblock_id: ts.zeitblock_name ? zeitblockMap[ts.zeitblock_name] ?? null : null,
+        rolle: ts.rolle,
+        anzahl_benoetigt: ts.anzahl_benoetigt,
+      }))
+
+      const { data: createdSchichtData, error: schichtError } = await supabase
+        .from('auffuehrung_schichten')
+        .insert(schichtInserts as never[])
+        .select('id, anzahl_benoetigt')
+
+      if (schichtError) {
+        console.error('Error creating schichten:', schichtError)
+        throw new Error('Fehler beim Erstellen der Schichten')
+      }
+
+      createdSchichten = createdSchichtData?.length ?? 0
+
+      // Count total slots (sum of anzahl_benoetigt)
+      createdSlots = createdSchichtData?.reduce((sum, s) => sum + s.anzahl_benoetigt, 0) ?? 0
+    }
+
+    // 3. Create info_bloecke from template
+    if (template.info_bloecke && template.info_bloecke.length > 0) {
+      const infoBlockInserts: InfoBlockInsert[] = template.info_bloecke.map((ib) => ({
+        veranstaltung_id: veranstaltungId,
+        titel: ib.titel,
+        beschreibung: ib.beschreibung,
+        startzeit: minutesToTime(startTotalMinutes + ib.offset_minuten),
+        endzeit: minutesToTime(startTotalMinutes + ib.offset_minuten + ib.dauer_minuten),
+        sortierung: ib.sortierung,
+      }))
+
+      const { data: createdInfoData, error: infoBlockError } = await supabase
+        .from('info_bloecke')
+        .insert(infoBlockInserts as never[])
+        .select('id')
+
+      if (infoBlockError) {
+        console.error('Error creating info_bloecke:', infoBlockError)
+        // Don't throw, info blocks are not critical
+      } else {
+        createdInfoBloecke = createdInfoData?.length ?? 0
+      }
+    }
+
+    // 4. Create sachleistungen from template
+    if (template.sachleistungen && template.sachleistungen.length > 0) {
+      const sachleistungInserts: SachleistungInsert[] = template.sachleistungen.map((sl) => ({
+        veranstaltung_id: veranstaltungId,
+        name: sl.name,
+        anzahl: sl.anzahl,
+        beschreibung: sl.beschreibung,
+      }))
+
+      const { data: createdSachData, error: sachleistungError } = await supabase
+        .from('sachleistungen')
+        .insert(sachleistungInserts as never[])
+        .select('id')
+
+      if (sachleistungError) {
+        console.error('Error creating sachleistungen:', sachleistungError)
+        // Don't throw, sachleistungen are not critical
+      } else {
+        createdSachleistungen = createdSachData?.length ?? 0
+      }
+    }
+
+    // 5. Update veranstaltung with template reference and status
+    const { error: updateError } = await supabase
+      .from('veranstaltungen')
+      .update({
+        helfer_template_id: templateId,
+        helfer_status: 'entwurf',
+      } as never)
+      .eq('id', veranstaltungId)
+
+    if (updateError) {
+      console.error('Error updating veranstaltung:', updateError)
+      // Don't throw, this is informational
+    }
+
+    // Revalidate paths
+    revalidatePath(`/auffuehrungen/${veranstaltungId}`)
+    revalidatePath(`/auffuehrungen/${veranstaltungId}/schichten`)
+    revalidatePath(`/auffuehrungen/${veranstaltungId}/helfer-koordination`)
+    revalidatePath('/auffuehrungen')
+
+    return {
+      success: true,
+      zeitbloecke: createdZeitbloecke,
+      schichten: createdSchichten,
+      slots: createdSlots,
+      infoBloecke: createdInfoBloecke,
+      sachleistungen: createdSachleistungen,
+    }
+  } catch (error) {
+    console.error('Error in generateSchichtenFromTemplate:', error)
+
+    // Attempt to clean up on error (rollback)
+    // Note: Supabase doesn't support true transactions in the JS client,
+    // so we do manual cleanup
+    try {
+      await supabase
+        .from('zeitbloecke')
+        .delete()
+        .eq('veranstaltung_id', veranstaltungId)
+
+      await supabase
+        .from('auffuehrung_schichten')
+        .delete()
+        .eq('veranstaltung_id', veranstaltungId)
+
+      await supabase
+        .from('info_bloecke')
+        .delete()
+        .eq('veranstaltung_id', veranstaltungId)
+
+      await supabase
+        .from('sachleistungen')
+        .delete()
+        .eq('veranstaltung_id', veranstaltungId)
+    } catch (cleanupError) {
+      console.error('Error during cleanup:', cleanupError)
+    }
+
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Ein unerwarteter Fehler ist aufgetreten',
+    }
+  }
+}
+
+/**
+ * Reset (delete) all generated shifts for a veranstaltung
+ * This allows re-generating from a different template
+ */
+export async function resetSchichten(
+  veranstaltungId: string
+): Promise<{ success: boolean; error?: string }> {
+  // Only admins can reset shifts
+  await requirePermission('admin:access')
+
+  const supabase = await createClient()
+
+  try {
+    // Delete all related data
+    const { error: zeitblockError } = await supabase
+      .from('zeitbloecke')
+      .delete()
+      .eq('veranstaltung_id', veranstaltungId)
+
+    if (zeitblockError) {
+      console.error('Error deleting zeitbloecke:', zeitblockError)
+      throw new Error('Fehler beim Loeschen der Zeitbloecke')
+    }
+
+    const { error: schichtError } = await supabase
+      .from('auffuehrung_schichten')
+      .delete()
+      .eq('veranstaltung_id', veranstaltungId)
+
+    if (schichtError) {
+      console.error('Error deleting schichten:', schichtError)
+      throw new Error('Fehler beim Loeschen der Schichten')
+    }
+
+    const { error: infoError } = await supabase
+      .from('info_bloecke')
+      .delete()
+      .eq('veranstaltung_id', veranstaltungId)
+
+    if (infoError) {
+      console.error('Error deleting info_bloecke:', infoError)
+      // Non-critical, continue
+    }
+
+    const { error: sachError } = await supabase
+      .from('sachleistungen')
+      .delete()
+      .eq('veranstaltung_id', veranstaltungId)
+
+    if (sachError) {
+      console.error('Error deleting sachleistungen:', sachError)
+      // Non-critical, continue
+    }
+
+    // Reset template reference and status
+    const { error: updateError } = await supabase
+      .from('veranstaltungen')
+      .update({
+        helfer_template_id: null,
+        helfer_status: null,
+      } as never)
+      .eq('id', veranstaltungId)
+
+    if (updateError) {
+      console.error('Error resetting veranstaltung:', updateError)
+    }
+
+    // Revalidate paths
+    revalidatePath(`/auffuehrungen/${veranstaltungId}`)
+    revalidatePath(`/auffuehrungen/${veranstaltungId}/schichten`)
+    revalidatePath(`/auffuehrungen/${veranstaltungId}/helfer-koordination`)
+    revalidatePath('/auffuehrungen')
+
+    return { success: true }
+  } catch (error) {
+    console.error('Error in resetSchichten:', error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Ein unerwarteter Fehler ist aufgetreten',
+    }
+  }
+}
+
+/**
+ * Get the current state of shifts for a veranstaltung
+ */
+export async function getSchichtenStatus(veranstaltungId: string): Promise<{
+  hasSchichten: boolean
+  zeitbloeckeCount: number
+  schichtenCount: number
+  slotsCount: number
+  zugewiesenCount: number
+  templateId: string | null
+  status: string | null
+}> {
+  const supabase = await createClient()
+
+  // Get veranstaltung info
+  const { data: veranstaltung } = await supabase
+    .from('veranstaltungen')
+    .select('helfer_template_id, helfer_status')
+    .eq('id', veranstaltungId)
+    .single()
+
+  // Count zeitbloecke
+  const { count: zeitbloeckeCount } = await supabase
+    .from('zeitbloecke')
+    .select('id', { count: 'exact', head: true })
+    .eq('veranstaltung_id', veranstaltungId)
+
+  // Count schichten and sum anzahl_benoetigt
+  const { data: schichten } = await supabase
+    .from('auffuehrung_schichten')
+    .select('id, anzahl_benoetigt')
+    .eq('veranstaltung_id', veranstaltungId)
+
+  const schichtenCount = schichten?.length ?? 0
+  const slotsCount = schichten?.reduce((sum, s) => sum + s.anzahl_benoetigt, 0) ?? 0
+
+  // Count zuweisungen
+  const { count: zugewiesenCount } = await supabase
+    .from('auffuehrung_zuweisungen')
+    .select('id', { count: 'exact', head: true })
+    .in(
+      'schicht_id',
+      schichten?.map((s) => s.id) ?? []
+    )
+
+  return {
+    hasSchichten: schichtenCount > 0,
+    zeitbloeckeCount: zeitbloeckeCount ?? 0,
+    schichtenCount,
+    slotsCount,
+    zugewiesenCount: zugewiesenCount ?? 0,
+    templateId: veranstaltung?.helfer_template_id ?? null,
+    status: veranstaltung?.helfer_status ?? null,
+  }
+}

--- a/apps/web/lib/supabase/types.ts
+++ b/apps/web/lib/supabase/types.ts
@@ -296,6 +296,8 @@ export type VeranstaltungStatus =
   | 'abgesagt'
   | 'abgeschlossen'
 
+export type HelferStatus = 'entwurf' | 'veroeffentlicht' | 'abgeschlossen'
+
 export type Veranstaltung = {
   id: string
   titel: string
@@ -309,14 +311,19 @@ export type Veranstaltung = {
   organisator_id: string | null
   typ: VeranstaltungTyp
   status: VeranstaltungStatus
+  helfer_template_id: string | null
+  helfer_status: HelferStatus | null
   created_at: string
   updated_at: string
 }
 
 export type VeranstaltungInsert = Omit<
   Veranstaltung,
-  'id' | 'created_at' | 'updated_at'
->
+  'id' | 'created_at' | 'updated_at' | 'helfer_template_id' | 'helfer_status'
+> & {
+  helfer_template_id?: string | null
+  helfer_status?: HelferStatus | null
+}
 export type VeranstaltungUpdate = Partial<VeranstaltungInsert>
 
 export type AnmeldungStatus =
@@ -1274,6 +1281,38 @@ export type SerienauffuehrungInsert = Omit<
   'id' | 'created_at' | 'updated_at'
 >
 export type SerienauffuehrungUpdate = Partial<SerienauffuehrungInsert>
+
+// =============================================================================
+// Produktions-Serie Template-Zuweisung (Issue #207)
+// =============================================================================
+
+export type Wochentag = 0 | 1 | 2 | 3 | 4 | 5 | 6
+
+export const WOCHENTAG_LABELS: Record<Wochentag, string> = {
+  0: 'Sonntag',
+  1: 'Montag',
+  2: 'Dienstag',
+  3: 'Mittwoch',
+  4: 'Donnerstag',
+  5: 'Freitag',
+  6: 'Samstag',
+}
+
+export type ProduktionsSerieTemplate = {
+  id: string
+  serie_id: string
+  wochentag: Wochentag
+  template_id: string
+  created_at: string
+}
+
+export type ProduktionsSerieTemplateInsert = Omit<ProduktionsSerieTemplate, 'id' | 'created_at'>
+export type ProduktionsSerieTemplateUpdate = Partial<ProduktionsSerieTemplateInsert>
+
+// Extended type with template details
+export type ProduktionsSerieTemplateMitDetails = ProduktionsSerieTemplate & {
+  template: Pick<AuffuehrungTemplate, 'id' | 'name'>
+}
 
 export type ProduktionsStab = {
   id: string

--- a/supabase/migrations/20260205013903_schicht_generator.sql
+++ b/supabase/migrations/20260205013903_schicht_generator.sql
@@ -1,0 +1,27 @@
+-- Migration: Schicht Generator Support (Issue #205)
+-- Created: 2026-02-05
+-- Description: Add columns to track template usage and helper status on veranstaltungen
+
+-- =============================================================================
+-- ADD COLUMNS TO veranstaltungen
+-- =============================================================================
+
+-- Add helfer_template_id to track which template was used
+ALTER TABLE veranstaltungen
+ADD COLUMN IF NOT EXISTS helfer_template_id UUID REFERENCES auffuehrung_templates(id) ON DELETE SET NULL;
+
+-- Add helfer_status to track the status of helper coordination
+-- Possible values: null (not started), 'entwurf' (draft), 'veroeffentlicht' (published), 'abgeschlossen' (completed)
+ALTER TABLE veranstaltungen
+ADD COLUMN IF NOT EXISTS helfer_status TEXT CHECK (helfer_status IS NULL OR helfer_status IN ('entwurf', 'veroeffentlicht', 'abgeschlossen'));
+
+-- Create index for quick lookups
+CREATE INDEX IF NOT EXISTS veranstaltungen_helfer_template_idx ON veranstaltungen(helfer_template_id);
+CREATE INDEX IF NOT EXISTS veranstaltungen_helfer_status_idx ON veranstaltungen(helfer_status);
+
+-- =============================================================================
+-- COMMENTS
+-- =============================================================================
+
+COMMENT ON COLUMN veranstaltungen.helfer_template_id IS 'Reference to the template used to generate shifts. NULL if no template was used.';
+COMMENT ON COLUMN veranstaltungen.helfer_status IS 'Status of helper coordination: NULL (not started), entwurf (draft), veroeffentlicht (published), abgeschlossen (completed)';

--- a/supabase/migrations/20260205085111_produktions_serie_templates.sql
+++ b/supabase/migrations/20260205085111_produktions_serie_templates.sql
@@ -1,0 +1,58 @@
+-- Migration: Produktions-Serie Template-Zuweisung (Issue #207)
+-- Created: 2026-02-05
+-- Description: Weekday-based template mapping for series bulk generation
+
+-- =============================================================================
+-- TABLE: produktions_serie_templates (Weekday-based template mapping)
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS produktions_serie_templates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  serie_id UUID NOT NULL REFERENCES auffuehrungsserien(id) ON DELETE CASCADE,
+  wochentag INTEGER NOT NULL CHECK (wochentag BETWEEN 0 AND 6),
+  template_id UUID NOT NULL REFERENCES auffuehrung_templates(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(serie_id, wochentag)
+);
+
+-- Enable Row Level Security
+ALTER TABLE produktions_serie_templates ENABLE ROW LEVEL SECURITY;
+
+-- Policy: All authenticated users can read
+CREATE POLICY "produktions_serie_templates_select"
+  ON produktions_serie_templates FOR SELECT
+  TO authenticated
+  USING (true);
+
+-- Policy: Management can insert
+CREATE POLICY "produktions_serie_templates_insert"
+  ON produktions_serie_templates FOR INSERT
+  TO authenticated
+  WITH CHECK (is_management());
+
+-- Policy: Management can update
+CREATE POLICY "produktions_serie_templates_update"
+  ON produktions_serie_templates FOR UPDATE
+  TO authenticated
+  USING (is_management())
+  WITH CHECK (is_management());
+
+-- Policy: Management can delete
+CREATE POLICY "produktions_serie_templates_delete"
+  ON produktions_serie_templates FOR DELETE
+  TO authenticated
+  USING (is_management());
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_produktions_serie_templates_serie
+  ON produktions_serie_templates(serie_id);
+
+CREATE INDEX IF NOT EXISTS idx_produktions_serie_templates_template
+  ON produktions_serie_templates(template_id);
+
+-- =============================================================================
+-- COMMENTS
+-- =============================================================================
+
+COMMENT ON TABLE produktions_serie_templates IS 'Maps weekdays to templates for bulk shift generation in series';
+COMMENT ON COLUMN produktions_serie_templates.wochentag IS 'Day of week: 0=Sunday, 1=Monday, ..., 6=Saturday';


### PR DESCRIPTION
## Summary
- Erweitert `auffuehrungsserien` mit `stueck_id`, `datum_von`, `datum_bis` (#201)
- Erstellt `template_info_bloecke` und `info_bloecke` Tabellen für Info-Blöcke (#203)
- Erstellt `template_sachleistungen` und `sachleistungen` Tabellen (#202)
- Seedet "Abendvorstellung" Template mit 10 Schichten und 2 Info-Blöcken
- Erweitert TypeScript-Typen und Zod-Validierungen
- Erweitert TemplateDetailEditor UI mit Info-Blöcke und Sachleistungen Sektionen
- Erweitert `applyTemplate()` um Info-Blöcke und Sachleistungen zu übertragen

## Betroffene Dateien
- 3 neue Migrationen in `supabase/migrations/`
- `apps/web/lib/supabase/types.ts`
- `apps/web/lib/actions/templates.ts`
- `apps/web/lib/validations/modul2.ts`
- `apps/web/components/templates/TemplateDetailEditor.tsx`

## Closes
- Closes #201
- Closes #202
- Closes #203

## Test plan
- [x] Migrationen erfolgreich ausführen
- [x] Templates-Seite öffnen und Info-Blöcke hinzufügen/entfernen
- [x] Sachleistungen hinzufügen/entfernen
- [x] Template auf Veranstaltung anwenden und prüfen ob Info-Blöcke/Sachleistungen übertragen werden

🤖 Generated with [Claude Code](https://claude.ai/claude-code)