### PR TITLE
docs: M1 Datenmodell & Templates Dokumentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Hier sammeln wir Projekt- und Fachdokumentation (z. B. Architektur, Entscheidung
 ### 🎭 **Projekt Dokumentation:**
 - [BackstagePass – Detailkonzept der drei Kernmodule](backstagepass-module-details.md)
 - [BackstagePass – High-Level Architecture](architecture/backstagepass-architecture.md)
+- [Database Schema: Modul 2](architecture/database-schema-modul2.md)
 - [Teamrollen & Workflow](team.md)
 - [Kanban-Board](kanban.md)
 - [Mitarbeiter Beschreibungen](mitarbeiter-beschreibungen.md)
@@ -43,7 +44,8 @@ docs/
 │   ├── backstagepass-module-details.md (Module Konzepte)
 │   ├── kanban.md                       (Kanban Board)
 │   └── architecture/
-│       └── backstagepass-architecture.md (High-Level Architecture)
+│       ├── backstagepass-architecture.md (High-Level Architecture)
+│       └── database-schema-modul2.md  (Database Schema Modul 2)
 │
 ├── 📊 STRATEGIE & PLANUNG
 │   ├── strategy/
@@ -63,13 +65,22 @@ docs/
 | "Meine API Keys funktionieren nicht" | [VSCODE-SECRETS-SETUP.md](VSCODE-SECRETS-SETUP.md) |
 | "Welche Keybinding war das?" | [VSCODE-QUICK-REFERENCE.md](VSCODE-QUICK-REFERENCE.md) |
 | "Wie ist die Architektur?" | [architecture/backstagepass-architecture.md](architecture/backstagepass-architecture.md) |
+| "Wie ist das Datenmodell?" | [architecture/database-schema-modul2.md](architecture/database-schema-modul2.md) |
 | "Wer hat welche Rolle?" | [team.md](team.md) |
 | "Was ist im Kanban?" | [kanban.md](kanban.md) |
 | "Ich verstehe VS Code Setup nicht" | [VS-CODE-SETUP-GUIDE.md](VS-CODE-SETUP-GUIDE.md) |
 | "Visuelle Erklärung?" | [VSCODE-SETUP-VISUALS.md](VSCODE-SETUP-VISUALS.md) |
 
-## ✨ Highlights (2026-01-26 Update)
+## ✨ Highlights
 
+### 2026-02-05 Update
+🆕 **M1: Datenmodell & Templates dokumentiert:**
+- ✅ ADR-001: Offset-Based Template Times
+- ✅ Vollständige Datenbank-Schema Dokumentation (Modul 2)
+- ✅ Implementation Log mit technischen Details
+- ✅ Journal-Eintrag mit Lessons Learned
+
+### 2026-01-26 Update
 🆕 **Komplettes VS Code Multi-Device Setup hinzugefügt:**
 - ✅ Automatische Extension Synchronisierung
 - ✅ Settings Sync zwischen Geräten
@@ -78,5 +89,3 @@ docs/
 - ✅ Sicherheits-Best-Practices
 - ✅ Troubleshooting Guides
 - ✅ Visuelle Diagramme
-
-**Total neue Dokumentation:** ~10,000 Zeilen

--- a/docs/architecture/database-schema-modul2.md
+++ b/docs/architecture/database-schema-modul2.md
@@ -1,0 +1,523 @@
+# Database Schema: Modul 2 - Produktion & Logistik
+
+**Version:** 1.0
+**Date:** 2026-02-05
+**Status:** Current
+
+## Overview
+
+This document describes the database schema for Modul 2 (Produktion & Logistik), which manages performance series, templates, and helper scheduling for the Theatergruppe Widen.
+
+## Core Concepts
+
+### Two-Level Architecture
+
+The system uses a **template-instance pattern** where reusable templates are defined once and applied to create concrete instances:
+
+```
+TEMPLATE LEVEL (Reusable)          INSTANCE LEVEL (Concrete)
+├── auffuehrung_templates     →    ├── auffuehrungsserien
+├── template_zeitbloecke      →    │   └── (generates) auffuehrungen
+├── template_info_bloecke     →    ├── auffuehrung_schichten
+└── template_sachleistungen   →    ├── info_bloecke
+                                   └── sachleistungen
+```
+
+## Entity Relationship Diagram
+
+```
+┌─────────────────┐
+│     stuecke     │
+│   (Play/Show)   │
+└────────┬────────┘
+         │
+         │ 1:N
+         ▼
+┌─────────────────────────┐
+│  auffuehrungsserien     │
+│  (Performance Series)   │
+│  ──────────────────────│
+│  • stueck_id            │
+│  • datum_von, datum_bis │
+│  • template_id          │
+└────────┬────────────────┘
+         │
+         │ 1:N (generated)
+         ▼
+┌─────────────────────────┐
+│    auffuehrungen        │
+│    (Performances)       │
+│    ─────────────────   │
+│    • serie_id           │
+│    • datum, start_zeit  │
+└────────┬────────────────┘
+         │
+         ├─────────────────┐
+         │                 │
+         │ 1:N             │ 1:N
+         ▼                 ▼
+┌──────────────────┐  ┌─────────────────┐
+│ auffuehrung_     │  │  info_bloecke   │
+│ schichten        │  │  (Info Blocks)  │
+│ (Shifts)         │  │  ──────────────│
+│ ──────────────  │  │  • start_zeit   │
+│ • start_zeit     │  └─────────────────┘
+│ • end_zeit       │
+│ • slots          │
+└────────┬─────────┘
+         │
+         │ 1:N
+         ▼
+┌──────────────────┐
+│ auffuehrung_     │
+│ zuweisungen      │
+│ (Assignments)    │
+│ ──────────────  │
+│ • person_id      │
+│ • slot_nummer    │
+└──────────────────┘
+
+┌─────────────────────────┐
+│ auffuehrung_templates   │
+│ (Templates)             │
+│ ─────────────────────  │
+│ • name                  │
+│ • beschreibung          │
+└────────┬────────────────┘
+         │
+         ├──────────────────┬────────────────────┐
+         │                  │                    │
+         │ 1:N              │ 1:N                │ 1:N
+         ▼                  ▼                    ▼
+┌──────────────────┐  ┌─────────────────┐  ┌─────────────────┐
+│ template_        │  │ template_       │  │ template_       │
+│ zeitbloecke      │  │ info_bloecke    │  │ sachleistungen  │
+│ (Shift Templates)│  │ (Info Templates)│  │ (Contributions) │
+│ ──────────────  │  │ ──────────────  │  │ ──────────────  │
+│ • start_offset_  │  │ • offset_       │  │ • bezeichnung   │
+│   minuten        │  │   minuten       │  │ • menge         │
+│ • dauer_minuten  │  └─────────────────┘  └─────────────────┘
+└──────────────────┘
+```
+
+## Tables
+
+### 1. auffuehrungsserien
+
+Performance series serve as the master planning level for a set of related performances.
+
+```sql
+CREATE TABLE auffuehrungsserien (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  titel TEXT NOT NULL,
+  stueck_id UUID REFERENCES stuecke(id) ON DELETE SET NULL,
+  datum_von DATE,
+  datum_bis DATE,
+  template_id UUID REFERENCES auffuehrung_templates(id) ON DELETE SET NULL,
+  beschreibung TEXT,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+```
+
+**Purpose:** Groups multiple performances (e.g., "Summer Run 2026") and associates them with a play and template.
+
+**Key Fields:**
+- `stueck_id` - Link to the play being performed (optional)
+- `datum_von/datum_bis` - Date range for the series
+- `template_id` - Default template for performances in this series
+
+**Extended:** Migration `20260205000000_auffuehrungsserien_erweitern.sql`
+
+### 2. auffuehrungen
+
+Individual performances generated from a series or created standalone.
+
+```sql
+CREATE TABLE auffuehrungen (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  serie_id UUID REFERENCES auffuehrungsserien(id) ON DELETE CASCADE,
+  titel TEXT NOT NULL,
+  datum DATE NOT NULL,
+  start_zeit TIMESTAMPTZ NOT NULL,
+  ort TEXT,
+  beschreibung TEXT,
+  status TEXT DEFAULT 'geplant',
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+```
+
+**Purpose:** Represents a single performance with a specific date and time.
+
+**Status Values:** `geplant`, `publiziert`, `ausverkauft`, `abgeschlossen`, `abgesagt`
+
+### 3. template_info_bloecke
+
+Template-level information blocks using offset-based timing.
+
+```sql
+CREATE TABLE template_info_bloecke (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  template_id UUID NOT NULL REFERENCES auffuehrung_templates(id) ON DELETE CASCADE,
+  titel TEXT NOT NULL,
+  beschreibung TEXT,
+  offset_minuten INTEGER NOT NULL,
+  sortierung INTEGER DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  CONSTRAINT valid_offset CHECK (
+    offset_minuten >= -480 AND offset_minuten <= 480
+  )
+);
+```
+
+**Purpose:** Define reusable information markers (e.g., "Einlass", "Pause") relative to performance start.
+
+**Key Fields:**
+- `offset_minuten` - Minutes before (negative) or after (positive) performance start
+- `sortierung` - Display order in UI
+
+**Offset Range:** -480 to +480 minutes (-8h to +8h)
+
+**Created:** Migration `20260205000001_template_info_bloecke.sql`
+
+### 4. info_bloecke
+
+Instance-level information blocks with calculated absolute times.
+
+```sql
+CREATE TABLE info_bloecke (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  auffuehrung_id UUID NOT NULL REFERENCES auffuehrungen(id) ON DELETE CASCADE,
+  template_info_block_id UUID REFERENCES template_info_bloecke(id) ON DELETE SET NULL,
+  titel TEXT NOT NULL,
+  beschreibung TEXT,
+  start_zeit TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+```
+
+**Purpose:** Concrete information blocks for a specific performance with absolute times.
+
+**Key Fields:**
+- `template_info_block_id` - Reference to source template (nullable for manual entries)
+- `start_zeit` - Calculated from template offset or manually set
+
+**Created:** Migration `20260205000001_template_info_bloecke.sql`
+
+### 5. template_sachleistungen
+
+Template-level in-kind contributions (Sachleistungen).
+
+```sql
+CREATE TABLE template_sachleistungen (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  template_id UUID NOT NULL REFERENCES auffuehrung_templates(id) ON DELETE CASCADE,
+  bezeichnung TEXT NOT NULL,
+  beschreibung TEXT,
+  menge NUMERIC(10,2) NOT NULL DEFAULT 0,
+  einheit TEXT,
+  sortierung INTEGER DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  CONSTRAINT positive_menge CHECK (menge > 0)
+);
+```
+
+**Purpose:** Define reusable contribution types (e.g., "Kuchen für Pause", "Blumendeko").
+
+**Key Fields:**
+- `menge` - Quantity (numeric with 2 decimal places)
+- `einheit` - Unit of measurement (e.g., "Stück", "kg", "Liter")
+- `sortierung` - Display order
+
+**Created:** Migration `20260205000002_template_sachleistungen.sql`
+
+### 6. sachleistungen
+
+Instance-level in-kind contributions for specific performances.
+
+```sql
+CREATE TABLE sachleistungen (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  auffuehrung_id UUID NOT NULL REFERENCES auffuehrungen(id) ON DELETE CASCADE,
+  template_sachleistung_id UUID REFERENCES template_sachleistungen(id) ON DELETE SET NULL,
+  bezeichnung TEXT NOT NULL,
+  beschreibung TEXT,
+  menge NUMERIC(10,2) NOT NULL DEFAULT 0,
+  einheit TEXT,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  CONSTRAINT positive_menge CHECK (menge > 0)
+);
+```
+
+**Purpose:** Track actual contributions for a specific performance.
+
+**Key Fields:**
+- `template_sachleistung_id` - Reference to source template (nullable)
+- Can be manually adjusted after template application
+
+**Created:** Migration `20260205000002_template_sachleistungen.sql`
+
+### 7. template_zeitbloecke
+
+Template-level shift definitions with offset-based timing.
+
+```sql
+CREATE TABLE template_zeitbloecke (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  template_id UUID NOT NULL REFERENCES auffuehrung_templates(id) ON DELETE CASCADE,
+  titel TEXT NOT NULL,
+  beschreibung TEXT,
+  start_offset_minuten INTEGER NOT NULL,
+  dauer_minuten INTEGER NOT NULL,
+  slots INTEGER NOT NULL DEFAULT 1,
+  helferrolle_id UUID REFERENCES helferrollen(id) ON DELETE SET NULL,
+  sortierung INTEGER DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  CONSTRAINT valid_offset CHECK (
+    start_offset_minuten >= -480 AND start_offset_minuten <= 480
+  ),
+  CONSTRAINT positive_duration CHECK (dauer_minuten > 0),
+  CONSTRAINT positive_slots CHECK (slots > 0)
+);
+```
+
+**Purpose:** Define reusable shift patterns with relative timing.
+
+**Key Fields:**
+- `start_offset_minuten` - Start time relative to performance
+- `dauer_minuten` - Duration in minutes
+- `slots` - Number of helper positions needed
+- `helferrolle_id` - Optional role requirement
+
+### 8. auffuehrung_schichten
+
+Instance-level shifts with absolute times.
+
+```sql
+CREATE TABLE auffuehrung_schichten (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  auffuehrung_id UUID NOT NULL REFERENCES auffuehrungen(id) ON DELETE CASCADE,
+  template_zeitblock_id UUID REFERENCES template_zeitbloecke(id) ON DELETE SET NULL,
+  titel TEXT NOT NULL,
+  beschreibung TEXT,
+  start_zeit TIMESTAMPTZ NOT NULL,
+  end_zeit TIMESTAMPTZ NOT NULL,
+  slots INTEGER NOT NULL DEFAULT 1,
+  helferrolle_id UUID REFERENCES helferrollen(id) ON DELETE SET NULL,
+  status TEXT DEFAULT 'offen',
+  created_at TIMESTAMPTZ DEFAULT now(),
+  CONSTRAINT valid_time_range CHECK (end_zeit > start_zeit),
+  CONSTRAINT positive_slots CHECK (slots > 0)
+);
+```
+
+**Purpose:** Concrete shifts for a specific performance with calculated times.
+
+**Status Values:** `offen`, `teilweise`, `voll`, `geschlossen`
+
+## Indexes
+
+```sql
+-- Performance lookups
+CREATE INDEX idx_auffuehrungen_serie ON auffuehrungen(serie_id);
+CREATE INDEX idx_auffuehrungen_datum ON auffuehrungen(datum);
+CREATE INDEX idx_auffuehrungen_start_zeit ON auffuehrungen(start_zeit);
+
+-- Template relationships
+CREATE INDEX idx_template_info_bloecke_template ON template_info_bloecke(template_id);
+CREATE INDEX idx_template_sachleistungen_template ON template_sachleistungen(template_id);
+CREATE INDEX idx_template_zeitbloecke_template ON template_zeitbloecke(template_id);
+
+-- Instance lookups
+CREATE INDEX idx_info_bloecke_auffuehrung ON info_bloecke(auffuehrung_id);
+CREATE INDEX idx_sachleistungen_auffuehrung ON sachleistungen(auffuehrung_id);
+CREATE INDEX idx_auffuehrung_schichten_auffuehrung ON auffuehrung_schichten(auffuehrung_id);
+
+-- Template traceability
+CREATE INDEX idx_info_bloecke_template_source ON info_bloecke(template_info_block_id);
+CREATE INDEX idx_sachleistungen_template_source ON sachleistungen(template_sachleistung_id);
+CREATE INDEX idx_schichten_template_source ON auffuehrung_schichten(template_zeitblock_id);
+```
+
+## Row Level Security (RLS)
+
+All tables have RLS enabled. Standard policies:
+
+```sql
+-- SELECT: All authenticated users
+CREATE POLICY "authenticated_read" ON table_name
+  FOR SELECT TO authenticated
+  USING (true);
+
+-- INSERT/UPDATE/DELETE: Management only (ADMIN + VORSTAND)
+CREATE POLICY "management_write" ON table_name
+  FOR ALL TO authenticated
+  USING (is_management());
+```
+
+**Helper Function:**
+```sql
+CREATE OR REPLACE FUNCTION is_management()
+RETURNS BOOLEAN AS $$
+BEGIN
+  RETURN EXISTS (
+    SELECT 1 FROM profiles
+    WHERE id = auth.uid()
+    AND role IN ('ADMIN', 'VORSTAND')
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+```
+
+## Offset-Based Time System
+
+### Concept
+
+Templates store relative times (offsets) that are converted to absolute times when applied to performances.
+
+### Calculation Formula
+
+```
+absolute_time = performance_start_time + (offset_minutes * interval '1 minute')
+```
+
+### Example
+
+```
+Performance Start: 2026-06-15 19:00:00
+
+Template Shift:
+- start_offset_minuten: -120 (2 hours before)
+- dauer_minuten: 180 (3 hours)
+
+Calculated Instance:
+- start_zeit: 2026-06-15 17:00:00  (19:00 - 2h)
+- end_zeit: 2026-06-15 20:00:00    (17:00 + 3h)
+```
+
+### Validation Constraints
+
+```sql
+CONSTRAINT valid_offset CHECK (
+  offset_minuten >= -480 AND   -- Up to 8 hours before
+  offset_minuten <= 480         -- Up to 8 hours after
+)
+```
+
+**Rationale:** See [ADR-001: Offset-Based Template Times](../../journal/decisions/ADR-001-offset-based-template-times.md)
+
+## Seed Data
+
+### Default Template: "Abendvorstellung"
+
+Created in migration `20260205000002_template_sachleistungen.sql`:
+
+**10 Shifts:**
+1. Einlass: -60 min, 60 min duration, 3 slots
+2. Kasse: -90 min, 90 min duration, 2 slots
+3. Service Runde 1: -120 min, 120 min duration, 4 slots
+4. Service Runde 2: +15 min, 120 min duration, 4 slots
+5. Bar: -90 min, 240 min duration, 2 slots
+6. Garderobe: -90 min, 240 min duration, 2 slots
+7. Technik Auf-/Abbau: -240 min, 480 min duration, 2 slots
+8. Technik Show: -90 min, 180 min duration, 1 slot
+9. Inspizienz: -90 min, 180 min duration, 1 slot
+10. Requisite: -120 min, 210 min duration, 1 slot
+
+**2 Info Blocks:**
+1. Einlass: -30 min
+2. Vorstellung Beginn: 0 min
+
+## Migration History
+
+| Date | File | Description |
+|------|------|-------------|
+| 2026-02-05 | `20260205000000_auffuehrungsserien_erweitern.sql` | Extended series with stueck_id, date range |
+| 2026-02-05 | `20260205000001_template_info_bloecke.sql` | Added info blocks (template + instance) |
+| 2026-02-05 | `20260205000002_template_sachleistungen.sql` | Added sachleistungen + seed data |
+
+## Usage Examples
+
+### Query 1: Get Template with All Components
+
+```sql
+SELECT
+  t.id,
+  t.name,
+  t.beschreibung,
+  json_agg(DISTINCT tz.*) FILTER (WHERE tz.id IS NOT NULL) AS zeitbloecke,
+  json_agg(DISTINCT ib.*) FILTER (WHERE ib.id IS NOT NULL) AS info_bloecke,
+  json_agg(DISTINCT sl.*) FILTER (WHERE sl.id IS NOT NULL) AS sachleistungen
+FROM auffuehrung_templates t
+LEFT JOIN template_zeitbloecke tz ON tz.template_id = t.id
+LEFT JOIN template_info_bloecke ib ON ib.template_id = t.id
+LEFT JOIN template_sachleistungen sl ON sl.template_id = t.id
+WHERE t.id = $1
+GROUP BY t.id;
+```
+
+### Query 2: Get Performance with Shifts and Info Blocks
+
+```sql
+SELECT
+  a.id,
+  a.titel,
+  a.start_zeit,
+  json_agg(DISTINCT s.*) FILTER (WHERE s.id IS NOT NULL) AS schichten,
+  json_agg(DISTINCT ib.*) FILTER (WHERE ib.id IS NOT NULL) AS info_bloecke,
+  json_agg(DISTINCT sl.*) FILTER (WHERE sl.id IS NOT NULL) AS sachleistungen
+FROM auffuehrungen a
+LEFT JOIN auffuehrung_schichten s ON s.auffuehrung_id = a.id
+LEFT JOIN info_bloecke ib ON ib.auffuehrung_id = a.id
+LEFT JOIN sachleistungen sl ON sl.auffuehrung_id = a.id
+WHERE a.id = $1
+GROUP BY a.id;
+```
+
+### Query 3: Calculate Offset for Info Block
+
+```sql
+-- PostgreSQL function to calculate absolute time from offset
+CREATE OR REPLACE FUNCTION calculate_info_block_time(
+  p_performance_start TIMESTAMPTZ,
+  p_offset_minutes INTEGER
+)
+RETURNS TIMESTAMPTZ AS $$
+BEGIN
+  RETURN p_performance_start + (p_offset_minutes * interval '1 minute');
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- Usage
+SELECT calculate_info_block_time('2026-06-15 19:00:00', -60);
+-- Returns: 2026-06-15 18:00:00
+```
+
+## Future Enhancements
+
+### Planned for M2
+- Automatic performance generation from series date patterns
+- Resource management (rooms, equipment)
+- Bulk template application
+- Schedule conflict detection
+
+### Planned for M3
+- Performance statistics and reporting
+- Helper availability tracking
+- Automatic shift optimization
+- Mobile-friendly helper assignment
+
+## References
+
+- **Milestone Document:** [docs/milestones/produktionsplanung-logistik.md](../milestones/produktionsplanung-logistik.md)
+- **ADR-001:** [journal/decisions/ADR-001-offset-based-template-times.md](../../journal/decisions/ADR-001-offset-based-template-times.md)
+- **Implementation Log:** [journal/2026-02-05-m1-datenmodell-templates-complete.md](../../journal/2026-02-05-m1-datenmodell-templates-complete.md)
+- **Type Definitions:** `apps/web/lib/supabase/types.ts`
+- **Migrations:** `supabase/migrations/202602050000*`
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-02-05 | Initial documentation for M1 completion |

--- a/journal/2026-02-05-m1-datenmodell-templates-complete.md
+++ b/journal/2026-02-05-m1-datenmodell-templates-complete.md
@@ -1,0 +1,344 @@
+# M1: Datenmodell & Templates - Implementation Complete
+
+**Date:** 2026-02-05
+**Issue:** #171
+**Milestone:** Modul 2 - Produktion & Logistik
+**Status:** Complete
+
+## Overview
+
+Successfully implemented M1 of the performance template system, extending the database schema and UI to support info blocks and in-kind contributions (Sachleistungen). This milestone establishes the foundation for reusable performance templates.
+
+## What Was Implemented
+
+### 1. Database Schema Extensions
+
+#### Migration 1: Auffuehrungsserien Extended
+**File:** `supabase/migrations/20260205000000_auffuehrungsserien_erweitern.sql`
+
+Extended `auffuehrungsserien` table with:
+- `stueck_id` (UUID, FK to stuecke) - Link to play/production
+- `datum_von` (DATE) - Series start date
+- `datum_bis` (DATE) - Series end date
+
+**Rationale:** Performance series need to be associated with a specific play and have defined date ranges for planning purposes.
+
+#### Migration 2: Template Info Blocks
+**File:** `supabase/migrations/20260205000001_template_info_bloecke.sql`
+
+New tables:
+- `template_info_bloecke` - Template-level info blocks
+  - Uses offset-based timing (offset_minuten)
+  - Defines reusable information blocks
+  - Linked to templates via template_id
+
+- `info_bloecke` - Instance-level info blocks
+  - Calculated absolute times (start_zeit)
+  - Linked to specific performances
+  - Inherits template properties
+
+**Key Pattern:** Offset-based time system (see ADR-001)
+
+#### Migration 3: Template Sachleistungen
+**File:** `supabase/migrations/20260205000002_template_sachleistungen.sql`
+
+New tables:
+- `template_sachleistungen` - Template-level in-kind contributions
+  - Reusable contribution definitions
+  - Quantity and unit fields
+  - Linked to templates
+
+- `sachleistungen` - Instance-level contributions
+  - Linked to specific performances
+  - Tracks actual contributions
+
+**Seed Data:** Created "Abendvorstellung" template with:
+- 10 pre-configured shifts (Einlass, Kasse, Service, Bar, Garderobe, Technik, etc.)
+- 2 info blocks (Einlass, Vorstellung Beginn)
+
+### 2. TypeScript Type System
+
+**File:** `apps/web/lib/supabase/types.ts`
+
+Added complete type definitions:
+
+```typescript
+// Template level (offset-based)
+type TemplateInfoBlock = {
+  id: string
+  template_id: string
+  titel: string
+  beschreibung: string | null
+  offset_minuten: number
+  created_at: string
+}
+
+type TemplateSachleistung = {
+  id: string
+  template_id: string
+  bezeichnung: string
+  beschreibung: string | null
+  menge: number
+  einheit: string | null
+  created_at: string
+}
+
+// Instance level (absolute times)
+type InfoBlock = {
+  id: string
+  auffuehrung_id: string
+  template_info_block_id: string | null
+  titel: string
+  beschreibung: string | null
+  start_zeit: string
+  created_at: string
+}
+
+type Sachleistung = {
+  id: string
+  auffuehrung_id: string
+  template_sachleistung_id: string | null
+  bezeichnung: string
+  beschreibung: string | null
+  menge: number
+  einheit: string | null
+  created_at: string
+}
+```
+
+Extended `TemplateMitDetails` to include nested info blocks and sachleistungen.
+
+### 3. Validation Schemas
+
+**File:** `apps/web/lib/validations/modul2.ts`
+
+Added Zod schemas for form validation:
+
+```typescript
+export const templateInfoBlockSchema = z.object({
+  titel: z.string().min(1, 'Titel ist erforderlich'),
+  beschreibung: z.string().optional(),
+  offset_minuten: z.number()
+    .int('Offset muss eine ganze Zahl sein')
+    .min(-480, 'Offset darf nicht früher als 8 Stunden vorher sein')
+    .max(480, 'Offset darf nicht später als 8 Stunden danach sein'),
+})
+
+export const templateSachleistungSchema = z.object({
+  bezeichnung: z.string().min(1, 'Bezeichnung ist erforderlich'),
+  beschreibung: z.string().optional(),
+  menge: z.number().positive('Menge muss positiv sein'),
+  einheit: z.string().optional(),
+})
+```
+
+### 4. Server Actions
+
+**File:** `apps/web/lib/actions/templates.ts`
+
+Implemented CRUD operations:
+
+```typescript
+// Info Blocks
+async function addTemplateInfoBlock(templateId, data)
+async function removeTemplateInfoBlock(id)
+
+// Sachleistungen
+async function addTemplateSachleistung(templateId, data)
+async function removeTemplateSachleistung(id)
+
+// Extended getTemplate() to include info_bloecke and sachleistungen
+// Extended applyTemplate() to transfer info blocks with offset calculation
+```
+
+**Offset Calculation Logic:**
+```typescript
+// In applyTemplate()
+for (const infoBlock of template.info_bloecke) {
+  const startZeit = new Date(
+    auffuehrung.start_zeit.getTime() +
+    infoBlock.offset_minuten * 60000
+  )
+
+  await supabase.from('info_bloecke').insert({
+    auffuehrung_id: auffuehrungId,
+    template_info_block_id: infoBlock.id,
+    titel: infoBlock.titel,
+    beschreibung: infoBlock.beschreibung,
+    start_zeit: startZeit.toISOString(),
+  })
+}
+```
+
+### 5. UI Components
+
+**File:** `apps/web/components/templates/TemplateDetailEditor.tsx`
+
+Added two new sections to the template editor:
+
+#### Info-Blöcke Section (Amber Theme)
+- List display with calculated times based on offset
+- Add form with titel, beschreibung, offset_minuten
+- Delete functionality with confirmation
+- Time preview: "19:00 (Offset: -60 Min)" format
+
+#### Sachleistungen Section (Green Theme)
+- List display with quantity and unit
+- Add form with bezeichnung, beschreibung, menge, einheit
+- Delete functionality with confirmation
+- Visual distinction using color themes
+
+**Design Pattern:** Consistent with existing shift management UI
+
+## Key Design Decisions
+
+### 1. Offset-Based Time System
+
+**Decision:** Use integer minute offsets instead of absolute times in templates.
+
+**Rationale:**
+- Enables true template reusability across different performance times
+- Simple calculation: `performance_start + offset_minutes = actual_time`
+- Supports negative offsets (pre-show) and positive (post-show)
+- See ADR-001 for full details
+
+### 2. Two-Level Architecture
+
+**Pattern:** Separate template definitions from instances
+
+```
+Template Level (Reusable)          Instance Level (Concrete)
+├── template_info_bloecke    →     ├── info_bloecke
+│   └── offset_minuten             │   └── start_zeit
+├── template_sachleistungen  →     ├── sachleistungen
+└── template_zeitbloecke     →     └── auffuehrung_schichten
+    └── start_offset_minuten           └── start_zeit
+```
+
+**Benefits:**
+- Clear separation of concerns
+- Templates remain unchanged when applied multiple times
+- Instances can be manually adjusted post-creation
+
+### 3. Info Blocks vs. Shifts
+
+**Distinction:**
+- **Shifts (Zeitblöcke):** Staffed positions requiring helpers (e.g., "Kasse", "Bar")
+- **Info Blocks:** Informational markers without staffing (e.g., "Einlass", "Pause")
+
+**Database Difference:**
+- Shifts: Have slots, roles, assignments
+- Info Blocks: Only have time and description
+
+## Testing
+
+### Manual Testing Performed
+
+1. Created "Test Template" with info blocks and sachleistungen
+2. Applied template to performance, verified offset calculation
+3. Tested negative offsets (-120 min) and positive offsets (+30 min)
+4. Verified UI updates after add/remove operations
+5. Confirmed seed data loads correctly
+
+### Edge Cases Handled
+
+- Offset validation (min: -480, max: 480)
+- Empty descriptions (optional fields)
+- Quantity validation for sachleistungen (must be positive)
+- Template deletion with cascading references
+
+## Database Seed Data
+
+Created comprehensive "Abendvorstellung" template:
+
+**10 Shifts:**
+1. Einlass (19:00-20:00, -60 min, 3 slots)
+2. Kasse (18:30-20:00, -90 min, 2 slots)
+3. Service Runde 1 (18:00-20:00, -120 min, 4 slots)
+4. Service Runde 2 (20:15-22:15, +15 min, 4 slots)
+5. Bar (18:30-22:30, -90 min, 2 slots)
+6. Garderobe (18:30-22:30, -90 min, 2 slots)
+7. Technik Auf-/Abbau (15:00-23:00, -240 min, 2 slots)
+8. Technik Show (18:30-21:30, -90 min, 1 slot)
+9. Inspizienz (18:30-21:30, -90 min, 1 slot)
+10. Requisite (18:00-21:30, -120 min, 1 slot)
+
+**2 Info Blocks:**
+1. Einlass (-30 min)
+2. Vorstellung Beginn (0 min)
+
+## File Structure
+
+```
+C:/GIT/BackstagePass-1/
+├── supabase/migrations/
+│   ├── 20260205000000_auffuehrungsserien_erweitern.sql
+│   ├── 20260205000001_template_info_bloecke.sql
+│   └── 20260205000002_template_sachleistungen.sql
+├── apps/web/
+│   ├── lib/
+│   │   ├── supabase/types.ts (extended)
+│   │   ├── validations/modul2.ts (extended)
+│   │   └── actions/templates.ts (extended)
+│   └── components/templates/
+│       └── TemplateDetailEditor.tsx (extended)
+└── journal/decisions/
+    └── ADR-001-offset-based-template-times.md (new)
+```
+
+## Impact on Existing Code
+
+### Breaking Changes
+None - purely additive changes.
+
+### Extended Features
+- `getTemplate()` now includes info_bloecke and sachleistungen
+- `applyTemplate()` now transfers info blocks with offset calculation
+- `TemplateMitDetails` type extended with new nested arrays
+
+### Migration Path
+No migration needed for existing data. New columns have sensible defaults or are nullable.
+
+## Performance Considerations
+
+### Database Queries
+- Info blocks and sachleistungen use indexed foreign keys
+- Template fetching includes nested data via JOINs
+- Offset calculation happens in application layer (acceptable for current scale)
+
+### Future Optimizations
+- Consider database function for offset calculation if needed at scale
+- Potential caching layer for frequently used templates
+
+## Next Steps (M2)
+
+Based on this foundation, M2 will implement:
+
+1. **Auffuehrungen Generation** - Create performances from series with date patterns
+2. **Ressourcen Management** - Non-personal resources (rooms, equipment)
+3. **Template Application Workflow** - Bulk apply templates to multiple performances
+4. **Schedule Visualization** - Gantt/timeline view of shifts and info blocks
+
+## References
+
+- **Issue:** #171 M1: Datenmodell & Templates
+- **Milestone:** Modul 2 - Produktion & Logistik
+- **ADR:** ADR-001 Offset-Based Time System
+- **Database Schema:** See migrations directory
+- **Type Definitions:** `apps/web/lib/supabase/types.ts`
+- **UI Components:** `apps/web/components/templates/TemplateDetailEditor.tsx`
+
+## Lessons Learned
+
+1. **Offset System Clarity**: The offset-based approach proved intuitive once explained
+2. **Seed Data Value**: Having a complete example template aids development and testing
+3. **Type Safety**: TypeScript caught several potential bugs during development
+4. **UI Consistency**: Following existing patterns made integration seamless
+5. **Documentation First**: ADR-001 helped solidify the design before implementation
+
+## Acknowledgments
+
+- **Martin (Bühnenmeister)**: Database design and migration scripts
+- **Peter (Kulissenbauer)**: Server actions and UI implementation
+- **Ioannis (Kritiker)**: Type safety and validation patterns
+- **Silke (Chronist)**: This documentation and ADR-001

--- a/journal/decisions/ADR-001-offset-based-template-times.md
+++ b/journal/decisions/ADR-001-offset-based-template-times.md
@@ -1,0 +1,157 @@
+# ADR-001: Offset-Based Time System for Performance Templates
+
+**Status:** Accepted
+**Date:** 2026-02-05
+**Author:** Silke (Documentation Specialist) based on Martin's implementation
+**Issue:** #171
+
+## Context
+
+Performance templates (Aufführungsvorlagen) define reusable shift patterns and information blocks that can be applied to multiple performances. When a template is applied to a specific performance, the shifts and info blocks need to be instantiated with concrete times.
+
+The challenge: How should we represent times in templates that can be applied to performances starting at different times?
+
+### Options Considered
+
+1. **Absolute Times**: Store fixed times like "19:00" in templates
+2. **Offset-Based Times**: Store relative times like "+60 minutes from performance start"
+3. **Time Ranges**: Store flexible ranges like "1-2 hours before"
+
+## Decision
+
+We decided to use **offset-based times** with minutes as the unit.
+
+### Template Level (Offset-Based)
+
+Templates store shifts and info blocks with relative times:
+
+```sql
+-- template_zeitbloecke (shift templates)
+- start_offset_minuten: INTEGER  -- e.g., -120 (2 hours before)
+- dauer_minuten: INTEGER         -- e.g., 180 (3 hours duration)
+
+-- template_info_bloecke (info block templates)
+- offset_minuten: INTEGER        -- e.g., -60 (1 hour before)
+```
+
+### Instance Level (Absolute Times)
+
+When applied to a performance, offsets are converted to concrete times:
+
+```sql
+-- auffuehrung_schichten (shift instances)
+- start_zeit: TIMESTAMPTZ        -- e.g., '2026-06-15 17:00:00'
+- end_zeit: TIMESTAMPTZ          -- e.g., '2026-06-15 20:00:00'
+
+-- info_bloecke (info block instances)
+- start_zeit: TIMESTAMPTZ        -- e.g., '2026-06-15 18:00:00'
+```
+
+### Calculation Example
+
+```
+Performance Start: 2026-06-15 19:00:00
+Template Shift: start_offset_minuten = -120, dauer_minuten = 180
+
+Calculated Times:
+- start_zeit = 19:00:00 + (-120 minutes) = 17:00:00
+- end_zeit = 17:00:00 + 180 minutes = 20:00:00
+```
+
+## Rationale
+
+### Advantages
+
+1. **Template Reusability**: Same template works for matinee (14:00) and evening (19:00) performances
+2. **Consistency**: All shifts maintain their relative timing to the performance
+3. **Simplicity**: Single integer value is easy to store, calculate, and understand
+4. **Flexibility**: Supports negative offsets (before performance) and positive offsets (after)
+5. **Precision**: Minute-level precision is sufficient for theater logistics
+
+### Why Minutes?
+
+- **Standard Unit**: Minutes are the standard unit for shift planning
+- **No Ambiguity**: Unlike hours (fractional) or seconds (too granular)
+- **Database Efficiency**: Single INTEGER column vs. INTERVAL type
+- **Easy Calculation**: PostgreSQL handles `timestamp + (minutes * interval '1 minute')` efficiently
+
+### Implementation Pattern
+
+```typescript
+// Server action to apply template
+export async function applyTemplate(
+  performanceId: string,
+  templateId: string
+) {
+  // 1. Get performance start time
+  const performance = await getPerformance(performanceId)
+  const startTime = performance.start_zeit
+
+  // 2. Get template shifts with offsets
+  const templateShifts = await getTemplateShifts(templateId)
+
+  // 3. Calculate absolute times
+  for (const shift of templateShifts) {
+    const shiftStart = addMinutes(startTime, shift.start_offset_minuten)
+    const shiftEnd = addMinutes(shiftStart, shift.dauer_minuten)
+
+    await createShift({
+      auffuehrung_id: performanceId,
+      start_zeit: shiftStart,
+      end_zeit: shiftEnd,
+      // ... other fields
+    })
+  }
+}
+```
+
+## Consequences
+
+### Positive
+
+- Templates are truly reusable across different performance times
+- Clear separation between template definition and instance
+- Straightforward calculation logic
+- Easy to validate (offsets should be reasonable, e.g., -360 to +360 minutes)
+- Supports all common use cases (pre-show, during show, post-show)
+
+### Negative
+
+- Requires conversion step when applying template
+- Need to handle edge cases (performance start time changes)
+- Two different time representations in the system
+
+### Neutral
+
+- Manual time adjustments still possible at instance level
+- If performance time changes, shifts need to be recalculated
+
+## Related Decisions
+
+- Template system architecture (PLAN-156)
+- Performance scheduling (Issue #171)
+- Shift management system (Modul 2)
+
+## Database Migration
+
+Implemented in:
+- `20260205000001_template_info_bloecke.sql` - Info blocks with offsets
+- Template shifts already had offset-based system
+
+## Validation Rules
+
+```typescript
+// Reasonable offset ranges for theater context
+const OFFSET_CONSTRAINTS = {
+  minOffset: -480,  // 8 hours before (load-in)
+  maxOffset: 480,   // 8 hours after (tear-down)
+  minDuration: 15,  // 15 minutes minimum shift
+  maxDuration: 480  // 8 hours maximum shift
+}
+```
+
+## References
+
+- Issue #171: M1 Datenmodell & Templates
+- `apps/web/lib/actions/templates.ts` - Implementation
+- `supabase/migrations/20260205000001_template_info_bloecke.sql` - Schema


### PR DESCRIPTION
## Summary
- ADR-001: Dokumentiert Entscheidung für offset-basierte Zeiten in Templates
- Journal-Eintrag für M1-Implementierung
- Datenbank-Schema Dokumentation für Modul 2 (alle 6 neuen Tabellen)
- Aktualisierter docs/README.md Index

## Neue Dateien
- `docs/architecture/database-schema-modul2.md`
- `journal/2026-02-05-m1-datenmodell-templates-complete.md`
- `journal/decisions/ADR-001-offset-based-template-times.md`

## Test plan
- [x] Markdown-Dateien korrekt formatiert
- [x] Links zu Code-Dateien korrekt

🤖 Generated with [Claude Code](https://claude.ai/claude-code)