### PR TITLE
feat(m4): Öffentliche Anmeldung & Token-System

### DIFF
--- a/apps/web/app/(public)/helfer/anmeldung/[token]/page.tsx
+++ b/apps/web/app/(public)/helfer/anmeldung/[token]/page.tsx
@@ -1,0 +1,164 @@
+import { Metadata } from 'next'
+import { getPublicHelferlisteByToken } from '@/lib/actions/external-registration'
+import { PublicHelferlisteView } from '@/components/public-registration'
+
+interface PageProps {
+  params: Promise<{ token: string }>
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { token } = await params
+  const result = await getPublicHelferlisteByToken(token)
+
+  if ('error' in result) {
+    return {
+      title: 'Helfer gesucht | Theatergruppe Widen',
+      robots: { index: false, follow: false },
+    }
+  }
+
+  return {
+    title: `Helfer gesucht: ${result.veranstaltung.titel} | Theatergruppe Widen`,
+    description: `Melde dich als Helfer für "${result.veranstaltung.titel}" an.`,
+    openGraph: {
+      title: `Helfer gesucht: ${result.veranstaltung.titel}`,
+      description: `Wir suchen Helfer für unsere Veranstaltung am ${new Date(result.veranstaltung.datum).toLocaleDateString('de-CH')}`,
+      type: 'website',
+    },
+    robots: { index: false, follow: false }, // Privacy: don't index token URLs
+  }
+}
+
+export default async function PublicHelferAnmeldungPage({ params }: PageProps) {
+  const { token } = await params
+  const result = await getPublicHelferlisteByToken(token)
+
+  // Handle errors
+  if ('error' in result) {
+    return (
+      <main className="min-h-screen bg-gray-50">
+        <div className="mx-auto max-w-2xl px-4 py-16 text-center">
+          <div className="rounded-xl border border-gray-200 bg-white p-8 shadow-sm">
+            <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-warning-100">
+              <svg
+                className="h-8 w-8 text-warning-600"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                />
+              </svg>
+            </div>
+            <h1 className="text-xl font-semibold text-gray-900">
+              {result.error}
+            </h1>
+            <p className="mt-3 text-gray-600">
+              Falls du einen gültigen Anmeldelink erwartest, wende dich bitte an
+              den Veranstalter.
+            </p>
+          </div>
+
+          {/* Footer */}
+          <div className="mt-8 text-sm text-gray-500">
+            <p>Theatergruppe Widen</p>
+          </div>
+        </div>
+      </main>
+    )
+  }
+
+  const { veranstaltung, zeitbloecke, infoBloecke } = result
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleDateString('de-CH', {
+      weekday: 'long',
+      day: '2-digit',
+      month: 'long',
+      year: 'numeric',
+    })
+  }
+
+  const formatTime = (timeStr: string | null) => {
+    if (!timeStr) return null
+    return timeStr.slice(0, 5)
+  }
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <div className="mx-auto max-w-3xl px-4 py-8">
+        {/* Header */}
+        <div className="mb-8 text-center">
+          <div className="mb-4 inline-flex items-center gap-2 rounded-full bg-primary-100 px-4 py-1 text-sm font-medium text-primary-700">
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+              />
+            </svg>
+            Helfer gesucht
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900 sm:text-3xl">
+            {veranstaltung.titel}
+          </h1>
+        </div>
+
+        {/* Event Details */}
+        <div className="mb-8 rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+          <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div>
+              <dt className="text-sm font-medium text-gray-500">Datum</dt>
+              <dd className="mt-1 text-gray-900">
+                {formatDate(veranstaltung.datum)}
+              </dd>
+            </div>
+            {veranstaltung.startzeit && (
+              <div>
+                <dt className="text-sm font-medium text-gray-500">Zeit</dt>
+                <dd className="mt-1 text-gray-900">
+                  {formatTime(veranstaltung.startzeit)}
+                  {veranstaltung.endzeit &&
+                    ` - ${formatTime(veranstaltung.endzeit)}`}{' '}
+                  Uhr
+                </dd>
+              </div>
+            )}
+            {veranstaltung.ort && (
+              <div className="sm:col-span-2">
+                <dt className="text-sm font-medium text-gray-500">Ort</dt>
+                <dd className="mt-1 text-gray-900">{veranstaltung.ort}</dd>
+              </div>
+            )}
+          </dl>
+        </div>
+
+        {/* Public Helferliste View */}
+        <PublicHelferlisteView
+          data={{ veranstaltung, zeitbloecke, infoBloecke }}
+          token={token}
+        />
+
+        {/* Footer */}
+        <div className="mt-12 text-center text-sm text-gray-500">
+          <p>Theatergruppe Widen</p>
+          <p className="mt-1">
+            <a href="/datenschutz" className="text-primary-600 hover:underline">
+              Datenschutzerklärung
+            </a>
+          </p>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/apps/web/components/admin/helferliste/BulkSichtbarkeitAction.tsx
+++ b/apps/web/components/admin/helferliste/BulkSichtbarkeitAction.tsx
@@ -1,0 +1,107 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { setAllSchichtenSichtbarkeit } from '@/lib/actions/schicht-sichtbarkeit'
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
+import type { SchichtSichtbarkeit } from '@/lib/supabase/types'
+
+interface BulkSichtbarkeitActionProps {
+  veranstaltungId: string
+  stats: {
+    intern: number
+    public: number
+    total: number
+  }
+  disabled?: boolean
+}
+
+export function BulkSichtbarkeitAction({
+  veranstaltungId,
+  stats,
+  disabled = false,
+}: BulkSichtbarkeitActionProps) {
+  const router = useRouter()
+  const [isLoading, setIsLoading] = useState(false)
+  const [showDialog, setShowDialog] = useState<SchichtSichtbarkeit | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleBulkUpdate = async (sichtbarkeit: SchichtSichtbarkeit) => {
+    setIsLoading(true)
+    setError(null)
+
+    const result = await setAllSchichtenSichtbarkeit(veranstaltungId, sichtbarkeit)
+
+    if (!result.success) {
+      setError(result.error || 'Fehler beim Aktualisieren')
+    }
+
+    setShowDialog(null)
+    setIsLoading(false)
+    router.refresh()
+  }
+
+  if (stats.total === 0) return null
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <p className="text-sm font-medium text-gray-700">
+            Sichtbarkeit aller Schichten
+          </p>
+          <p className="mt-1 text-xs text-gray-500">
+            {stats.public} öffentlich, {stats.intern} intern von {stats.total} gesamt
+          </p>
+        </div>
+
+        <div className="flex gap-2">
+          <button
+            onClick={() => setShowDialog('public')}
+            disabled={disabled || isLoading || stats.public === stats.total}
+            className="inline-flex items-center gap-1 rounded-lg border border-success-300 bg-white px-3 py-1.5 text-xs font-medium text-success-700 transition-colors hover:bg-success-50 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            Alle öffentlich
+          </button>
+          <button
+            onClick={() => setShowDialog('intern')}
+            disabled={disabled || isLoading || stats.intern === stats.total}
+            className="inline-flex items-center gap-1 rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+            </svg>
+            Alle intern
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mt-3 rounded-lg border border-error-200 bg-error-50 px-3 py-2 text-xs text-error-700">
+          {error}
+        </div>
+      )}
+
+      {/* Confirm Dialog */}
+      <ConfirmDialog
+        open={showDialog !== null}
+        title={
+          showDialog === 'public'
+            ? 'Alle Schichten öffentlich machen?'
+            : 'Alle Schichten intern machen?'
+        }
+        description={
+          showDialog === 'public'
+            ? `${stats.total} Schichten werden für externe Helfer sichtbar.`
+            : `${stats.total} Schichten werden nur für Mitglieder sichtbar. Bereits angemeldete externe Helfer bleiben angemeldet.`
+        }
+        confirmLabel={isLoading ? 'Wird aktualisiert...' : 'Anwenden'}
+        onConfirm={() => showDialog && handleBulkUpdate(showDialog)}
+        onCancel={() => setShowDialog(null)}
+      />
+    </div>
+  )
+}

--- a/apps/web/components/admin/helferliste/CopyLinkButton.tsx
+++ b/apps/web/components/admin/helferliste/CopyLinkButton.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { useState } from 'react'
+
+interface CopyLinkButtonProps {
+  link: string
+}
+
+export function CopyLinkButton({ link }: CopyLinkButtonProps) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(link)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch (error) {
+      console.error('Failed to copy:', error)
+    }
+  }
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="relative inline-flex shrink-0 items-center gap-1 rounded-lg bg-white px-3 py-2 text-sm font-medium text-success-700 shadow-sm transition-colors hover:bg-success-100"
+    >
+      {copied ? (
+        <>
+          <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+          </svg>
+          Kopiert!
+        </>
+      ) : (
+        <>
+          <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
+          </svg>
+          Link kopieren
+        </>
+      )}
+    </button>
+  )
+}

--- a/apps/web/components/admin/helferliste/HelferStatusControl.tsx
+++ b/apps/web/components/admin/helferliste/HelferStatusControl.tsx
@@ -1,0 +1,228 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import {
+  publishHelferliste,
+  closeHelferliste,
+  regeneratePublicToken,
+} from '@/lib/actions/helfer-status'
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
+import { CopyLinkButton } from './CopyLinkButton'
+import type { HelferStatus } from '@/lib/supabase/types'
+
+interface HelferStatusControlProps {
+  veranstaltungId: string
+  currentStatus: HelferStatus | null
+  publicToken: string | null
+  canEdit: boolean
+  isAdmin: boolean
+}
+
+export function HelferStatusControl({
+  veranstaltungId,
+  currentStatus,
+  publicToken,
+  canEdit,
+  isAdmin,
+}: HelferStatusControlProps) {
+  const router = useRouter()
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [showPublishDialog, setShowPublishDialog] = useState(false)
+  const [showCloseDialog, setShowCloseDialog] = useState(false)
+  const [showRegenerateDialog, setShowRegenerateDialog] = useState(false)
+
+  const baseUrl = typeof window !== 'undefined'
+    ? window.location.origin
+    : process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
+
+  const publicLink = publicToken ? `${baseUrl}/helfer/anmeldung/${publicToken}` : null
+
+  const handlePublish = async () => {
+    setIsLoading(true)
+    setError(null)
+
+    const result = await publishHelferliste(veranstaltungId)
+    if (!result.success) {
+      setError(result.error || 'Fehler beim Veröffentlichen')
+    }
+
+    setShowPublishDialog(false)
+    setIsLoading(false)
+    router.refresh()
+  }
+
+  const handleClose = async () => {
+    setIsLoading(true)
+    setError(null)
+
+    const result = await closeHelferliste(veranstaltungId)
+    if (!result.success) {
+      setError(result.error || 'Fehler beim Abschliessen')
+    }
+
+    setShowCloseDialog(false)
+    setIsLoading(false)
+    router.refresh()
+  }
+
+  const handleRegenerate = async () => {
+    setIsLoading(true)
+    setError(null)
+
+    const result = await regeneratePublicToken(veranstaltungId)
+    if (!result.success) {
+      setError(result.error || 'Fehler beim Generieren')
+    }
+
+    setShowRegenerateDialog(false)
+    setIsLoading(false)
+    router.refresh()
+  }
+
+  const getStatusBadge = () => {
+    switch (currentStatus) {
+      case 'entwurf':
+        return (
+          <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-3 py-1 text-sm font-medium text-gray-700">
+            <span className="h-2 w-2 rounded-full bg-gray-400" />
+            Entwurf
+          </span>
+        )
+      case 'veroeffentlicht':
+        return (
+          <span className="inline-flex items-center gap-1 rounded-full bg-success-100 px-3 py-1 text-sm font-medium text-success-700">
+            <span className="h-2 w-2 rounded-full bg-success-500" />
+            Veröffentlicht
+          </span>
+        )
+      case 'abgeschlossen':
+        return (
+          <span className="inline-flex items-center gap-1 rounded-full bg-primary-100 px-3 py-1 text-sm font-medium text-primary-700">
+            <span className="h-2 w-2 rounded-full bg-primary-500" />
+            Abgeschlossen
+          </span>
+        )
+      default:
+        return (
+          <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-3 py-1 text-sm font-medium text-gray-500">
+            <span className="h-2 w-2 rounded-full bg-gray-300" />
+            Nicht gestartet
+          </span>
+        )
+    }
+  }
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="font-semibold text-gray-900">Helferliste-Status</h3>
+          <div className="mt-2">{getStatusBadge()}</div>
+        </div>
+      </div>
+
+      {/* Error Display */}
+      {error && (
+        <div className="mt-4 rounded-lg border border-error-200 bg-error-50 px-4 py-3 text-sm text-error-700">
+          {error}
+        </div>
+      )}
+
+      {/* Public Link Section */}
+      {currentStatus === 'veroeffentlicht' && publicLink && (
+        <div className="mt-4 rounded-lg border border-success-200 bg-success-50 p-4">
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-medium text-success-800">
+                Öffentlicher Anmelde-Link
+              </p>
+              <p className="mt-1 truncate text-xs text-success-600">{publicLink}</p>
+            </div>
+            <CopyLinkButton link={publicLink} />
+          </div>
+          {canEdit && (
+            <button
+              onClick={() => setShowRegenerateDialog(true)}
+              className="mt-3 text-xs text-success-700 underline hover:no-underline"
+            >
+              Neuen Link generieren (alter wird ungültig)
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Action Buttons */}
+      {canEdit && (
+        <div className="mt-6 flex flex-wrap gap-3">
+          {/* Publish Button */}
+          {(!currentStatus || currentStatus === 'entwurf') && (
+            <button
+              onClick={() => setShowPublishDialog(true)}
+              disabled={isLoading}
+              className="inline-flex items-center gap-2 rounded-lg bg-success-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-success-700 disabled:opacity-50"
+            >
+              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              Helferliste veröffentlichen
+            </button>
+          )}
+
+          {/* Close Button */}
+          {currentStatus === 'veroeffentlicht' && (
+            <button
+              onClick={() => setShowCloseDialog(true)}
+              disabled={isLoading}
+              className="inline-flex items-center gap-2 rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-700 disabled:opacity-50"
+            >
+              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+              Helferliste abschliessen
+            </button>
+          )}
+
+          {/* Status Info for Closed */}
+          {currentStatus === 'abgeschlossen' && (
+            <p className="text-sm text-gray-500">
+              Die Helferliste ist abgeschlossen. Keine neuen Anmeldungen möglich.
+              {isAdmin && ' (Admin: Status kann zurückgesetzt werden)'}
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Confirm Dialogs */}
+      <ConfirmDialog
+        open={showPublishDialog}
+        title="Helferliste veröffentlichen?"
+        description="Der öffentliche Anmelde-Link wird aktiviert. Externe Helfer können sich dann für öffentlich sichtbare Schichten anmelden."
+        confirmLabel={isLoading ? 'Wird veröffentlicht...' : 'Veröffentlichen'}
+        onConfirm={handlePublish}
+        onCancel={() => setShowPublishDialog(false)}
+      />
+
+      <ConfirmDialog
+        open={showCloseDialog}
+        title="Helferliste abschliessen?"
+        description="Es sind keine weiteren Anmeldungen möglich (weder intern noch extern). Bestehende Anmeldungen bleiben sichtbar. Dieser Schritt kann nicht rückgängig gemacht werden."
+        confirmLabel={isLoading ? 'Wird abgeschlossen...' : 'Abschliessen'}
+        variant="danger"
+        onConfirm={handleClose}
+        onCancel={() => setShowCloseDialog(false)}
+      />
+
+      <ConfirmDialog
+        open={showRegenerateDialog}
+        title="Neuen Link generieren?"
+        description="Der alte Link wird ungültig und funktioniert nicht mehr. Personen mit dem alten Link können sich nicht mehr anmelden."
+        confirmLabel={isLoading ? 'Wird generiert...' : 'Neuen Link generieren'}
+        variant="warning"
+        onConfirm={handleRegenerate}
+        onCancel={() => setShowRegenerateDialog(false)}
+      />
+    </div>
+  )
+}

--- a/apps/web/components/admin/helferliste/SichtbarkeitToggle.tsx
+++ b/apps/web/components/admin/helferliste/SichtbarkeitToggle.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { updateSchichtSichtbarkeit } from '@/lib/actions/schicht-sichtbarkeit'
+import type { SchichtSichtbarkeit } from '@/lib/supabase/types'
+
+interface SichtbarkeitToggleProps {
+  schichtId: string
+  currentSichtbarkeit: SchichtSichtbarkeit
+  disabled?: boolean
+}
+
+export function SichtbarkeitToggle({
+  schichtId,
+  currentSichtbarkeit,
+  disabled = false,
+}: SichtbarkeitToggleProps) {
+  const router = useRouter()
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const isPublic = currentSichtbarkeit === 'public'
+
+  const handleToggle = async () => {
+    setIsLoading(true)
+    setError(null)
+
+    const newSichtbarkeit: SchichtSichtbarkeit = isPublic ? 'intern' : 'public'
+    const result = await updateSchichtSichtbarkeit(schichtId, newSichtbarkeit)
+
+    if (!result.success) {
+      setError(result.error || 'Fehler')
+    }
+
+    setIsLoading(false)
+    router.refresh()
+  }
+
+  return (
+    <button
+      onClick={handleToggle}
+      disabled={disabled || isLoading}
+      className={`group relative inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-all ${
+        isPublic
+          ? 'bg-success-100 text-success-700 hover:bg-success-200'
+          : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+      } disabled:cursor-not-allowed disabled:opacity-50`}
+      title={isPublic ? 'Öffentlich sichtbar - Klicken zum Ausblenden' : 'Intern - Klicken für öffentlich'}
+    >
+      {isPublic ? (
+        <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+      ) : (
+        <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+        </svg>
+      )}
+      <span>{isPublic ? 'Öffentlich' : 'Intern'}</span>
+
+      {error && (
+        <span className="absolute -top-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded bg-error-600 px-2 py-1 text-xs text-white opacity-0 group-hover:opacity-100">
+          {error}
+        </span>
+      )}
+    </button>
+  )
+}

--- a/apps/web/components/admin/helferliste/index.ts
+++ b/apps/web/components/admin/helferliste/index.ts
@@ -1,0 +1,4 @@
+export { HelferStatusControl } from './HelferStatusControl'
+export { CopyLinkButton } from './CopyLinkButton'
+export { SichtbarkeitToggle } from './SichtbarkeitToggle'
+export { BulkSichtbarkeitAction } from './BulkSichtbarkeitAction'

--- a/apps/web/components/auffuehrungen/SchichtZuweisungListe.tsx
+++ b/apps/web/components/auffuehrungen/SchichtZuweisungListe.tsx
@@ -85,7 +85,9 @@ export function SchichtZuweisungListe({
 
   // Get already assigned person IDs for a schicht
   const getAssignedPersonIds = (schichtId: string): string[] => {
-    return (zuweisungenBySchicht[schichtId] || []).map((z) => z.person_id)
+    return (zuweisungenBySchicht[schichtId] || [])
+      .map((z) => z.person_id)
+      .filter((id): id is string => id !== null)
   }
 
   return (

--- a/apps/web/components/auffuehrungen/helferliste/HelferlisteView.tsx
+++ b/apps/web/components/auffuehrungen/helferliste/HelferlisteView.tsx
@@ -13,13 +13,14 @@ import { InfoBlockCard } from './InfoBlockCard'
 interface HelferlisteViewProps {
   data: HelferlisteData
   canRegister: boolean
+  canEdit?: boolean
 }
 
 type OptimisticAction =
   | { type: 'register'; schichtId: string }
   | { type: 'unregister'; schichtId: string }
 
-export function HelferlisteView({ data, canRegister }: HelferlisteViewProps) {
+export function HelferlisteView({ data, canRegister, canEdit = false }: HelferlisteViewProps) {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
   const [error, setError] = useState<string | null>(null)
@@ -194,6 +195,7 @@ export function HelferlisteView({ data, canRegister }: HelferlisteViewProps) {
                 isLoading={isPending}
                 onRegister={canRegister ? handleRegister : () => {}}
                 onUnregister={canRegister ? handleUnregister : () => {}}
+                canEdit={canEdit}
               />
             ))
         )}

--- a/apps/web/components/auffuehrungen/helferliste/SchichtSlot.tsx
+++ b/apps/web/components/auffuehrungen/helferliste/SchichtSlot.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import type { SchichtMitDetails } from '@/lib/actions/helfer-anmeldung'
+import { SichtbarkeitToggle } from '@/components/admin/helferliste'
 
 interface SchichtSlotProps {
   schicht: SchichtMitDetails
@@ -11,6 +12,7 @@ interface SchichtSlotProps {
   waitlistPosition?: number | null  // null = not on waitlist, number = position
   onJoinWaitlist?: () => void
   onLeaveWaitlist?: () => void
+  canEdit?: boolean
 }
 
 export function SchichtSlot({
@@ -22,6 +24,7 @@ export function SchichtSlot({
   waitlistPosition,
   onJoinWaitlist,
   onLeaveWaitlist,
+  canEdit = false,
 }: SchichtSlotProps) {
   // Count active zuweisungen
   const activeZuweisungen = (schicht.zuweisungen || []).filter(
@@ -65,6 +68,13 @@ export function SchichtSlot({
               <span className="rounded-full bg-warning-100 px-2 py-0.5 text-xs font-medium text-warning-700">
                 Warteliste Position {waitlistPosition}
               </span>
+            )}
+            {/* Visibility Toggle (Admin only) */}
+            {canEdit && (
+              <SichtbarkeitToggle
+                schichtId={schicht.id}
+                currentSichtbarkeit={schicht.sichtbarkeit || 'intern'}
+              />
             )}
           </div>
 

--- a/apps/web/components/auffuehrungen/helferliste/ZeitblockCard.tsx
+++ b/apps/web/components/auffuehrungen/helferliste/ZeitblockCard.tsx
@@ -9,6 +9,7 @@ interface ZeitblockCardProps {
   isLoading: boolean
   onRegister: (schichtId: string) => void
   onUnregister: (schichtId: string) => void
+  canEdit?: boolean
 }
 
 export function ZeitblockCard({
@@ -17,6 +18,7 @@ export function ZeitblockCard({
   isLoading,
   onRegister,
   onUnregister,
+  canEdit = false,
 }: ZeitblockCardProps) {
   const formatTime = (timeStr: string) => {
     return timeStr.slice(0, 5)
@@ -94,6 +96,7 @@ export function ZeitblockCard({
                 isLoading={isLoading}
                 onRegister={() => onRegister(schicht.id)}
                 onUnregister={() => onUnregister(schicht.id)}
+                canEdit={canEdit}
               />
             ))}
           </div>

--- a/apps/web/components/public-registration/ExternalRegistrationForm.tsx
+++ b/apps/web/components/public-registration/ExternalRegistrationForm.tsx
@@ -1,0 +1,250 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { registerExternalHelper } from '@/lib/actions/external-registration'
+import {
+  externeHelferRegistrierungFormSchema,
+  type ExterneHelferRegistrierungFormWithPrivacy,
+} from '@/lib/validations/externe-helfer'
+
+interface ExternalRegistrationFormProps {
+  token: string
+  schichtId: string
+  schichtName: string
+  zeitInfo?: string
+  onClose: () => void
+  onSuccess: () => void
+}
+
+export function ExternalRegistrationForm({
+  token,
+  schichtId,
+  schichtName,
+  zeitInfo,
+  onClose,
+  onSuccess,
+}: ExternalRegistrationFormProps) {
+  const router = useRouter()
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
+
+  const [formData, setFormData] = useState<ExterneHelferRegistrierungFormWithPrivacy>({
+    email: '',
+    vorname: '',
+    nachname: '',
+    telefon: '',
+    datenschutz: false,
+  })
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setFieldErrors({})
+
+    // Validate form
+    const parseResult = externeHelferRegistrierungFormSchema.safeParse(formData)
+    if (!parseResult.success) {
+      const errors: Record<string, string> = {}
+      for (const issue of parseResult.error.issues) {
+        const field = issue.path[0] as string
+        if (!errors[field]) {
+          errors[field] = issue.message
+        }
+      }
+      setFieldErrors(errors)
+      return
+    }
+
+    setIsSubmitting(true)
+
+    const result = await registerExternalHelper(token, schichtId, {
+      email: formData.email,
+      vorname: formData.vorname,
+      nachname: formData.nachname,
+      telefon: formData.telefon || undefined,
+    })
+
+    if (!result.success) {
+      setError(result.error || 'Fehler bei der Anmeldung')
+      setIsSubmitting(false)
+      return
+    }
+
+    router.refresh()
+    onSuccess()
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="w-full max-w-md rounded-xl bg-white shadow-xl">
+        {/* Header */}
+        <div className="border-b border-gray-100 px-6 py-4">
+          <h2 className="text-lg font-semibold text-gray-900">
+            Anmeldung: {schichtName}
+          </h2>
+          {zeitInfo && <p className="text-sm text-gray-500">{zeitInfo}</p>}
+        </div>
+
+        {/* Form */}
+        <form onSubmit={handleSubmit} className="p-6">
+          {error && (
+            <div className="mb-4 rounded-lg border border-error-200 bg-error-50 px-4 py-3 text-sm text-error-700">
+              {error}
+            </div>
+          )}
+
+          <div className="space-y-4">
+            {/* Vorname */}
+            <div>
+              <label
+                htmlFor="vorname"
+                className="block text-sm font-medium text-gray-700"
+              >
+                Vorname *
+              </label>
+              <input
+                type="text"
+                id="vorname"
+                value={formData.vorname}
+                onChange={(e) =>
+                  setFormData({ ...formData, vorname: e.target.value })
+                }
+                className={`mt-1 block w-full rounded-lg border px-4 py-2 focus:ring-2 focus:ring-primary-500 ${
+                  fieldErrors.vorname
+                    ? 'border-error-300 focus:border-error-500'
+                    : 'border-gray-300 focus:border-primary-500'
+                }`}
+                placeholder="Max"
+              />
+              {fieldErrors.vorname && (
+                <p className="mt-1 text-sm text-error-600">{fieldErrors.vorname}</p>
+              )}
+            </div>
+
+            {/* Nachname */}
+            <div>
+              <label
+                htmlFor="nachname"
+                className="block text-sm font-medium text-gray-700"
+              >
+                Nachname *
+              </label>
+              <input
+                type="text"
+                id="nachname"
+                value={formData.nachname}
+                onChange={(e) =>
+                  setFormData({ ...formData, nachname: e.target.value })
+                }
+                className={`mt-1 block w-full rounded-lg border px-4 py-2 focus:ring-2 focus:ring-primary-500 ${
+                  fieldErrors.nachname
+                    ? 'border-error-300 focus:border-error-500'
+                    : 'border-gray-300 focus:border-primary-500'
+                }`}
+                placeholder="Muster"
+              />
+              {fieldErrors.nachname && (
+                <p className="mt-1 text-sm text-error-600">{fieldErrors.nachname}</p>
+              )}
+            </div>
+
+            {/* Email */}
+            <div>
+              <label
+                htmlFor="email"
+                className="block text-sm font-medium text-gray-700"
+              >
+                E-Mail *
+              </label>
+              <input
+                type="email"
+                id="email"
+                value={formData.email}
+                onChange={(e) =>
+                  setFormData({ ...formData, email: e.target.value })
+                }
+                className={`mt-1 block w-full rounded-lg border px-4 py-2 focus:ring-2 focus:ring-primary-500 ${
+                  fieldErrors.email
+                    ? 'border-error-300 focus:border-error-500'
+                    : 'border-gray-300 focus:border-primary-500'
+                }`}
+                placeholder="max.muster@beispiel.ch"
+              />
+              {fieldErrors.email && (
+                <p className="mt-1 text-sm text-error-600">{fieldErrors.email}</p>
+              )}
+            </div>
+
+            {/* Telefon */}
+            <div>
+              <label
+                htmlFor="telefon"
+                className="block text-sm font-medium text-gray-700"
+              >
+                Telefon <span className="text-gray-400">(optional)</span>
+              </label>
+              <input
+                type="tel"
+                id="telefon"
+                value={formData.telefon}
+                onChange={(e) =>
+                  setFormData({ ...formData, telefon: e.target.value })
+                }
+                className="mt-1 block w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-primary-500 focus:ring-2 focus:ring-primary-500"
+                placeholder="+41 79 123 45 67"
+              />
+            </div>
+
+            {/* Datenschutz */}
+            <div className="flex items-start gap-3">
+              <input
+                type="checkbox"
+                id="datenschutz"
+                checked={formData.datenschutz}
+                onChange={(e) =>
+                  setFormData({ ...formData, datenschutz: e.target.checked })
+                }
+                className="mt-1 h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+              />
+              <label htmlFor="datenschutz" className="text-sm text-gray-600">
+                Ich akzeptiere die{' '}
+                <a
+                  href="/datenschutz"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary-600 hover:underline"
+                >
+                  Datenschutzerklärung
+                </a>{' '}
+                und stimme der Verarbeitung meiner Daten zu. *
+              </label>
+            </div>
+            {fieldErrors.datenschutz && (
+              <p className="text-sm text-error-600">{fieldErrors.datenschutz}</p>
+            )}
+          </div>
+
+          {/* Actions */}
+          <div className="mt-6 flex gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+            >
+              Abbrechen
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="flex-1 rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-700 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isSubmitting ? 'Wird angemeldet...' : 'Verbindlich anmelden'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/public-registration/PublicHelferlisteView.tsx
+++ b/apps/web/components/public-registration/PublicHelferlisteView.tsx
@@ -1,0 +1,189 @@
+'use client'
+
+import { useState } from 'react'
+import { PublicZeitblockGroup } from './PublicZeitblockGroup'
+import { ExternalRegistrationForm } from './ExternalRegistrationForm'
+import { SuccessScreen } from './SuccessScreen'
+import type {
+  PublicHelferlisteData,
+  PublicSchichtData,
+} from '@/lib/actions/external-registration'
+
+interface PublicHelferlisteViewProps {
+  data: PublicHelferlisteData
+  token: string
+}
+
+type RegistrationState =
+  | { type: 'list' }
+  | { type: 'form'; schichtId: string; schichtName: string; zeitInfo?: string }
+  | { type: 'success'; schichtName: string }
+
+export function PublicHelferlisteView({ data, token }: PublicHelferlisteViewProps) {
+  const [state, setState] = useState<RegistrationState>({ type: 'list' })
+
+  const handleRegister = (schichtId: string) => {
+    // Find schicht info
+    let schichtInfo: { schicht: PublicSchichtData; zeitblock?: { name: string; startzeit: string; endzeit: string } } | null = null
+
+    for (const zb of data.zeitbloecke) {
+      const schicht = zb.schichten.find((s) => s.id === schichtId)
+      if (schicht) {
+        schichtInfo = {
+          schicht,
+          zeitblock: { name: zb.name, startzeit: zb.startzeit, endzeit: zb.endzeit },
+        }
+        break
+      }
+    }
+
+    if (!schichtInfo) return
+
+    const zeitInfo = schichtInfo.zeitblock
+      ? `${schichtInfo.zeitblock.name} (${schichtInfo.zeitblock.startzeit.slice(0, 5)} - ${schichtInfo.zeitblock.endzeit.slice(0, 5)} Uhr)`
+      : undefined
+
+    setState({
+      type: 'form',
+      schichtId,
+      schichtName: schichtInfo.schicht.rolle,
+      zeitInfo,
+    })
+  }
+
+  const handleSuccess = () => {
+    if (state.type !== 'form') return
+    setState({ type: 'success', schichtName: state.schichtName })
+  }
+
+  const handleClose = () => {
+    setState({ type: 'list' })
+  }
+
+  // Success screen
+  if (state.type === 'success') {
+    return (
+      <SuccessScreen
+        schichtName={state.schichtName}
+        veranstaltungName={data.veranstaltung.titel}
+        onRegisterMore={() => setState({ type: 'list' })}
+      />
+    )
+  }
+
+  // Check if there are any schichten
+  const totalSchichten = data.zeitbloecke.reduce(
+    (sum, zb) => sum + zb.schichten.length,
+    0
+  )
+
+  if (totalSchichten === 0) {
+    return (
+      <div className="rounded-xl border border-gray-200 bg-white p-8 text-center shadow-sm">
+        <div className="mx-auto mb-4 h-12 w-12 rounded-full bg-gray-100 p-3">
+          <svg
+            className="h-6 w-6 text-gray-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+            />
+          </svg>
+        </div>
+        <h3 className="text-lg font-medium text-gray-900">
+          Keine Schichten verfügbar
+        </h3>
+        <p className="mt-2 text-gray-500">
+          Derzeit sind keine öffentlichen Helferschichten für diese Veranstaltung
+          verfügbar.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      {/* Info Box */}
+      <div className="mb-6 rounded-xl border border-primary-200 bg-primary-50 p-5">
+        <div className="flex items-start gap-4">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary-100">
+            <svg
+              className="h-5 w-5 text-primary-600"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+          </div>
+          <div>
+            <h3 className="font-medium text-primary-900">
+              Vielen Dank für deine Unterstützung!
+            </h3>
+            <p className="mt-1 text-sm text-primary-700">
+              Bitte melde dich nur an, wenn du sicher kommen kannst. Bei Fragen
+              oder falls du kurzfristig absagen musst, kontaktiere uns bitte
+              direkt.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Info Blocks */}
+      {data.infoBloecke.length > 0 && (
+        <div className="mb-6 space-y-4">
+          {data.infoBloecke.map((info) => (
+            <div
+              key={info.id}
+              className="rounded-xl border border-info-200 bg-info-50 p-4"
+            >
+              <h4 className="font-medium text-info-900">{info.titel}</h4>
+              {info.beschreibung && (
+                <p className="mt-1 text-sm text-info-700">{info.beschreibung}</p>
+              )}
+              <p className="mt-2 text-xs text-info-600">
+                {info.startzeit.slice(0, 5)} - {info.endzeit.slice(0, 5)} Uhr
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Zeitbloecke with Schichten */}
+      <div className="space-y-6">
+        <h2 className="text-lg font-semibold text-gray-900">
+          Verfügbare Schichten
+        </h2>
+        {data.zeitbloecke.map((zeitblock) => (
+          <PublicZeitblockGroup
+            key={zeitblock.id}
+            zeitblock={zeitblock}
+            onRegister={handleRegister}
+          />
+        ))}
+      </div>
+
+      {/* Registration Form Modal */}
+      {state.type === 'form' && (
+        <ExternalRegistrationForm
+          token={token}
+          schichtId={state.schichtId}
+          schichtName={state.schichtName}
+          zeitInfo={state.zeitInfo}
+          onClose={handleClose}
+          onSuccess={handleSuccess}
+        />
+      )}
+    </>
+  )
+}

--- a/apps/web/components/public-registration/PublicSchichtCard.tsx
+++ b/apps/web/components/public-registration/PublicSchichtCard.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { useState } from 'react'
+import type { PublicSchichtData } from '@/lib/actions/external-registration'
+
+interface PublicSchichtCardProps {
+  schicht: PublicSchichtData
+  onRegister: (schichtId: string) => void
+  disabled?: boolean
+}
+
+export function PublicSchichtCard({
+  schicht,
+  onRegister,
+  disabled = false,
+}: PublicSchichtCardProps) {
+  const [isHovered, setIsHovered] = useState(false)
+
+  const isFull = schicht.freie_plaetze <= 0
+  const slotsText = isFull
+    ? 'Alle Plätze belegt'
+    : `${schicht.freie_plaetze} von ${schicht.anzahl_benoetigt} ${schicht.freie_plaetze === 1 ? 'Platz' : 'Plätze'} frei`
+
+  return (
+    <div
+      className={`rounded-lg border p-4 transition-all ${
+        isFull
+          ? 'border-gray-200 bg-gray-50'
+          : 'border-primary-200 bg-white hover:border-primary-300 hover:shadow-sm'
+      }`}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex-1">
+          <h4 className="font-medium text-gray-900">{schicht.rolle}</h4>
+          <p className={`text-sm ${isFull ? 'text-gray-400' : 'text-gray-600'}`}>
+            {slotsText}
+          </p>
+        </div>
+
+        {!isFull && (
+          <button
+            onClick={() => onRegister(schicht.id)}
+            disabled={disabled}
+            className={`ml-4 rounded-lg px-4 py-2 text-sm font-medium transition-all ${
+              isHovered
+                ? 'bg-primary-600 text-white'
+                : 'bg-primary-50 text-primary-700'
+            } hover:bg-primary-600 hover:text-white disabled:cursor-not-allowed disabled:opacity-50`}
+          >
+            Anmelden
+          </button>
+        )}
+
+        {isFull && (
+          <span className="ml-4 rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-500">
+            Belegt
+          </span>
+        )}
+      </div>
+
+      {/* Slot indicator */}
+      <div className="mt-3">
+        <div className="flex gap-1">
+          {Array.from({ length: schicht.anzahl_benoetigt }).map((_, i) => (
+            <div
+              key={i}
+              className={`h-2 flex-1 rounded-full ${
+                i < schicht.anzahl_belegt
+                  ? 'bg-primary-500'
+                  : 'bg-gray-200'
+              }`}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/public-registration/PublicZeitblockGroup.tsx
+++ b/apps/web/components/public-registration/PublicZeitblockGroup.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { PublicSchichtCard } from './PublicSchichtCard'
+import type { PublicZeitblockData } from '@/lib/actions/external-registration'
+
+interface PublicZeitblockGroupProps {
+  zeitblock: PublicZeitblockData
+  onRegister: (schichtId: string) => void
+  disabled?: boolean
+}
+
+export function PublicZeitblockGroup({
+  zeitblock,
+  onRegister,
+  disabled = false,
+}: PublicZeitblockGroupProps) {
+  const formatTime = (timeStr: string) => {
+    return timeStr.slice(0, 5)
+  }
+
+  const totalSlots = zeitblock.schichten.reduce(
+    (sum, s) => sum + s.anzahl_benoetigt,
+    0
+  )
+  const totalFree = zeitblock.schichten.reduce(
+    (sum, s) => sum + s.freie_plaetze,
+    0
+  )
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white shadow-sm">
+      {/* Header */}
+      <div className="border-b border-gray-100 px-5 py-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="font-semibold text-gray-900">{zeitblock.name}</h3>
+            <p className="text-sm text-gray-500">
+              {formatTime(zeitblock.startzeit)} - {formatTime(zeitblock.endzeit)} Uhr
+            </p>
+          </div>
+          <div className="text-right">
+            <span
+              className={`text-sm font-medium ${
+                totalFree > 0 ? 'text-success-600' : 'text-gray-400'
+              }`}
+            >
+              {totalFree > 0
+                ? `${totalFree} ${totalFree === 1 ? 'Platz' : 'Plätze'} frei`
+                : 'Alle belegt'}
+            </span>
+            <p className="text-xs text-gray-400">
+              von {totalSlots} gesamt
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Schichten */}
+      <div className="space-y-3 p-4">
+        {zeitblock.schichten.map((schicht) => (
+          <PublicSchichtCard
+            key={schicht.id}
+            schicht={schicht}
+            onRegister={onRegister}
+            disabled={disabled}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/public-registration/SuccessScreen.tsx
+++ b/apps/web/components/public-registration/SuccessScreen.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+interface SuccessScreenProps {
+  schichtName: string
+  veranstaltungName: string
+  onRegisterMore: () => void
+}
+
+export function SuccessScreen({
+  schichtName,
+  veranstaltungName,
+  onRegisterMore,
+}: SuccessScreenProps) {
+  return (
+    <div className="rounded-xl border border-success-200 bg-white p-8 text-center shadow-sm">
+      {/* Success Icon */}
+      <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-success-100">
+        <svg
+          className="h-8 w-8 text-success-600"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M5 13l4 4L19 7"
+          />
+        </svg>
+      </div>
+
+      {/* Message */}
+      <h2 className="text-xl font-semibold text-gray-900">
+        Deine Anmeldung wurde gespeichert!
+      </h2>
+
+      <p className="mt-3 text-gray-600">
+        Du hast dich erfolgreich für{' '}
+        <span className="font-medium text-gray-900">&quot;{schichtName}&quot;</span>{' '}
+        bei{' '}
+        <span className="font-medium text-gray-900">&quot;{veranstaltungName}&quot;</span>{' '}
+        angemeldet.
+      </p>
+
+      {/* Email Notice */}
+      <div className="mt-6 rounded-lg bg-gray-50 p-4">
+        <p className="text-sm text-gray-600">
+          Du erhältst in Kürze eine Bestätigung per E-Mail.
+        </p>
+        <p className="mt-1 text-xs text-gray-500">
+          Falls du die E-Mail nicht erhältst, prüfe bitte deinen Spam-Ordner.
+        </p>
+      </div>
+
+      {/* Actions */}
+      <div className="mt-8">
+        <button
+          onClick={onRegisterMore}
+          className="inline-flex items-center gap-2 rounded-lg bg-primary-600 px-6 py-3 font-medium text-white transition-colors hover:bg-primary-700"
+        >
+          <svg
+            className="h-5 w-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+            />
+          </svg>
+          Weitere Schicht buchen
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/public-registration/index.ts
+++ b/apps/web/components/public-registration/index.ts
@@ -1,0 +1,5 @@
+export { PublicHelferlisteView } from './PublicHelferlisteView'
+export { PublicZeitblockGroup } from './PublicZeitblockGroup'
+export { PublicSchichtCard } from './PublicSchichtCard'
+export { ExternalRegistrationForm } from './ExternalRegistrationForm'
+export { SuccessScreen } from './SuccessScreen'

--- a/apps/web/components/ui/ConfirmDialog.tsx
+++ b/apps/web/components/ui/ConfirmDialog.tsx
@@ -5,7 +5,8 @@ import { useEffect, useRef } from 'react'
 export interface ConfirmDialogProps {
   open: boolean
   title?: string
-  message: string
+  message?: string
+  description?: string // alias for message
   confirmLabel?: string
   cancelLabel?: string
   variant?: 'danger' | 'warning' | 'default'
@@ -17,12 +18,15 @@ export function ConfirmDialog({
   open,
   title = 'Bestätigung',
   message,
+  description,
   confirmLabel = 'Bestätigen',
   cancelLabel = 'Abbrechen',
   variant = 'default',
   onConfirm,
   onCancel,
 }: ConfirmDialogProps) {
+  // Support both message and description (description takes precedence)
+  const displayMessage = description || message || ''
   const dialogRef = useRef<HTMLDialogElement>(null)
   const confirmButtonRef = useRef<HTMLButtonElement>(null)
 
@@ -66,7 +70,7 @@ export function ConfirmDialog({
     >
       <div className="p-6">
         <h2 className="text-lg font-semibold text-neutral-900">{title}</h2>
-        <p className="mt-2 text-neutral-600">{message}</p>
+        <p className="mt-2 text-neutral-600">{displayMessage}</p>
 
         <div className="mt-6 flex justify-end gap-3">
           <button

--- a/apps/web/lib/actions/external-registration.ts
+++ b/apps/web/lib/actions/external-registration.ts
@@ -1,0 +1,347 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { createAdminClient } from '../supabase/admin'
+import { canRegisterForHelferliste } from './helfer-status'
+import { externeHelferRegistrierungSchema } from '../validations/externe-helfer'
+import type {
+  Veranstaltung,
+  AuffuehrungSchicht,
+  Zeitblock,
+  InfoBlock,
+} from '../supabase/types'
+
+// =============================================================================
+// Types for Public Access
+// =============================================================================
+
+export type PublicVeranstaltungData = Pick<
+  Veranstaltung,
+  'id' | 'titel' | 'datum' | 'startzeit' | 'endzeit' | 'ort' | 'helfer_status'
+>
+
+export type PublicSchichtData = Pick<
+  AuffuehrungSchicht,
+  'id' | 'rolle' | 'anzahl_benoetigt'
+> & {
+  zeitblock: Pick<Zeitblock, 'id' | 'name' | 'startzeit' | 'endzeit'> | null
+  anzahl_belegt: number
+  freie_plaetze: number
+}
+
+export type PublicZeitblockData = Pick<
+  Zeitblock,
+  'id' | 'name' | 'startzeit' | 'endzeit' | 'typ' | 'sortierung'
+> & {
+  schichten: PublicSchichtData[]
+}
+
+export type PublicHelferlisteData = {
+  veranstaltung: PublicVeranstaltungData
+  zeitbloecke: PublicZeitblockData[]
+  infoBloecke: InfoBlock[]
+}
+
+export type RegistrationResult = {
+  success: boolean
+  error?: string
+  waitlist?: boolean
+}
+
+// =============================================================================
+// Token Validation and Data Fetching
+// =============================================================================
+
+/**
+ * Validate token and get public helferliste data
+ * This is called by the public page - no authentication required
+ */
+export async function getPublicHelferlisteByToken(
+  token: string
+): Promise<PublicHelferlisteData | { error: string }> {
+  // Use admin client for public access (bypasses RLS for reading)
+  const supabase = createAdminClient()
+
+  // Validate token and get veranstaltung
+  const { data: veranstaltung, error: veranstaltungError } = await supabase
+    .from('veranstaltungen')
+    .select('id, titel, datum, startzeit, endzeit, ort, helfer_status')
+    .eq('public_helfer_token', token)
+    .single()
+
+  if (veranstaltungError || !veranstaltung) {
+    return { error: 'Ungültiger Link. Bitte überprüfe die URL.' }
+  }
+
+  // Check status
+  if (veranstaltung.helfer_status !== 'veroeffentlicht') {
+    if (veranstaltung.helfer_status === 'abgeschlossen') {
+      return { error: 'Die Anmeldung für diese Veranstaltung ist abgeschlossen.' }
+    }
+    return { error: 'Diese Helferliste ist noch nicht öffentlich verfügbar.' }
+  }
+
+  // Check if event is in the past
+  const eventDate = new Date(veranstaltung.datum)
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  if (eventDate < today) {
+    return { error: 'Diese Veranstaltung hat bereits stattgefunden.' }
+  }
+
+  // Get zeitbloecke with public schichten
+  const { data: zeitbloecke, error: zeitblockError } = await supabase
+    .from('zeitbloecke')
+    .select('id, name, startzeit, endzeit, typ, sortierung')
+    .eq('veranstaltung_id', veranstaltung.id)
+    .order('sortierung', { ascending: true })
+
+  if (zeitblockError) {
+    console.error('Error fetching zeitbloecke:', zeitblockError)
+    return { error: 'Fehler beim Laden der Daten.' }
+  }
+
+  // Get public schichten with assignment counts
+  const { data: schichten, error: schichtenError } = await supabase
+    .from('auffuehrung_schichten')
+    .select(`
+      id,
+      rolle,
+      anzahl_benoetigt,
+      zeitblock_id,
+      zuweisungen:auffuehrung_zuweisungen(id, status)
+    `)
+    .eq('veranstaltung_id', veranstaltung.id)
+    .eq('sichtbarkeit', 'public')
+
+  if (schichtenError) {
+    console.error('Error fetching schichten:', schichtenError)
+    return { error: 'Fehler beim Laden der Daten.' }
+  }
+
+  // Get info_bloecke
+  const { data: infoBloecke, error: infoError } = await supabase
+    .from('info_bloecke')
+    .select('*')
+    .eq('veranstaltung_id', veranstaltung.id)
+    .order('sortierung', { ascending: true })
+
+  if (infoError) {
+    console.error('Error fetching info_bloecke:', infoError)
+  }
+
+  // Group schichten by zeitblock
+  const zeitblockMap = new Map<string | null, PublicSchichtData[]>()
+
+  for (const schicht of schichten || []) {
+    const zuweisungen = (schicht.zuweisungen as unknown as { id: string; status: string }[]) || []
+    const anzahl_belegt = zuweisungen.filter(z => z.status !== 'abgesagt').length
+    const freie_plaetze = Math.max(0, schicht.anzahl_benoetigt - anzahl_belegt)
+
+    const zeitblockId = schicht.zeitblock_id
+    const zeitblock = zeitbloecke?.find(zb => zb.id === zeitblockId)
+
+    const schichtData: PublicSchichtData = {
+      id: schicht.id,
+      rolle: schicht.rolle,
+      anzahl_benoetigt: schicht.anzahl_benoetigt,
+      zeitblock: zeitblock ? {
+        id: zeitblock.id,
+        name: zeitblock.name,
+        startzeit: zeitblock.startzeit,
+        endzeit: zeitblock.endzeit,
+      } : null,
+      anzahl_belegt,
+      freie_plaetze,
+    }
+
+    const key = zeitblockId
+    if (!zeitblockMap.has(key)) {
+      zeitblockMap.set(key, [])
+    }
+    zeitblockMap.get(key)!.push(schichtData)
+  }
+
+  // Build response with grouped schichten
+  const transformedZeitbloecke: PublicZeitblockData[] = (zeitbloecke || [])
+    .filter(zb => zeitblockMap.has(zb.id))
+    .map(zb => ({
+      ...zb,
+      schichten: zeitblockMap.get(zb.id) || [],
+    }))
+
+  // Add schichten without zeitblock if any
+  const orphanSchichten = zeitblockMap.get(null)
+  if (orphanSchichten && orphanSchichten.length > 0) {
+    transformedZeitbloecke.push({
+      id: 'ohne-zeitblock',
+      name: 'Allgemein',
+      startzeit: veranstaltung.startzeit || '00:00',
+      endzeit: veranstaltung.endzeit || '23:59',
+      typ: 'standard',
+      sortierung: 9999,
+      schichten: orphanSchichten,
+    })
+  }
+
+  return {
+    veranstaltung: veranstaltung as PublicVeranstaltungData,
+    zeitbloecke: transformedZeitbloecke,
+    infoBloecke: (infoBloecke || []) as InfoBlock[],
+  }
+}
+
+// =============================================================================
+// External Helper Registration
+// =============================================================================
+
+/**
+ * Register an external helper for a shift
+ * This is called from the public page - uses token validation
+ */
+export async function registerExternalHelper(
+  token: string,
+  schichtId: string,
+  helperData: {
+    email: string
+    vorname: string
+    nachname: string
+    telefon?: string
+  }
+): Promise<RegistrationResult> {
+  // Validate helper data
+  const parseResult = externeHelferRegistrierungSchema.safeParse(helperData)
+  if (!parseResult.success) {
+    const firstIssue = parseResult.error.issues[0]
+    return { success: false, error: firstIssue.message }
+  }
+  const validData = parseResult.data
+
+  const supabase = createAdminClient()
+
+  // Validate token and get veranstaltung
+  const { data: veranstaltung, error: veranstaltungError } = await supabase
+    .from('veranstaltungen')
+    .select('id, helfer_status')
+    .eq('public_helfer_token', token)
+    .single()
+
+  if (veranstaltungError || !veranstaltung) {
+    return { success: false, error: 'Ungültiger Link' }
+  }
+
+  // Check if registration is allowed
+  const canRegister = await canRegisterForHelferliste(veranstaltung.id, true)
+  if (!canRegister.allowed) {
+    return { success: false, error: canRegister.reason }
+  }
+
+  // Verify schicht exists and is public
+  const { data: schicht, error: schichtError } = await supabase
+    .from('auffuehrung_schichten')
+    .select('id, veranstaltung_id, anzahl_benoetigt, sichtbarkeit')
+    .eq('id', schichtId)
+    .single()
+
+  if (schichtError || !schicht) {
+    return { success: false, error: 'Schicht nicht gefunden' }
+  }
+
+  if (schicht.veranstaltung_id !== veranstaltung.id) {
+    return { success: false, error: 'Ungültige Schicht' }
+  }
+
+  if (schicht.sichtbarkeit !== 'public') {
+    return { success: false, error: 'Diese Schicht ist nicht öffentlich verfügbar' }
+  }
+
+  // Find or create external helper profile
+  const { data: helperId, error: helperError } = await supabase
+    .rpc('find_or_create_external_helper', {
+      p_email: validData.email,
+      p_vorname: validData.vorname,
+      p_nachname: validData.nachname,
+      p_telefon: validData.telefon || null,
+    })
+
+  if (helperError || !helperId) {
+    console.error('Error creating helper profile:', helperError)
+    return { success: false, error: 'Fehler bei der Registrierung' }
+  }
+
+  // Check if already registered for this shift
+  const { data: existingZuweisung } = await supabase
+    .from('auffuehrung_zuweisungen')
+    .select('id')
+    .eq('schicht_id', schichtId)
+    .eq('external_helper_id', helperId)
+    .single()
+
+  if (existingZuweisung) {
+    return { success: false, error: 'Du bist bereits für diese Schicht angemeldet' }
+  }
+
+  // Check available slots
+  const { count: currentCount } = await supabase
+    .from('auffuehrung_zuweisungen')
+    .select('id', { count: 'exact', head: true })
+    .eq('schicht_id', schichtId)
+    .neq('status', 'abgesagt')
+
+  const isWaitlist = (currentCount ?? 0) >= schicht.anzahl_benoetigt
+
+  // Create zuweisung
+  const { error: insertError } = await supabase
+    .from('auffuehrung_zuweisungen')
+    .insert({
+      schicht_id: schichtId,
+      external_helper_id: helperId,
+      status: 'zugesagt',
+    } as never)
+
+  if (insertError) {
+    console.error('Error creating zuweisung:', insertError)
+    if (insertError.code === '23505') {
+      return { success: false, error: 'Du bist bereits für diese Schicht angemeldet' }
+    }
+    return { success: false, error: 'Fehler bei der Anmeldung' }
+  }
+
+  // Revalidate paths
+  revalidatePath(`/helfer/anmeldung/${token}`)
+
+  return { success: true, waitlist: isWaitlist }
+}
+
+/**
+ * Check if an email is already registered for a schicht
+ */
+export async function checkExistingRegistration(
+  token: string,
+  schichtId: string,
+  email: string
+): Promise<{ registered: boolean }> {
+  const supabase = createAdminClient()
+
+  // Find external helper by email
+  const { data: helper } = await supabase
+    .from('externe_helfer_profile')
+    .select('id')
+    .ilike('email', email.toLowerCase().trim())
+    .single()
+
+  if (!helper) {
+    return { registered: false }
+  }
+
+  // Check if registered for this schicht
+  const { data: zuweisung } = await supabase
+    .from('auffuehrung_zuweisungen')
+    .select('id')
+    .eq('schicht_id', schichtId)
+    .eq('external_helper_id', helper.id)
+    .neq('status', 'abgesagt')
+    .single()
+
+  return { registered: !!zuweisung }
+}

--- a/apps/web/lib/actions/helfer-anmeldung.ts
+++ b/apps/web/lib/actions/helfer-anmeldung.ts
@@ -36,6 +36,8 @@ export type HelferlisteData = {
     startzeit: string | null
     endzeit: string | null
     ort: string | null
+    helfer_status: 'entwurf' | 'veroeffentlicht' | 'abgeschlossen' | null
+    public_helfer_token: string | null
   }
   zeitbloecke: ZeitblockMitSchichten[]
   infoBloecke: InfoBlock[]
@@ -57,7 +59,7 @@ export async function getHelferlisteData(
   // Get veranstaltung
   const { data: veranstaltung, error: veranstaltungError } = await supabase
     .from('veranstaltungen')
-    .select('id, titel, datum, startzeit, endzeit, ort')
+    .select('id, titel, datum, startzeit, endzeit, ort, helfer_status, public_helfer_token')
     .eq('id', veranstaltungId)
     .eq('typ', 'auffuehrung')
     .single()

--- a/apps/web/lib/actions/helfer-status.ts
+++ b/apps/web/lib/actions/helfer-status.ts
@@ -1,0 +1,279 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { createClient } from '../supabase/server'
+import { requirePermission } from '../supabase/auth-helpers'
+import type { HelferStatus, Veranstaltung } from '../supabase/types'
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type HelferStatusResult = {
+  success: boolean
+  error?: string
+  token?: string
+}
+
+export type VeranstaltungMitHelferStatus = Pick<
+  Veranstaltung,
+  'id' | 'titel' | 'helfer_status' | 'public_helfer_token'
+>
+
+// =============================================================================
+// Status Transitions
+// =============================================================================
+
+/**
+ * Publish helper list (Entwurf -> Veroeffentlicht)
+ *
+ * - Generates public token if not already present
+ * - Changes status to 'veroeffentlicht'
+ * - Enables public registration
+ */
+export async function publishHelferliste(
+  veranstaltungId: string
+): Promise<HelferStatusResult> {
+  await requirePermission('helferliste:write')
+
+  const supabase = await createClient()
+
+  // Get current state
+  const { data: veranstaltung, error: fetchError } = await supabase
+    .from('veranstaltungen')
+    .select('id, helfer_status, public_helfer_token')
+    .eq('id', veranstaltungId)
+    .single()
+
+  if (fetchError || !veranstaltung) {
+    console.error('Error fetching veranstaltung:', fetchError)
+    return { success: false, error: 'Veranstaltung nicht gefunden' }
+  }
+
+  // Validate transition
+  if (veranstaltung.helfer_status === 'abgeschlossen') {
+    return { success: false, error: 'Abgeschlossene Helferlisten können nicht erneut veröffentlicht werden' }
+  }
+
+  if (veranstaltung.helfer_status === 'veroeffentlicht') {
+    return { success: false, error: 'Helferliste ist bereits veröffentlicht' }
+  }
+
+  // Generate token if not present
+  let token = veranstaltung.public_helfer_token
+  if (!token) {
+    const { data: newToken, error: tokenError } = await supabase
+      .rpc('generate_public_helfer_token', { p_veranstaltung_id: veranstaltungId })
+
+    if (tokenError) {
+      console.error('Error generating token:', tokenError)
+      return { success: false, error: 'Fehler beim Generieren des öffentlichen Links' }
+    }
+    token = newToken
+  }
+
+  // Update status
+  const { error: updateError } = await supabase
+    .from('veranstaltungen')
+    .update({
+      helfer_status: 'veroeffentlicht' as HelferStatus,
+      public_helfer_token: token,
+    } as never)
+    .eq('id', veranstaltungId)
+
+  if (updateError) {
+    console.error('Error updating helfer_status:', updateError)
+    return { success: false, error: 'Fehler beim Veröffentlichen' }
+  }
+
+  revalidatePath(`/auffuehrungen/${veranstaltungId}`)
+  revalidatePath(`/auffuehrungen/${veranstaltungId}/helferliste`)
+
+  return { success: true, token: token ?? undefined }
+}
+
+/**
+ * Close helper list (Veroeffentlicht -> Abgeschlossen)
+ *
+ * - Prevents new registrations (internal and external)
+ * - Existing registrations remain visible
+ * - Cannot be undone (except by admin)
+ */
+export async function closeHelferliste(
+  veranstaltungId: string
+): Promise<HelferStatusResult> {
+  await requirePermission('helferliste:write')
+
+  const supabase = await createClient()
+
+  // Get current state
+  const { data: veranstaltung, error: fetchError } = await supabase
+    .from('veranstaltungen')
+    .select('id, helfer_status')
+    .eq('id', veranstaltungId)
+    .single()
+
+  if (fetchError || !veranstaltung) {
+    console.error('Error fetching veranstaltung:', fetchError)
+    return { success: false, error: 'Veranstaltung nicht gefunden' }
+  }
+
+  // Validate transition
+  if (veranstaltung.helfer_status === 'abgeschlossen') {
+    return { success: false, error: 'Helferliste ist bereits abgeschlossen' }
+  }
+
+  if (veranstaltung.helfer_status === 'entwurf' || !veranstaltung.helfer_status) {
+    return { success: false, error: 'Nur veröffentlichte Helferlisten können abgeschlossen werden' }
+  }
+
+  // Update status
+  const { error: updateError } = await supabase
+    .from('veranstaltungen')
+    .update({ helfer_status: 'abgeschlossen' as HelferStatus } as never)
+    .eq('id', veranstaltungId)
+
+  if (updateError) {
+    console.error('Error updating helfer_status:', updateError)
+    return { success: false, error: 'Fehler beim Abschliessen' }
+  }
+
+  revalidatePath(`/auffuehrungen/${veranstaltungId}`)
+  revalidatePath(`/auffuehrungen/${veranstaltungId}/helferliste`)
+
+  return { success: true }
+}
+
+/**
+ * Reset helper list status (Admin only)
+ *
+ * - Allows admin to reopen a closed list
+ * - Use with caution - should be rare
+ */
+export async function resetHelferStatus(
+  veranstaltungId: string,
+  newStatus: HelferStatus
+): Promise<HelferStatusResult> {
+  await requirePermission('admin:access')
+
+  const supabase = await createClient()
+
+  const { error: updateError } = await supabase
+    .from('veranstaltungen')
+    .update({ helfer_status: newStatus } as never)
+    .eq('id', veranstaltungId)
+
+  if (updateError) {
+    console.error('Error resetting helfer_status:', updateError)
+    return { success: false, error: 'Fehler beim Zurücksetzen' }
+  }
+
+  revalidatePath(`/auffuehrungen/${veranstaltungId}`)
+  revalidatePath(`/auffuehrungen/${veranstaltungId}/helferliste`)
+
+  return { success: true }
+}
+
+// =============================================================================
+// Token Management
+// =============================================================================
+
+/**
+ * Generate a new public token (invalidates old one)
+ */
+export async function regeneratePublicToken(
+  veranstaltungId: string
+): Promise<HelferStatusResult> {
+  await requirePermission('helferliste:write')
+
+  const supabase = await createClient()
+
+  const { data: newToken, error: tokenError } = await supabase
+    .rpc('generate_public_helfer_token', { p_veranstaltung_id: veranstaltungId })
+
+  if (tokenError) {
+    console.error('Error generating token:', tokenError)
+    return { success: false, error: 'Fehler beim Generieren des neuen Links' }
+  }
+
+  revalidatePath(`/auffuehrungen/${veranstaltungId}`)
+  revalidatePath(`/auffuehrungen/${veranstaltungId}/helferliste`)
+
+  return { success: true, token: newToken }
+}
+
+/**
+ * Get public link URL for a veranstaltung
+ */
+export async function getPublicHelferLink(
+  veranstaltungId: string
+): Promise<{ url: string | null; status: HelferStatus | null }> {
+  const supabase = await createClient()
+
+  const { data, error } = await supabase
+    .from('veranstaltungen')
+    .select('public_helfer_token, helfer_status')
+    .eq('id', veranstaltungId)
+    .single()
+
+  if (error || !data?.public_helfer_token) {
+    return { url: null, status: data?.helfer_status ?? null }
+  }
+
+  // Build URL based on environment
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
+  const url = `${baseUrl}/helfer/anmeldung/${data.public_helfer_token}`
+
+  return { url, status: data.helfer_status }
+}
+
+// =============================================================================
+// Validation Helpers
+// =============================================================================
+
+/**
+ * Check if registration is allowed for a veranstaltung
+ * Used by both internal and external registration flows
+ */
+export async function canRegisterForHelferliste(
+  veranstaltungId: string,
+  isExternal: boolean = false
+): Promise<{ allowed: boolean; reason?: string }> {
+  const supabase = await createClient()
+
+  const { data: veranstaltung, error } = await supabase
+    .from('veranstaltungen')
+    .select('helfer_status, datum, helfer_buchung_deadline')
+    .eq('id', veranstaltungId)
+    .single()
+
+  if (error || !veranstaltung) {
+    return { allowed: false, reason: 'Veranstaltung nicht gefunden' }
+  }
+
+  // Check status
+  if (veranstaltung.helfer_status === 'abgeschlossen') {
+    return { allowed: false, reason: 'Die Anmeldung für diese Veranstaltung ist abgeschlossen' }
+  }
+
+  // External helpers need published status
+  if (isExternal && veranstaltung.helfer_status !== 'veroeffentlicht') {
+    return { allowed: false, reason: 'Diese Helferliste ist nicht öffentlich verfügbar' }
+  }
+
+  // Check if event date has passed
+  const eventDate = new Date(veranstaltung.datum)
+  if (eventDate < new Date()) {
+    return { allowed: false, reason: 'Diese Veranstaltung hat bereits stattgefunden' }
+  }
+
+  // Check deadline
+  if (veranstaltung.helfer_buchung_deadline) {
+    const deadline = new Date(veranstaltung.helfer_buchung_deadline)
+    if (deadline < new Date()) {
+      return { allowed: false, reason: 'Die Anmeldefrist ist abgelaufen' }
+    }
+  }
+
+  return { allowed: true }
+}

--- a/apps/web/lib/actions/schicht-sichtbarkeit.ts
+++ b/apps/web/lib/actions/schicht-sichtbarkeit.ts
@@ -1,0 +1,202 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { createClient } from '../supabase/server'
+import { requirePermission } from '../supabase/auth-helpers'
+import type { SchichtSichtbarkeit } from '../supabase/types'
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type SichtbarkeitResult = {
+  success: boolean
+  error?: string
+  updated?: number
+}
+
+// =============================================================================
+// Single Schicht Updates
+// =============================================================================
+
+/**
+ * Update visibility of a single shift
+ */
+export async function updateSchichtSichtbarkeit(
+  schichtId: string,
+  sichtbarkeit: SchichtSichtbarkeit
+): Promise<SichtbarkeitResult> {
+  await requirePermission('helferliste:write')
+
+  const supabase = await createClient()
+
+  // Get veranstaltung_id for path revalidation
+  const { data: schicht, error: fetchError } = await supabase
+    .from('auffuehrung_schichten')
+    .select('veranstaltung_id')
+    .eq('id', schichtId)
+    .single()
+
+  if (fetchError || !schicht) {
+    console.error('Error fetching schicht:', fetchError)
+    return { success: false, error: 'Schicht nicht gefunden' }
+  }
+
+  const { error: updateError } = await supabase
+    .from('auffuehrung_schichten')
+    .update({ sichtbarkeit } as never)
+    .eq('id', schichtId)
+
+  if (updateError) {
+    console.error('Error updating sichtbarkeit:', updateError)
+    return { success: false, error: 'Fehler beim Aktualisieren der Sichtbarkeit' }
+  }
+
+  revalidatePath(`/auffuehrungen/${schicht.veranstaltung_id}`)
+  revalidatePath(`/auffuehrungen/${schicht.veranstaltung_id}/helferliste`)
+  revalidatePath(`/auffuehrungen/${schicht.veranstaltung_id}/schichten`)
+
+  return { success: true, updated: 1 }
+}
+
+// =============================================================================
+// Bulk Updates
+// =============================================================================
+
+/**
+ * Update visibility for multiple shifts at once
+ */
+export async function bulkUpdateSichtbarkeit(
+  schichtIds: string[],
+  sichtbarkeit: SchichtSichtbarkeit
+): Promise<SichtbarkeitResult> {
+  await requirePermission('helferliste:write')
+
+  if (schichtIds.length === 0) {
+    return { success: false, error: 'Keine Schichten ausgewählt' }
+  }
+
+  const supabase = await createClient()
+
+  // Get all affected veranstaltung_ids for revalidation
+  const { data: schichten, error: fetchError } = await supabase
+    .from('auffuehrung_schichten')
+    .select('veranstaltung_id')
+    .in('id', schichtIds)
+
+  if (fetchError) {
+    console.error('Error fetching schichten:', fetchError)
+    return { success: false, error: 'Fehler beim Laden der Schichten' }
+  }
+
+  const { error: updateError } = await supabase
+    .from('auffuehrung_schichten')
+    .update({ sichtbarkeit } as never)
+    .in('id', schichtIds)
+
+  if (updateError) {
+    console.error('Error bulk updating sichtbarkeit:', updateError)
+    return { success: false, error: 'Fehler beim Aktualisieren der Sichtbarkeit' }
+  }
+
+  // Revalidate all affected veranstaltungen
+  const veranstaltungIds = [...new Set(schichten?.map(s => s.veranstaltung_id) || [])]
+  for (const vId of veranstaltungIds) {
+    revalidatePath(`/auffuehrungen/${vId}`)
+    revalidatePath(`/auffuehrungen/${vId}/helferliste`)
+    revalidatePath(`/auffuehrungen/${vId}/schichten`)
+  }
+
+  return { success: true, updated: schichtIds.length }
+}
+
+/**
+ * Set all shifts of a veranstaltung to a specific visibility
+ */
+export async function setAllSchichtenSichtbarkeit(
+  veranstaltungId: string,
+  sichtbarkeit: SchichtSichtbarkeit
+): Promise<SichtbarkeitResult> {
+  await requirePermission('helferliste:write')
+
+  const supabase = await createClient()
+
+  // First count existing schichten
+  const { count: totalCount } = await supabase
+    .from('auffuehrung_schichten')
+    .select('id', { count: 'exact', head: true })
+    .eq('veranstaltung_id', veranstaltungId)
+
+  const { error: updateError } = await supabase
+    .from('auffuehrung_schichten')
+    .update({ sichtbarkeit } as never)
+    .eq('veranstaltung_id', veranstaltungId)
+
+  if (updateError) {
+    console.error('Error setting all schichten sichtbarkeit:', updateError)
+    return { success: false, error: 'Fehler beim Aktualisieren der Sichtbarkeit' }
+  }
+
+  revalidatePath(`/auffuehrungen/${veranstaltungId}`)
+  revalidatePath(`/auffuehrungen/${veranstaltungId}/helferliste`)
+  revalidatePath(`/auffuehrungen/${veranstaltungId}/schichten`)
+
+  return { success: true, updated: totalCount ?? 0 }
+}
+
+// =============================================================================
+// Query Helpers
+// =============================================================================
+
+/**
+ * Get visibility statistics for a veranstaltung
+ */
+export async function getSchichtSichtbarkeitStats(
+  veranstaltungId: string
+): Promise<{ intern: number; public: number; total: number }> {
+  const supabase = await createClient()
+
+  const { data: schichten, error } = await supabase
+    .from('auffuehrung_schichten')
+    .select('id, sichtbarkeit')
+    .eq('veranstaltung_id', veranstaltungId)
+
+  if (error || !schichten) {
+    console.error('Error fetching schichten stats:', error)
+    return { intern: 0, public: 0, total: 0 }
+  }
+
+  const intern = schichten.filter(s => s.sichtbarkeit === 'intern').length
+  const publicCount = schichten.filter(s => s.sichtbarkeit === 'public').length
+
+  return {
+    intern,
+    public: publicCount,
+    total: schichten.length,
+  }
+}
+
+/**
+ * Check if changing visibility would affect external registrations
+ */
+export async function checkExternalRegistrationsForSchicht(
+  schichtId: string
+): Promise<{ hasExternalRegistrations: boolean; count: number }> {
+  const supabase = await createClient()
+
+  const { count, error } = await supabase
+    .from('auffuehrung_zuweisungen')
+    .select('id', { count: 'exact', head: true })
+    .eq('schicht_id', schichtId)
+    .not('external_helper_id', 'is', null)
+
+  if (error) {
+    console.error('Error checking external registrations:', error)
+    return { hasExternalRegistrations: false, count: 0 }
+  }
+
+  return {
+    hasExternalRegistrations: (count ?? 0) > 0,
+    count: count ?? 0,
+  }
+}

--- a/apps/web/lib/supabase/types.ts
+++ b/apps/web/lib/supabase/types.ts
@@ -298,6 +298,12 @@ export type VeranstaltungStatus =
 
 export type HelferStatus = 'entwurf' | 'veroeffentlicht' | 'abgeschlossen'
 
+export const HELFER_STATUS_LABELS: Record<HelferStatus, string> = {
+  entwurf: 'Entwurf',
+  veroeffentlicht: 'Veröffentlicht',
+  abgeschlossen: 'Abgeschlossen',
+}
+
 export type Veranstaltung = {
   id: string
   titel: string
@@ -313,6 +319,7 @@ export type Veranstaltung = {
   status: VeranstaltungStatus
   helfer_template_id: string | null
   helfer_status: HelferStatus | null
+  public_helfer_token: string | null
   // Booking limits (Issue #210)
   max_schichten_pro_helfer: number | null
   helfer_buchung_deadline: string | null
@@ -328,12 +335,14 @@ export type VeranstaltungInsert = Omit<
   | 'updated_at'
   | 'helfer_template_id'
   | 'helfer_status'
+  | 'public_helfer_token'
   | 'max_schichten_pro_helfer'
   | 'helfer_buchung_deadline'
   | 'helfer_buchung_limit_aktiv'
 > & {
   helfer_template_id?: string | null
   helfer_status?: HelferStatus | null
+  public_helfer_token?: string | null
   max_schichten_pro_helfer?: number | null
   helfer_buchung_deadline?: string | null
   helfer_buchung_limit_aktiv?: boolean
@@ -580,19 +589,29 @@ export type ZeitblockUpdate = Partial<ZeitblockInsert>
 // Aufführung Schichten (Performance Shifts) - Issue #97
 // =============================================================================
 
+export type SchichtSichtbarkeit = 'intern' | 'public'
+
+export const SCHICHT_SICHTBARKEIT_LABELS: Record<SchichtSichtbarkeit, string> = {
+  intern: 'Intern',
+  public: 'Öffentlich',
+}
+
 export type AuffuehrungSchicht = {
   id: string
   veranstaltung_id: string
   zeitblock_id: string | null
   rolle: string
   anzahl_benoetigt: number
+  sichtbarkeit: SchichtSichtbarkeit
   created_at: string
 }
 
 export type AuffuehrungSchichtInsert = Omit<
   AuffuehrungSchicht,
-  'id' | 'created_at'
->
+  'id' | 'created_at' | 'sichtbarkeit'
+> & {
+  sichtbarkeit?: SchichtSichtbarkeit // defaults to 'intern' in DB
+}
 export type AuffuehrungSchichtUpdate = Partial<AuffuehrungSchichtInsert>
 
 // Extended type with time block details
@@ -616,7 +635,8 @@ export type ZuweisungStatus =
 export type AuffuehrungZuweisung = {
   id: string
   schicht_id: string
-  person_id: string
+  person_id: string | null
+  external_helper_id: string | null
   status: ZuweisungStatus
   notizen: string | null
   created_at: string
@@ -624,8 +644,10 @@ export type AuffuehrungZuweisung = {
 
 export type AuffuehrungZuweisungInsert = Omit<
   AuffuehrungZuweisung,
-  'id' | 'created_at' | 'updated_at'
->
+  'id' | 'created_at' | 'updated_at' | 'external_helper_id'
+> & {
+  external_helper_id?: string | null // optional - only for external helpers
+}
 export type AuffuehrungZuweisungUpdate = Partial<AuffuehrungZuweisungInsert>
 
 // Extended type with person details

--- a/apps/web/lib/validations/externe-helfer.ts
+++ b/apps/web/lib/validations/externe-helfer.ts
@@ -65,7 +65,17 @@ export const externeHelferRegistrierungSchema = z.object({
     .optional(),
 })
 
+/**
+ * Schema for public registration form with privacy acceptance
+ */
+export const externeHelferRegistrierungFormSchema = externeHelferRegistrierungSchema.extend({
+  datenschutz: z
+    .boolean()
+    .refine((val) => val === true, 'Bitte akzeptiere die Datenschutzerklärung'),
+})
+
 // Export types inferred from schemas
 export type ExterneHelferProfilFormData = z.infer<typeof externeHelferProfilSchema>
 export type ExterneHelferProfilUpdateFormData = z.infer<typeof externeHelferProfilUpdateSchema>
 export type ExterneHelferRegistrierungFormData = z.infer<typeof externeHelferRegistrierungSchema>
+export type ExterneHelferRegistrierungFormWithPrivacy = z.infer<typeof externeHelferRegistrierungFormSchema>

--- a/supabase/migrations/20260205111718_public_helfer_token.sql
+++ b/supabase/migrations/20260205111718_public_helfer_token.sql
@@ -1,0 +1,213 @@
+-- Migration: Public Helfer Token for Veranstaltungen
+-- Created: 2026-02-05
+-- Issues: #212, #213, #214, #215
+-- Description: Add public token to veranstaltungen for shareable helper registration links
+--   - Token enables anonymous access to helper registration
+--   - Works in conjunction with helfer_status for publication control
+
+-- =============================================================================
+-- ADD public_helfer_token TO veranstaltungen
+-- =============================================================================
+
+-- Add the public token column
+ALTER TABLE veranstaltungen
+ADD COLUMN IF NOT EXISTS public_helfer_token UUID UNIQUE;
+
+-- Create index for token lookups (used by public pages)
+CREATE INDEX IF NOT EXISTS veranstaltungen_public_helfer_token_idx
+  ON veranstaltungen(public_helfer_token)
+  WHERE public_helfer_token IS NOT NULL;
+
+-- Add comment
+COMMENT ON COLUMN veranstaltungen.public_helfer_token IS 'UUID token for public helper registration links. NULL means no public access.';
+
+-- =============================================================================
+-- ADD sichtbarkeit TO auffuehrung_schichten
+-- =============================================================================
+
+-- Add visibility control for individual shifts
+ALTER TABLE auffuehrung_schichten
+ADD COLUMN IF NOT EXISTS sichtbarkeit TEXT DEFAULT 'intern'
+  CHECK (sichtbarkeit IN ('intern', 'public'));
+
+-- Create index for filtering public shifts
+CREATE INDEX IF NOT EXISTS auffuehrung_schichten_sichtbarkeit_idx
+  ON auffuehrung_schichten(sichtbarkeit);
+
+-- Add comment
+COMMENT ON COLUMN auffuehrung_schichten.sichtbarkeit IS 'Visibility: intern (members only) or public (with token link)';
+
+-- =============================================================================
+-- RLS POLICIES FOR ANONYMOUS ACCESS
+-- =============================================================================
+
+-- Allow anon to read veranstaltungen with valid public token
+DROP POLICY IF EXISTS "veranstaltungen_select_public" ON veranstaltungen;
+CREATE POLICY "veranstaltungen_select_public"
+  ON veranstaltungen FOR SELECT
+  TO anon
+  USING (
+    public_helfer_token IS NOT NULL
+    AND helfer_status = 'veroeffentlicht'
+  );
+
+-- Allow anon to read zeitbloecke for published events
+DROP POLICY IF EXISTS "zeitbloecke_select_public" ON zeitbloecke;
+CREATE POLICY "zeitbloecke_select_public"
+  ON zeitbloecke FOR SELECT
+  TO anon
+  USING (
+    EXISTS (
+      SELECT 1 FROM veranstaltungen v
+      WHERE v.id = zeitbloecke.veranstaltung_id
+      AND v.public_helfer_token IS NOT NULL
+      AND v.helfer_status = 'veroeffentlicht'
+    )
+  );
+
+-- Allow anon to read public shifts for published events
+DROP POLICY IF EXISTS "auffuehrung_schichten_select_public" ON auffuehrung_schichten;
+CREATE POLICY "auffuehrung_schichten_select_public"
+  ON auffuehrung_schichten FOR SELECT
+  TO anon
+  USING (
+    sichtbarkeit = 'public'
+    AND EXISTS (
+      SELECT 1 FROM veranstaltungen v
+      WHERE v.id = auffuehrung_schichten.veranstaltung_id
+      AND v.public_helfer_token IS NOT NULL
+      AND v.helfer_status = 'veroeffentlicht'
+    )
+  );
+
+-- Allow anon to read info_bloecke for published events
+DROP POLICY IF EXISTS "info_bloecke_select_public" ON info_bloecke;
+CREATE POLICY "info_bloecke_select_public"
+  ON info_bloecke FOR SELECT
+  TO anon
+  USING (
+    EXISTS (
+      SELECT 1 FROM veranstaltungen v
+      WHERE v.id = info_bloecke.veranstaltung_id
+      AND v.public_helfer_token IS NOT NULL
+      AND v.helfer_status = 'veroeffentlicht'
+    )
+  );
+
+-- Allow anon to read public shift assignments (to show occupied slots)
+DROP POLICY IF EXISTS "auffuehrung_zuweisungen_select_public" ON auffuehrung_zuweisungen;
+CREATE POLICY "auffuehrung_zuweisungen_select_public"
+  ON auffuehrung_zuweisungen FOR SELECT
+  TO anon
+  USING (
+    EXISTS (
+      SELECT 1 FROM auffuehrung_schichten s
+      JOIN veranstaltungen v ON v.id = s.veranstaltung_id
+      WHERE s.id = auffuehrung_zuweisungen.schicht_id
+      AND s.sichtbarkeit = 'public'
+      AND v.public_helfer_token IS NOT NULL
+      AND v.helfer_status = 'veroeffentlicht'
+    )
+  );
+
+-- Allow anon to create zuweisungen for public shifts (external registration)
+DROP POLICY IF EXISTS "auffuehrung_zuweisungen_insert_public" ON auffuehrung_zuweisungen;
+CREATE POLICY "auffuehrung_zuweisungen_insert_public"
+  ON auffuehrung_zuweisungen FOR INSERT
+  TO anon
+  WITH CHECK (
+    -- Must have external_helper_id (uses externe_helfer_profile)
+    external_helper_id IS NOT NULL
+    AND person_id IS NULL
+    -- Must be for a public shift in a published event
+    AND EXISTS (
+      SELECT 1 FROM auffuehrung_schichten s
+      JOIN veranstaltungen v ON v.id = s.veranstaltung_id
+      WHERE s.id = schicht_id
+      AND s.sichtbarkeit = 'public'
+      AND v.public_helfer_token IS NOT NULL
+      AND v.helfer_status = 'veroeffentlicht'
+    )
+  );
+
+-- =============================================================================
+-- ADD external_helper_id TO auffuehrung_zuweisungen
+-- =============================================================================
+
+-- Add column for external helper reference
+ALTER TABLE auffuehrung_zuweisungen
+ADD COLUMN IF NOT EXISTS external_helper_id UUID REFERENCES externe_helfer_profile(id) ON DELETE SET NULL;
+
+-- Create index for lookups
+CREATE INDEX IF NOT EXISTS auffuehrung_zuweisungen_external_helper_idx
+  ON auffuehrung_zuweisungen(external_helper_id)
+  WHERE external_helper_id IS NOT NULL;
+
+-- Update constraint to allow either person_id or external_helper_id
+-- First check if constraint exists
+DO $$
+BEGIN
+  -- Add check constraint (will fail if neither or both are set)
+  -- This is a soft check - we'll handle validation in application code
+  -- since some existing records may have person_id set
+  NULL; -- No constraint change needed - person_id already allows NULL
+END $$;
+
+-- Add comment
+COMMENT ON COLUMN auffuehrung_zuweisungen.external_helper_id IS 'Reference to external helper profile (for non-member registrations)';
+
+-- =============================================================================
+-- FUNCTION: Generate public token for veranstaltung
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION generate_public_helfer_token(p_veranstaltung_id UUID)
+RETURNS UUID AS $$
+DECLARE
+  v_token UUID;
+BEGIN
+  v_token := gen_random_uuid();
+
+  UPDATE veranstaltungen
+  SET public_helfer_token = v_token
+  WHERE id = p_veranstaltung_id;
+
+  RETURN v_token;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Only authenticated users with management role can generate tokens
+REVOKE EXECUTE ON FUNCTION generate_public_helfer_token FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION generate_public_helfer_token TO authenticated;
+
+-- =============================================================================
+-- FUNCTION: Validate public token and return veranstaltung data
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION validate_public_helfer_token(p_token UUID)
+RETURNS TABLE (
+  id UUID,
+  titel TEXT,
+  datum DATE,
+  startzeit TIME,
+  endzeit TIME,
+  ort TEXT,
+  helfer_status TEXT
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    v.id,
+    v.titel,
+    v.datum,
+    v.startzeit,
+    v.endzeit,
+    v.ort,
+    v.helfer_status
+  FROM veranstaltungen v
+  WHERE v.public_helfer_token = p_token;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Allow anon and authenticated to validate tokens
+GRANT EXECUTE ON FUNCTION validate_public_helfer_token TO anon;
+GRANT EXECUTE ON FUNCTION validate_public_helfer_token TO authenticated;


### PR DESCRIPTION
## Summary

Implementiert Milestone M4: Öffentliche Anmeldung & Token für das Helper List & Shift Planning System.

### Issue #212: Public Token System für Aufführungen
- UUID-basierte Tokens für shareable Links
- Token-Validierung via `validate_public_helfer_token()` DB-Funktion
- Token-Regenerierung (invalidiert alte Links)
- "Link kopieren" Button in Admin-UI

### Issue #213: Öffentliche Helferliste-Seite (Anon)
- Neue Route `/helfer/anmeldung/[token]` ohne Login
- Zeigt nur Schichten mit `sichtbarkeit = 'public'`
- Registrierungsformular: Vorname, Nachname, Email, Telefon, Datenschutz-Checkbox
- Zod-Validierung für alle Felder
- Erfolgsbildschirm nach Anmeldung

### Issue #214: Sichtbarkeits-Kontrolle für Schichten
- Neues Feld `auffuehrung_schichten.sichtbarkeit` (intern/public)
- Toggle-Button pro Schicht (🔒/🌐 Icons)
- Bulk-Aktionen: "Alle öffentlich" / "Alle intern"
- Statistik-Anzeige: "X von Y Schichten öffentlich"

### Issue #215: Freigabe-Workflow
- Status-Workflow: Entwurf → Veröffentlicht → Abgeschlossen
- Farbige Status-Badges mit Icons
- Bestätigungsdialoge bei Status-Änderung
- Registrierung nur bei Status "Veröffentlicht" möglich
- Admin-Reset-Funktion

## Test plan

- [ ] Token wird beim Veröffentlichen automatisch generiert
- [ ] Öffentlicher Link `/helfer/anmeldung/[token]` zeigt nur öffentliche Schichten
- [ ] Externes Registrierungsformular validiert alle Felder
- [ ] Datenschutz-Checkbox ist erforderlich
- [ ] Nach Registrierung erscheint Erfolgsbildschirm
- [ ] Sichtbarkeits-Toggle ändert Icon (🔒↔🌐)
- [ ] Bulk-Aktionen ändern alle Schichten
- [ ] Status "Abgeschlossen" verhindert neue Anmeldungen
- [ ] Ungültiger Token zeigt Fehlerseite

🤖 Generated with [Claude Code](https://claude.com/claude-code)