### PR TITLE
feat(m5): Admin-Ansichten & Koordination

### DIFF
--- a/apps/web/app/(protected)/auffuehrungen/[id]/helfer-koordination/page.tsx
+++ b/apps/web/app/(protected)/auffuehrungen/[id]/helfer-koordination/page.tsx
@@ -1,0 +1,130 @@
+import Link from 'next/link'
+import { redirect, notFound } from 'next/navigation'
+import { getUserProfile } from '@/lib/supabase/server'
+import { hasPermission } from '@/lib/supabase/permissions'
+import { getKoordinationData } from '@/lib/actions/koordination'
+import { KoordinationView } from '@/components/koordination'
+
+interface PageProps {
+  params: Promise<{ id: string }>
+}
+
+export async function generateMetadata({ params }: PageProps) {
+  const { id } = await params
+  const data = await getKoordinationData(id)
+  return {
+    title: data ? `Helfer-Koordination - ${data.veranstaltung.titel}` : 'Helfer-Koordination',
+    description: 'Verwalte und koordiniere die Helfer fuer diese Auffuehrung',
+  }
+}
+
+export default async function HelferKoordinationPage({ params }: PageProps) {
+  const profile = await getUserProfile()
+
+  if (!profile) {
+    redirect('/login')
+  }
+
+  // Check permission
+  if (!hasPermission(profile.role, 'veranstaltungen:write')) {
+    redirect('/dashboard')
+  }
+
+  const { id } = await params
+  const data = await getKoordinationData(id)
+
+  if (!data) {
+    notFound()
+  }
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleDateString('de-CH', {
+      weekday: 'long',
+      day: '2-digit',
+      month: 'long',
+      year: 'numeric',
+    })
+  }
+
+  const formatTime = (timeStr: string | null) => {
+    if (!timeStr) return ''
+    return timeStr.slice(0, 5)
+  }
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <div className="mx-auto max-w-7xl px-4 py-8">
+        {/* Breadcrumb */}
+        <div className="mb-6">
+          <nav className="flex items-center gap-2 text-sm text-neutral-500">
+            <Link href="/auffuehrungen" className="hover:text-neutral-700">
+              Auffuehrungen
+            </Link>
+            <span>/</span>
+            <Link href={`/auffuehrungen/${id}` as never} className="hover:text-neutral-700">
+              {data.veranstaltung.titel}
+            </Link>
+            <span>/</span>
+            <span className="text-neutral-900">Helfer-Koordination</span>
+          </nav>
+        </div>
+
+        {/* Header */}
+        <div className="mb-8 flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Helfer-Koordination</h1>
+            <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-gray-600">
+              <span className="font-medium">{data.veranstaltung.titel}</span>
+              <span>{formatDate(data.veranstaltung.datum)}</span>
+              {data.veranstaltung.startzeit && (
+                <span>
+                  {formatTime(data.veranstaltung.startzeit)}
+                  {data.veranstaltung.endzeit &&
+                    ` - ${formatTime(data.veranstaltung.endzeit)}`}{' '}
+                  Uhr
+                </span>
+              )}
+              {data.veranstaltung.ort && <span>{data.veranstaltung.ort}</span>}
+            </div>
+          </div>
+
+          {/* Links */}
+          <div className="flex gap-2">
+            <Link
+              href={`/auffuehrungen/${id}/helferliste` as never}
+              className="inline-flex items-center gap-2 rounded-lg border border-neutral-200 bg-white px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+              </svg>
+              Helferliste anzeigen
+            </Link>
+            <Link
+              href={`/auffuehrungen/${id}/schichten` as never}
+              className="inline-flex items-center gap-2 rounded-lg border border-neutral-200 bg-white px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
+              </svg>
+              Schichten bearbeiten
+            </Link>
+          </div>
+        </div>
+
+        {/* Main Content */}
+        <KoordinationView data={data} />
+
+        {/* Back Link */}
+        <div className="mt-8">
+          <Link
+            href={`/auffuehrungen/${id}` as never}
+            className="text-blue-600 hover:text-blue-800"
+          >
+            &larr; Zurueck zur Auffuehrung
+          </Link>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/apps/web/components/koordination/ExportHandler.tsx
+++ b/apps/web/components/koordination/ExportHandler.tsx
@@ -1,0 +1,199 @@
+'use client'
+
+import { useState } from 'react'
+import { getExportData, generateExcelData } from '@/lib/actions/helfer-export'
+
+interface ExportHandlerProps {
+  veranstaltungId: string
+  veranstaltungTitel: string
+  veranstaltungDatum: string
+  children: (handlers: {
+    exportPDF: () => void
+    exportExcel: () => void
+    isExporting: boolean
+  }) => React.ReactNode
+}
+
+export function ExportHandler({
+  veranstaltungId,
+  veranstaltungTitel,
+  veranstaltungDatum,
+  children,
+}: ExportHandlerProps) {
+  const [isExporting, setIsExporting] = useState(false)
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleDateString('de-CH', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).replace(/\./g, '-')
+  }
+
+  const sanitizeFilename = (name: string) => {
+    return name.replace(/[^a-zA-Z0-9äöüÄÖÜß\s-]/g, '').replace(/\s+/g, '_')
+  }
+
+  const exportPDF = async () => {
+    setIsExporting(true)
+    try {
+      const data = await getExportData(veranstaltungId)
+      if (!data) return
+
+      // Create a printable HTML content
+      const printWindow = window.open('', '_blank')
+      if (!printWindow) {
+        alert('Popup blockiert. Bitte erlauben Sie Popups fuer diese Seite.')
+        return
+      }
+
+      const html = `
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <title>Helferliste - ${data.veranstaltung.titel}</title>
+          <style>
+            body { font-family: Arial, sans-serif; font-size: 12px; margin: 20px; }
+            h1 { font-size: 18px; margin-bottom: 5px; }
+            h2 { font-size: 14px; margin-top: 20px; margin-bottom: 10px; border-bottom: 1px solid #ccc; padding-bottom: 5px; }
+            .header { margin-bottom: 20px; }
+            .meta { color: #666; font-size: 11px; }
+            table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+            th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }
+            th { background-color: #f5f5f5; font-weight: bold; }
+            .zeitblock { background-color: #e8e8e8; font-weight: bold; }
+            .empty { color: #999; font-style: italic; }
+            .footer { margin-top: 30px; font-size: 10px; color: #666; border-top: 1px solid #ccc; padding-top: 10px; }
+            @media print {
+              body { margin: 0; }
+              .no-print { display: none; }
+            }
+          </style>
+        </head>
+        <body>
+          <div class="header">
+            <h1>Helferliste: ${data.veranstaltung.titel}</h1>
+            <p class="meta">
+              Datum: ${new Date(data.veranstaltung.datum).toLocaleDateString('de-CH', { weekday: 'long', day: '2-digit', month: 'long', year: 'numeric' })}<br>
+              ${data.veranstaltung.startzeit ? `Zeit: ${data.veranstaltung.startzeit} - ${data.veranstaltung.endzeit}` : ''}<br>
+              ${data.veranstaltung.ort ? `Ort: ${data.veranstaltung.ort}` : ''}
+            </p>
+          </div>
+
+          <h2>Schichten und Helfer</h2>
+          <table>
+            <thead>
+              <tr>
+                <th style="width: 20%">Zeitblock</th>
+                <th style="width: 20%">Rolle</th>
+                <th style="width: 25%">Helfer</th>
+                <th style="width: 20%">E-Mail</th>
+                <th style="width: 15%">Telefon</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${data.schichten.map((s) => {
+                if (s.helfer.length === 0) {
+                  return `
+                    <tr>
+                      <td>${s.zeitblockName} (${s.zeitblockStart} - ${s.zeitblockEnd})</td>
+                      <td>${s.rolle}</td>
+                      <td class="empty" colspan="3">Noch nicht besetzt (${s.benoetigt} benoetigt)</td>
+                    </tr>
+                  `
+                }
+                return s.helfer.map((h, i) => `
+                  <tr>
+                    ${i === 0 ? `<td rowspan="${s.helfer.length}">${s.zeitblockName} (${s.zeitblockStart} - ${s.zeitblockEnd})</td>` : ''}
+                    ${i === 0 ? `<td rowspan="${s.helfer.length}">${s.rolle}</td>` : ''}
+                    <td>${h.name}</td>
+                    <td>${h.email}</td>
+                    <td>${h.telefon}</td>
+                  </tr>
+                `).join('')
+              }).join('')}
+            </tbody>
+          </table>
+
+          <h2>Helfer-Uebersicht</h2>
+          <table>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>E-Mail</th>
+                <th>Telefon</th>
+                <th>Anzahl Schichten</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${data.helferUebersicht.map((h) => `
+                <tr>
+                  <td>${h.name}</td>
+                  <td>${h.email}</td>
+                  <td>${h.telefon}</td>
+                  <td>${h.anzahlSchichten}</td>
+                </tr>
+              `).join('')}
+            </tbody>
+          </table>
+
+          <div class="footer">
+            <p>Generiert am: ${new Date(data.generatedAt).toLocaleString('de-CH')}</p>
+          </div>
+
+          <div class="no-print" style="margin-top: 20px; text-align: center;">
+            <button onclick="window.print()" style="padding: 10px 20px; font-size: 14px; cursor: pointer;">
+              Als PDF drucken
+            </button>
+          </div>
+        </body>
+        </html>
+      `
+
+      printWindow.document.write(html)
+      printWindow.document.close()
+    } catch (err) {
+      console.error('PDF export error:', err)
+      alert('Fehler beim Erstellen des PDFs')
+    } finally {
+      setIsExporting(false)
+    }
+  }
+
+  const exportExcel = async () => {
+    setIsExporting(true)
+    try {
+      const result = await generateExcelData(veranstaltungId)
+      if (!result.success || !result.data) {
+        alert('Fehler beim Erstellen der Excel-Datei')
+        return
+      }
+
+      // Dynamic import of xlsx library
+      const XLSX = await import('xlsx')
+
+      // Create workbook
+      const wb = XLSX.utils.book_new()
+
+      // Add sheets
+      const schichtenWs = XLSX.utils.json_to_sheet(result.data.schichten)
+      XLSX.utils.book_append_sheet(wb, schichtenWs, 'Schichten')
+
+      const helferWs = XLSX.utils.json_to_sheet(result.data.helfer)
+      XLSX.utils.book_append_sheet(wb, helferWs, 'Helfer-Uebersicht')
+
+      // Generate filename
+      const filename = `Helferliste_${sanitizeFilename(veranstaltungTitel)}_${formatDate(veranstaltungDatum)}.xlsx`
+
+      // Download
+      XLSX.writeFile(wb, filename)
+    } catch (err) {
+      console.error('Excel export error:', err)
+      alert('Fehler beim Erstellen der Excel-Datei')
+    } finally {
+      setIsExporting(false)
+    }
+  }
+
+  return <>{children({ exportPDF, exportExcel, isExporting })}</>
+}

--- a/apps/web/components/koordination/HelferAssignmentModal.tsx
+++ b/apps/web/components/koordination/HelferAssignmentModal.tsx
@@ -1,0 +1,451 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import { searchHelfer, validateAssignment, assignHelferManual, createExternalAndAssign } from '@/lib/actions/manual-assignment'
+import type { HelferSearchResult, AssignmentValidation } from '@/lib/actions/manual-assignment'
+
+interface HelferAssignmentModalProps {
+  open: boolean
+  schichtId: string
+  schichtRolle: string
+  veranstaltungId: string
+  onClose: () => void
+  onSuccess: () => void
+}
+
+export function HelferAssignmentModal({
+  open,
+  schichtId,
+  schichtRolle,
+  veranstaltungId,
+  onClose,
+  onSuccess,
+}: HelferAssignmentModalProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null)
+  const searchInputRef = useRef<HTMLInputElement>(null)
+
+  const [searchQuery, setSearchQuery] = useState('')
+  const [searchResults, setSearchResults] = useState<HelferSearchResult[]>([])
+  const [isSearching, setIsSearching] = useState(false)
+  const [selectedHelfer, setSelectedHelfer] = useState<HelferSearchResult | null>(null)
+  const [validation, setValidation] = useState<AssignmentValidation | null>(null)
+  const [isValidating, setIsValidating] = useState(false)
+  const [isAssigning, setIsAssigning] = useState(false)
+  const [override, setOverride] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // New external helper form
+  const [showNewExternalForm, setShowNewExternalForm] = useState(false)
+  const [newExternal, setNewExternal] = useState({
+    vorname: '',
+    nachname: '',
+    email: '',
+    telefon: '',
+  })
+
+  // Handle dialog open/close
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (!dialog) return
+
+    if (open) {
+      dialog.showModal()
+      searchInputRef.current?.focus()
+    } else {
+      dialog.close()
+      // Reset state
+      setSearchQuery('')
+      setSearchResults([])
+      setSelectedHelfer(null)
+      setValidation(null)
+      setOverride(false)
+      setError(null)
+      setShowNewExternalForm(false)
+      setNewExternal({ vorname: '', nachname: '', email: '', telefon: '' })
+    }
+  }, [open])
+
+  // Search debounce
+  useEffect(() => {
+    if (searchQuery.length < 2) {
+      setSearchResults([])
+      return
+    }
+
+    const timer = setTimeout(async () => {
+      setIsSearching(true)
+      try {
+        const results = await searchHelfer(searchQuery, veranstaltungId)
+        setSearchResults(results)
+      } catch (err) {
+        console.error('Search error:', err)
+      } finally {
+        setIsSearching(false)
+      }
+    }, 300)
+
+    return () => clearTimeout(timer)
+  }, [searchQuery, veranstaltungId])
+
+  // Validate when helfer is selected
+  useEffect(() => {
+    if (!selectedHelfer) {
+      setValidation(null)
+      return
+    }
+
+    const validate = async () => {
+      setIsValidating(true)
+      try {
+        const result = await validateAssignment(
+          schichtId,
+          selectedHelfer.id,
+          selectedHelfer.type
+        )
+        setValidation(result)
+      } catch (err) {
+        console.error('Validation error:', err)
+      } finally {
+        setIsValidating(false)
+      }
+    }
+
+    validate()
+  }, [selectedHelfer, schichtId])
+
+  const handleSelectHelfer = (helfer: HelferSearchResult) => {
+    setSelectedHelfer(helfer)
+    setSearchQuery('')
+    setSearchResults([])
+    setError(null)
+  }
+
+  const handleAssign = async () => {
+    if (!selectedHelfer) return
+
+    setIsAssigning(true)
+    setError(null)
+
+    try {
+      const result = await assignHelferManual(
+        schichtId,
+        selectedHelfer.id,
+        selectedHelfer.type,
+        override
+      )
+
+      if (result.success) {
+        onSuccess()
+        onClose()
+      } else {
+        setError(result.error || 'Fehler beim Zuweisen')
+      }
+    } catch {
+      setError('Ein unerwarteter Fehler ist aufgetreten')
+    } finally {
+      setIsAssigning(false)
+    }
+  }
+
+  const handleCreateExternal = async () => {
+    if (!newExternal.vorname || !newExternal.nachname || !newExternal.email) {
+      setError('Bitte fuellen Sie alle Pflichtfelder aus')
+      return
+    }
+
+    setIsAssigning(true)
+    setError(null)
+
+    try {
+      const result = await createExternalAndAssign(schichtId, newExternal)
+
+      if (result.success) {
+        onSuccess()
+        onClose()
+      } else {
+        setError(result.error || 'Fehler beim Anlegen')
+      }
+    } catch {
+      setError('Ein unerwarteter Fehler ist aufgetreten')
+    } finally {
+      setIsAssigning(false)
+    }
+  }
+
+  if (!open) return null
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className="fixed inset-0 z-50 m-auto max-w-lg rounded-xl border border-neutral-200 bg-white p-0 shadow-xl backdrop:bg-black/50"
+      onClick={(e) => {
+        if (e.target === dialogRef.current) onClose()
+      }}
+    >
+      <div className="p-6">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-neutral-900">
+            Helfer zuweisen
+          </h2>
+          <button
+            onClick={onClose}
+            className="rounded p-1 text-neutral-400 hover:bg-neutral-100 hover:text-neutral-600"
+          >
+            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <p className="mt-1 text-sm text-neutral-500">
+          Schicht: <span className="font-medium">{schichtRolle}</span>
+        </p>
+
+        {/* Error message */}
+        {error && (
+          <div className="mt-4 rounded-lg bg-red-50 p-3 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        {!showNewExternalForm ? (
+          <>
+            {/* Search */}
+            <div className="mt-4">
+              <label className="block text-sm font-medium text-neutral-700">
+                Helfer suchen
+              </label>
+              <div className="relative mt-1">
+                <input
+                  ref={searchInputRef}
+                  type="text"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  placeholder="Name oder E-Mail eingeben..."
+                  className="w-full rounded-lg border border-neutral-300 px-3 py-2 text-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+                  disabled={!!selectedHelfer}
+                />
+                {isSearching && (
+                  <div className="absolute right-3 top-2.5">
+                    <svg className="h-5 w-5 animate-spin text-neutral-400" fill="none" viewBox="0 0 24 24">
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                    </svg>
+                  </div>
+                )}
+              </div>
+
+              {/* Search Results */}
+              {searchResults.length > 0 && (
+                <div className="mt-2 max-h-48 overflow-y-auto rounded-lg border border-neutral-200">
+                  {searchResults.map((result) => (
+                    <button
+                      key={`${result.type}-${result.id}`}
+                      onClick={() => handleSelectHelfer(result)}
+                      className="flex w-full items-center justify-between px-3 py-2 text-left hover:bg-neutral-50"
+                    >
+                      <div>
+                        <p className="text-sm font-medium text-neutral-900">
+                          {result.name}
+                          <span className={`ml-2 rounded px-1.5 py-0.5 text-xs ${
+                            result.type === 'intern'
+                              ? 'bg-green-100 text-green-700'
+                              : 'bg-orange-100 text-orange-700'
+                          }`}>
+                            {result.type === 'intern' ? 'Intern' : 'Extern'}
+                          </span>
+                        </p>
+                        <p className="text-xs text-neutral-500">{result.email}</p>
+                      </div>
+                      <span className="text-xs text-neutral-400">
+                        {result.einsaetzeCount} Einsaetze
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Selected Helfer */}
+            {selectedHelfer && (
+              <div className="mt-4 rounded-lg border border-neutral-200 p-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="font-medium text-neutral-900">{selectedHelfer.name}</p>
+                    <p className="text-sm text-neutral-500">{selectedHelfer.email}</p>
+                  </div>
+                  <button
+                    onClick={() => setSelectedHelfer(null)}
+                    className="text-sm text-primary-600 hover:text-primary-700"
+                  >
+                    Andere Person waehlen
+                  </button>
+                </div>
+
+                {/* Validation */}
+                {isValidating ? (
+                  <div className="mt-3 flex items-center gap-2 text-sm text-neutral-500">
+                    <svg className="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                    </svg>
+                    Pruefe Konflikte...
+                  </div>
+                ) : validation && (
+                  <div className="mt-3 space-y-2">
+                    {/* Time conflicts */}
+                    {validation.hasConflict && (
+                      <div className="rounded-lg bg-yellow-50 p-3">
+                        <p className="text-sm font-medium text-yellow-800">
+                          Zeitkonflikt erkannt
+                        </p>
+                        <ul className="mt-1 space-y-1">
+                          {validation.conflicts.map((c) => (
+                            <li key={c.schichtId} className="text-sm text-yellow-700">
+                              &quot;{c.rolle}&quot; ({c.startzeit.slice(0, 5)} - {c.endzeit.slice(0, 5)})
+                              - {c.ueberschneidungMinuten} Min. Ueberschneidung
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+
+                    {/* Booking limit */}
+                    {validation.bookingLimitReached && (
+                      <div className="rounded-lg bg-orange-50 p-3">
+                        <p className="text-sm font-medium text-orange-800">
+                          Buchungslimit erreicht
+                        </p>
+                        <p className="text-sm text-orange-700">
+                          {selectedHelfer.name} hat bereits {validation.currentBookings} von{' '}
+                          {validation.maxBookings} Schichten gebucht.
+                        </p>
+                      </div>
+                    )}
+
+                    {/* Override checkbox */}
+                    {(validation.hasConflict || validation.bookingLimitReached) && (
+                      <label className="flex items-center gap-2">
+                        <input
+                          type="checkbox"
+                          checked={override}
+                          onChange={(e) => setOverride(e.target.checked)}
+                          className="h-4 w-4 rounded border-neutral-300 text-primary-600"
+                        />
+                        <span className="text-sm text-neutral-700">
+                          Trotzdem zuweisen (Admin-Override)
+                        </span>
+                      </label>
+                    )}
+
+                    {/* No conflicts */}
+                    {!validation.hasConflict && !validation.bookingLimitReached && (
+                      <div className="rounded-lg bg-green-50 p-3">
+                        <p className="text-sm text-green-700">
+                          Keine Konflikte - Zuweisung moeglich
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* New external helper link */}
+            <button
+              onClick={() => setShowNewExternalForm(true)}
+              className="mt-4 text-sm text-primary-600 hover:text-primary-700"
+            >
+              + Neue externe Person anlegen
+            </button>
+          </>
+        ) : (
+          /* New External Form */
+          <div className="mt-4 space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-neutral-700">
+                  Vorname *
+                </label>
+                <input
+                  type="text"
+                  value={newExternal.vorname}
+                  onChange={(e) => setNewExternal({ ...newExternal, vorname: e.target.value })}
+                  className="mt-1 w-full rounded-lg border border-neutral-300 px-3 py-2 text-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-neutral-700">
+                  Nachname *
+                </label>
+                <input
+                  type="text"
+                  value={newExternal.nachname}
+                  onChange={(e) => setNewExternal({ ...newExternal, nachname: e.target.value })}
+                  className="mt-1 w-full rounded-lg border border-neutral-300 px-3 py-2 text-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+                />
+              </div>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-neutral-700">
+                E-Mail *
+              </label>
+              <input
+                type="email"
+                value={newExternal.email}
+                onChange={(e) => setNewExternal({ ...newExternal, email: e.target.value })}
+                className="mt-1 w-full rounded-lg border border-neutral-300 px-3 py-2 text-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-neutral-700">
+                Telefon
+              </label>
+              <input
+                type="tel"
+                value={newExternal.telefon}
+                onChange={(e) => setNewExternal({ ...newExternal, telefon: e.target.value })}
+                className="mt-1 w-full rounded-lg border border-neutral-300 px-3 py-2 text-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+              />
+            </div>
+            <button
+              onClick={() => setShowNewExternalForm(false)}
+              className="text-sm text-neutral-600 hover:text-neutral-700"
+            >
+              &larr; Zurueck zur Suche
+            </button>
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            onClick={onClose}
+            className="rounded-lg border border-neutral-300 bg-white px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+          >
+            Abbrechen
+          </button>
+          {showNewExternalForm ? (
+            <button
+              onClick={handleCreateExternal}
+              disabled={isAssigning || !newExternal.vorname || !newExternal.nachname || !newExternal.email}
+              className="rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isAssigning ? 'Wird angelegt...' : 'Anlegen und zuweisen'}
+            </button>
+          ) : (
+            <button
+              onClick={handleAssign}
+              disabled={!selectedHelfer || isAssigning || isValidating || !!(
+                validation && (validation.hasConflict || validation.bookingLimitReached) && !override
+              )}
+              className="rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isAssigning ? 'Wird zugewiesen...' : 'Zuweisen'}
+            </button>
+          )}
+        </div>
+      </div>
+    </dialog>
+  )
+}

--- a/apps/web/components/koordination/KoordinationView.tsx
+++ b/apps/web/components/koordination/KoordinationView.tsx
@@ -1,0 +1,280 @@
+'use client'
+
+import { useState, useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+import type { KoordinationData } from '@/lib/actions/koordination'
+import { removeHelferFromSchicht } from '@/lib/actions/koordination'
+import { MetricsCards } from './MetricsCards'
+import { ZeitblockAccordion } from './ZeitblockAccordion'
+import { QuickActions } from './QuickActions'
+import { StatistikSection } from './StatistikSection'
+import { HelferAssignmentModal } from './HelferAssignmentModal'
+import { ExportHandler } from './ExportHandler'
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
+
+interface KoordinationViewProps {
+  data: KoordinationData
+}
+
+export function KoordinationView({ data: initialData }: KoordinationViewProps) {
+  const router = useRouter()
+  const [data] = useState(initialData)
+
+  // Assignment modal state
+  const [assignmentModal, setAssignmentModal] = useState<{
+    open: boolean
+    schichtId: string
+    schichtRolle: string
+  }>({
+    open: false,
+    schichtId: '',
+    schichtRolle: '',
+  })
+
+  // Remove helfer confirm state
+  const [removeConfirm, setRemoveConfirm] = useState<{
+    open: boolean
+    zuweisungId: string
+    helferName: string
+  }>({
+    open: false,
+    zuweisungId: '',
+    helferName: '',
+  })
+  const [isRemoving, setIsRemoving] = useState(false)
+
+  // Filter state
+  const [filter, setFilter] = useState({
+    zeitblock: 'all',
+    besetzung: 'all', // all, full, partial, empty
+    sichtbarkeit: 'all', // all, public, intern
+  })
+
+  // Find schicht role by ID
+  const findSchichtRolle = (schichtId: string): string => {
+    for (const zb of data.zeitbloecke) {
+      const schicht = zb.schichten.find((s) => s.id === schichtId)
+      if (schicht) return schicht.rolle
+    }
+    return ''
+  }
+
+  // Handle assignment
+  const handleAssign = useCallback((schichtId: string) => {
+    setAssignmentModal({
+      open: true,
+      schichtId,
+      schichtRolle: findSchichtRolle(schichtId),
+    })
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data.zeitbloecke])
+
+  // Handle remove helfer
+  const handleRemoveHelfer = useCallback((zuweisungId: string, helferName: string) => {
+    setRemoveConfirm({ open: true, zuweisungId, helferName })
+  }, [])
+
+  const confirmRemoveHelfer = async () => {
+    if (!removeConfirm.zuweisungId) return
+
+    setIsRemoving(true)
+    try {
+      const result = await removeHelferFromSchicht(removeConfirm.zuweisungId)
+      if (result.success) {
+        router.refresh()
+      }
+    } finally {
+      setIsRemoving(false)
+      setRemoveConfirm({ open: false, zuweisungId: '', helferName: '' })
+    }
+  }
+
+  // Handle status change
+  const handleStatusChange = () => {
+    router.refresh()
+  }
+
+  // Handle assignment success
+  const handleAssignmentSuccess = () => {
+    router.refresh()
+  }
+
+  // Filter zeitbloecke
+  const getFilteredZeitbloecke = () => {
+    let filtered = [...data.zeitbloecke]
+
+    // Filter by zeitblock
+    if (filter.zeitblock !== 'all') {
+      filtered = filtered.filter((zb) => zb.id === filter.zeitblock)
+    }
+
+    // Filter schichten within zeitbloecke
+    filtered = filtered.map((zb) => {
+      let schichten = [...zb.schichten]
+
+      // Filter by besetzung
+      if (filter.besetzung === 'full') {
+        schichten = schichten.filter((s) => s.anzahlBesetzt >= s.anzahl_benoetigt)
+      } else if (filter.besetzung === 'partial') {
+        schichten = schichten.filter((s) =>
+          s.anzahlBesetzt > 0 && s.anzahlBesetzt < s.anzahl_benoetigt
+        )
+      } else if (filter.besetzung === 'empty') {
+        schichten = schichten.filter((s) =>
+          s.anzahlBesetzt < s.anzahl_benoetigt * 0.5
+        )
+      }
+
+      // Filter by sichtbarkeit
+      if (filter.sichtbarkeit === 'public') {
+        schichten = schichten.filter((s) => s.sichtbarkeit === 'public')
+      } else if (filter.sichtbarkeit === 'intern') {
+        schichten = schichten.filter((s) => s.sichtbarkeit !== 'public')
+      }
+
+      return { ...zb, schichten }
+    })
+
+    // Remove empty zeitbloecke
+    filtered = filtered.filter((zb) => zb.schichten.length > 0)
+
+    return filtered
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Metrics Cards */}
+      <MetricsCards
+        metrics={data.metrics}
+        helferStatus={data.veranstaltung.helfer_status}
+      />
+
+      {/* Quick Actions */}
+      <ExportHandler
+        veranstaltungId={data.veranstaltung.id}
+        veranstaltungTitel={data.veranstaltung.titel}
+        veranstaltungDatum={data.veranstaltung.datum}
+      >
+        {({ exportPDF, exportExcel }) => (
+          <QuickActions
+            veranstaltungId={data.veranstaltung.id}
+            helferStatus={data.veranstaltung.helfer_status}
+            onStatusChange={handleStatusChange}
+            onExportPDF={exportPDF}
+            onExportExcel={exportExcel}
+          />
+        )}
+      </ExportHandler>
+
+      {/* Filters */}
+      <div className="flex flex-wrap gap-4 rounded-lg border border-neutral-200 bg-white p-4">
+        <div>
+          <label className="block text-sm font-medium text-neutral-700">Zeitblock</label>
+          <select
+            value={filter.zeitblock}
+            onChange={(e) => setFilter({ ...filter, zeitblock: e.target.value })}
+            className="mt-1 rounded-lg border border-neutral-300 px-3 py-1.5 text-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+          >
+            <option value="all">Alle Zeitbloecke</option>
+            {data.zeitbloecke.map((zb) => (
+              <option key={zb.id} value={zb.id}>{zb.name}</option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-neutral-700">Besetzung</label>
+          <select
+            value={filter.besetzung}
+            onChange={(e) => setFilter({ ...filter, besetzung: e.target.value })}
+            className="mt-1 rounded-lg border border-neutral-300 px-3 py-1.5 text-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+          >
+            <option value="all">Alle</option>
+            <option value="full">Voll besetzt</option>
+            <option value="partial">Teilweise besetzt</option>
+            <option value="empty">Kritisch (&lt;50%)</option>
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-neutral-700">Sichtbarkeit</label>
+          <select
+            value={filter.sichtbarkeit}
+            onChange={(e) => setFilter({ ...filter, sichtbarkeit: e.target.value })}
+            className="mt-1 rounded-lg border border-neutral-300 px-3 py-1.5 text-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+          >
+            <option value="all">Alle</option>
+            <option value="public">Nur oeffentliche</option>
+            <option value="intern">Nur interne</option>
+          </select>
+        </div>
+
+        {/* Reset filter */}
+        {(filter.zeitblock !== 'all' || filter.besetzung !== 'all' || filter.sichtbarkeit !== 'all') && (
+          <button
+            onClick={() => setFilter({ zeitblock: 'all', besetzung: 'all', sichtbarkeit: 'all' })}
+            className="self-end text-sm text-primary-600 hover:text-primary-700"
+          >
+            Filter zuruecksetzen
+          </button>
+        )}
+      </div>
+
+      {/* Zeitbloecke */}
+      <ZeitblockAccordion
+        zeitbloecke={getFilteredZeitbloecke()}
+        onAssign={handleAssign}
+        onRemoveHelfer={handleRemoveHelfer}
+      />
+
+      {/* Warteliste Sidebar (if any) */}
+      {data.alleWarteliste.length > 0 && (
+        <div className="rounded-lg border border-blue-200 bg-blue-50 p-4">
+          <h3 className="font-medium text-blue-900">
+            Warteliste ({data.alleWarteliste.length} Helfer)
+          </h3>
+          <p className="mt-1 text-sm text-blue-700">
+            Diese Helfer warten auf einen freien Platz
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {data.alleWarteliste.map((w) => (
+              <span
+                key={w.id}
+                className="inline-flex items-center rounded-full bg-white px-3 py-1 text-sm text-blue-800 shadow-sm"
+              >
+                {w.name}
+                {w.isExtern && (
+                  <span className="ml-1 text-xs text-blue-600">(extern)</span>
+                )}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Statistiken */}
+      <StatistikSection veranstaltungId={data.veranstaltung.id} />
+
+      {/* Assignment Modal */}
+      <HelferAssignmentModal
+        open={assignmentModal.open}
+        schichtId={assignmentModal.schichtId}
+        schichtRolle={assignmentModal.schichtRolle}
+        veranstaltungId={data.veranstaltung.id}
+        onClose={() => setAssignmentModal({ open: false, schichtId: '', schichtRolle: '' })}
+        onSuccess={handleAssignmentSuccess}
+      />
+
+      {/* Remove Confirm Dialog */}
+      <ConfirmDialog
+        open={removeConfirm.open}
+        title="Helfer entfernen"
+        message={`Moechten Sie ${removeConfirm.helferName} wirklich von dieser Schicht entfernen?`}
+        confirmLabel={isRemoving ? 'Wird entfernt...' : 'Entfernen'}
+        variant="danger"
+        onConfirm={confirmRemoveHelfer}
+        onCancel={() => setRemoveConfirm({ open: false, zuweisungId: '', helferName: '' })}
+      />
+    </div>
+  )
+}

--- a/apps/web/components/koordination/MetricsCards.tsx
+++ b/apps/web/components/koordination/MetricsCards.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import type { KoordinationMetrics } from '@/lib/actions/koordination'
+
+interface MetricsCardsProps {
+  metrics: KoordinationMetrics
+  helferStatus: string | null
+}
+
+export function MetricsCards({ metrics, helferStatus }: MetricsCardsProps) {
+  const statusLabels: Record<string, { label: string; color: string }> = {
+    entwurf: { label: 'Entwurf', color: 'bg-gray-100 text-gray-800' },
+    veroeffentlicht: { label: 'Veroffentlicht', color: 'bg-green-100 text-green-800' },
+    abgeschlossen: { label: 'Abgeschlossen', color: 'bg-blue-100 text-blue-800' },
+  }
+
+  const statusInfo = statusLabels[helferStatus || 'entwurf'] || statusLabels.entwurf
+
+  // Color based on percentage
+  const getAuslastungColor = (prozent: number) => {
+    if (prozent >= 80) return 'text-green-600'
+    if (prozent >= 50) return 'text-yellow-600'
+    return 'text-red-600'
+  }
+
+  return (
+    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
+      {/* Status Badge */}
+      <div className="rounded-lg border border-neutral-200 bg-white p-4">
+        <p className="text-sm font-medium text-neutral-500">Status</p>
+        <div className="mt-2">
+          <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-sm font-medium ${statusInfo.color}`}>
+            {statusInfo.label}
+          </span>
+        </div>
+      </div>
+
+      {/* Gesamt Slots */}
+      <div className="rounded-lg border border-neutral-200 bg-white p-4">
+        <p className="text-sm font-medium text-neutral-500">Gesamt Slots</p>
+        <p className="mt-2 text-2xl font-bold text-neutral-900">
+          {metrics.gesamtSlots}
+        </p>
+        <p className="text-xs text-neutral-500">definiert</p>
+      </div>
+
+      {/* Besetzt */}
+      <div className="rounded-lg border border-neutral-200 bg-white p-4">
+        <p className="text-sm font-medium text-neutral-500">Besetzt</p>
+        <p className={`mt-2 text-2xl font-bold ${getAuslastungColor(metrics.auslastungProzent)}`}>
+          {metrics.besetztSlots}
+          <span className="ml-1 text-sm font-normal">
+            ({metrics.auslastungProzent}%)
+          </span>
+        </p>
+        <p className="text-xs text-neutral-500">zugewiesen</p>
+      </div>
+
+      {/* Offen */}
+      <div className="rounded-lg border border-neutral-200 bg-white p-4">
+        <p className="text-sm font-medium text-neutral-500">Offen</p>
+        <p className={`mt-2 text-2xl font-bold ${metrics.offeneSlots > 0 ? 'text-orange-600' : 'text-green-600'}`}>
+          {metrics.offeneSlots}
+        </p>
+        <p className="text-xs text-neutral-500">noch frei</p>
+      </div>
+
+      {/* Warteliste */}
+      <div className="rounded-lg border border-neutral-200 bg-white p-4">
+        <p className="text-sm font-medium text-neutral-500">Warteliste</p>
+        <p className={`mt-2 text-2xl font-bold ${metrics.warteliste > 0 ? 'text-blue-600' : 'text-neutral-400'}`}>
+          {metrics.warteliste}
+        </p>
+        <p className="text-xs text-neutral-500">wartend</p>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/koordination/QuickActions.tsx
+++ b/apps/web/components/koordination/QuickActions.tsx
@@ -1,0 +1,164 @@
+'use client'
+
+import { useState } from 'react'
+import { updateHelferStatus, getAllHelferEmails } from '@/lib/actions/koordination'
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
+
+interface QuickActionsProps {
+  veranstaltungId: string
+  helferStatus: string | null
+  onStatusChange: () => void
+  onExportPDF: () => void
+  onExportExcel: () => void
+}
+
+export function QuickActions({
+  veranstaltungId,
+  helferStatus,
+  onStatusChange,
+  onExportPDF,
+  onExportExcel,
+}: QuickActionsProps) {
+  const [isLoading, setIsLoading] = useState(false)
+  const [showPublishConfirm, setShowPublishConfirm] = useState(false)
+  const [showCloseConfirm, setShowCloseConfirm] = useState(false)
+  const [copiedEmails, setCopiedEmails] = useState(false)
+
+  const handlePublish = async () => {
+    setIsLoading(true)
+    try {
+      const result = await updateHelferStatus(veranstaltungId, 'veroeffentlicht')
+      if (result.success) {
+        onStatusChange()
+      }
+    } finally {
+      setIsLoading(false)
+      setShowPublishConfirm(false)
+    }
+  }
+
+  const handleClose = async () => {
+    setIsLoading(true)
+    try {
+      const result = await updateHelferStatus(veranstaltungId, 'abgeschlossen')
+      if (result.success) {
+        onStatusChange()
+      }
+    } finally {
+      setIsLoading(false)
+      setShowCloseConfirm(false)
+    }
+  }
+
+  const handleCopyEmails = async () => {
+    try {
+      const result = await getAllHelferEmails(veranstaltungId)
+      if (result.success && result.emails) {
+        await navigator.clipboard.writeText(result.emails)
+        setCopiedEmails(true)
+        setTimeout(() => setCopiedEmails(false), 2000)
+      }
+    } catch (err) {
+      console.error('Failed to copy emails:', err)
+    }
+  }
+
+  return (
+    <>
+      <div className="flex flex-wrap gap-3">
+        {/* Status Actions */}
+        {helferStatus === 'entwurf' && (
+          <button
+            onClick={() => setShowPublishConfirm(true)}
+            disabled={isLoading}
+            className="inline-flex items-center gap-2 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+            </svg>
+            Veroeffentlichen
+          </button>
+        )}
+
+        {helferStatus === 'veroeffentlicht' && (
+          <button
+            onClick={() => setShowCloseConfirm(true)}
+            disabled={isLoading}
+            className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            Abschliessen
+          </button>
+        )}
+
+        {/* Export Actions */}
+        <div className="flex items-center gap-2 rounded-lg border border-neutral-200 bg-white">
+          <button
+            onClick={onExportPDF}
+            className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            </svg>
+            PDF
+          </button>
+          <div className="h-6 w-px bg-neutral-200" />
+          <button
+            onClick={onExportExcel}
+            className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            </svg>
+            Excel
+          </button>
+        </div>
+
+        {/* Copy Emails */}
+        <button
+          onClick={handleCopyEmails}
+          className="inline-flex items-center gap-2 rounded-lg border border-neutral-200 bg-white px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+        >
+          {copiedEmails ? (
+            <>
+              <svg className="h-4 w-4 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+              Kopiert!
+            </>
+          ) : (
+            <>
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+              </svg>
+              Alle Emails kopieren
+            </>
+          )}
+        </button>
+      </div>
+
+      {/* Confirm Dialogs */}
+      <ConfirmDialog
+        open={showPublishConfirm}
+        title="Helferliste veroeffentlichen"
+        message="Moechten Sie die Helferliste veroeffentlichen? Danach koennen sich externe Helfer ueber den oeffentlichen Link anmelden."
+        confirmLabel={isLoading ? 'Wird veroeffentlicht...' : 'Veroeffentlichen'}
+        variant="default"
+        onConfirm={handlePublish}
+        onCancel={() => setShowPublishConfirm(false)}
+      />
+
+      <ConfirmDialog
+        open={showCloseConfirm}
+        title="Helferliste abschliessen"
+        message="Moechten Sie die Helferliste abschliessen? Danach sind keine weiteren Anmeldungen mehr moeglich."
+        confirmLabel={isLoading ? 'Wird abgeschlossen...' : 'Abschliessen'}
+        variant="warning"
+        onConfirm={handleClose}
+        onCancel={() => setShowCloseConfirm(false)}
+      />
+    </>
+  )
+}

--- a/apps/web/components/koordination/SchichtDetailCard.tsx
+++ b/apps/web/components/koordination/SchichtDetailCard.tsx
@@ -1,0 +1,167 @@
+'use client'
+
+import type { SchichtMitHelfer } from '@/lib/actions/koordination'
+
+interface SchichtDetailCardProps {
+  schicht: SchichtMitHelfer
+  onAssign: () => void
+  onRemoveHelfer: (zuweisungId: string, helferName: string) => void
+}
+
+export function SchichtDetailCard({
+  schicht,
+  onAssign,
+  onRemoveHelfer,
+}: SchichtDetailCardProps) {
+  const auslastungProzent = schicht.anzahl_benoetigt > 0
+    ? Math.round((schicht.anzahlBesetzt / schicht.anzahl_benoetigt) * 100)
+    : 0
+
+  const getProgressColor = () => {
+    if (auslastungProzent >= 100) return 'bg-green-500'
+    if (auslastungProzent >= 50) return 'bg-yellow-500'
+    return 'bg-red-500'
+  }
+
+  const getBorderColor = () => {
+    if (auslastungProzent >= 100) return 'border-green-200'
+    if (auslastungProzent >= 50) return 'border-yellow-200'
+    return 'border-red-200'
+  }
+
+  return (
+    <div className={`rounded-lg border ${getBorderColor()} bg-white p-4`}>
+      <div className="flex items-start justify-between">
+        {/* Left: Role info */}
+        <div className="flex-1">
+          <div className="flex items-center gap-3">
+            <h4 className="font-medium text-neutral-900">{schicht.rolle}</h4>
+            {schicht.sichtbarkeit === 'public' && (
+              <span className="rounded bg-blue-100 px-1.5 py-0.5 text-xs text-blue-700">
+                Oeffentlich
+              </span>
+            )}
+          </div>
+
+          {/* Progress */}
+          <div className="mt-2 flex items-center gap-3">
+            <div className="w-24">
+              <div className="h-2 overflow-hidden rounded-full bg-neutral-200">
+                <div
+                  className={`h-full ${getProgressColor()}`}
+                  style={{ width: `${Math.min(auslastungProzent, 100)}%` }}
+                />
+              </div>
+            </div>
+            <span className="text-sm text-neutral-600">
+              {schicht.anzahlBesetzt} von {schicht.anzahl_benoetigt} besetzt
+            </span>
+          </div>
+        </div>
+
+        {/* Right: Assign button */}
+        {schicht.anzahlBesetzt < schicht.anzahl_benoetigt && (
+          <button
+            onClick={onAssign}
+            className="rounded-lg border border-primary-300 bg-primary-50 px-3 py-1.5 text-sm font-medium text-primary-700 hover:bg-primary-100"
+          >
+            Helfer zuweisen
+          </button>
+        )}
+      </div>
+
+      {/* Helfer list */}
+      {schicht.helfer.length > 0 && (
+        <div className="mt-4 space-y-2">
+          {schicht.helfer.map((helfer) => (
+            <div
+              key={helfer.zuweisungId}
+              className="flex items-center justify-between rounded-lg bg-neutral-50 px-3 py-2"
+            >
+              <div className="flex items-center gap-3">
+                <div className="flex h-8 w-8 items-center justify-center rounded-full bg-neutral-200 text-sm font-medium text-neutral-600">
+                  {helfer.name.charAt(0)}
+                </div>
+                <div>
+                  <p className="text-sm font-medium text-neutral-900">
+                    {helfer.name}
+                    {helfer.isExtern && (
+                      <span className="ml-2 rounded bg-orange-100 px-1.5 py-0.5 text-xs text-orange-700">
+                        Extern
+                      </span>
+                    )}
+                  </p>
+                  <p className="text-xs text-neutral-500">
+                    {helfer.email && (
+                      <a
+                        href={`mailto:${helfer.email}`}
+                        className="hover:text-primary-600"
+                      >
+                        {helfer.email}
+                      </a>
+                    )}
+                    {helfer.email && helfer.telefon && ' | '}
+                    {helfer.telefon && (
+                      <a
+                        href={`tel:${helfer.telefon}`}
+                        className="hover:text-primary-600"
+                      >
+                        {helfer.telefon}
+                      </a>
+                    )}
+                  </p>
+                </div>
+              </div>
+
+              <button
+                onClick={() => onRemoveHelfer(helfer.zuweisungId, helfer.name)}
+                className="rounded p-1 text-neutral-400 hover:bg-red-50 hover:text-red-600"
+                title="Helfer entfernen"
+              >
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Empty slots indicator */}
+      {schicht.anzahlBesetzt < schicht.anzahl_benoetigt && (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {Array.from({ length: schicht.anzahl_benoetigt - schicht.anzahlBesetzt }).map((_, i) => (
+            <div
+              key={i}
+              className="flex items-center gap-1 rounded-lg border border-dashed border-neutral-300 px-3 py-1.5 text-sm text-neutral-400"
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+              </svg>
+              Offen
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Waitlist */}
+      {schicht.warteliste.length > 0 && (
+        <div className="mt-4 border-t border-neutral-200 pt-3">
+          <p className="text-sm font-medium text-neutral-700">
+            Warteliste ({schicht.warteliste.length})
+          </p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {schicht.warteliste.map((w) => (
+              <span
+                key={w.id}
+                className="inline-flex items-center rounded-full bg-blue-50 px-2.5 py-0.5 text-xs text-blue-700"
+              >
+                #{w.position} {w.name}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/components/koordination/StatistikSection.tsx
+++ b/apps/web/components/koordination/StatistikSection.tsx
@@ -1,0 +1,260 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { getHelferStatistik } from '@/lib/actions/helfer-statistiken'
+import type { HelferStatistik, ZeitblockAuslastung, KritischeSchicht, TopHelfer } from '@/lib/actions/helfer-statistiken'
+
+interface StatistikSectionProps {
+  veranstaltungId: string
+}
+
+export function StatistikSection({ veranstaltungId }: StatistikSectionProps) {
+  const [statistik, setStatistik] = useState<HelferStatistik | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    const loadStats = async () => {
+      setIsLoading(true)
+      try {
+        const data = await getHelferStatistik(veranstaltungId)
+        setStatistik(data)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    loadStats()
+  }, [veranstaltungId])
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <svg className="h-8 w-8 animate-spin text-neutral-400" fill="none" viewBox="0 0 24 24">
+          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+        </svg>
+      </div>
+    )
+  }
+
+  if (!statistik) {
+    return (
+      <div className="rounded-lg border border-neutral-200 bg-white p-4 text-center text-neutral-500">
+        Statistiken konnten nicht geladen werden.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-lg font-semibold text-neutral-900">Statistiken</h2>
+
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {/* Zeitblock Auslastung */}
+        <ZeitblockAuslastungCard zeitbloecke={statistik.zeitblockAuslastung} />
+
+        {/* Kritische Schichten */}
+        <KritischeSchichtenCard schichten={statistik.kritischeSchichten} />
+
+        {/* Top Helfer */}
+        <TopHelferCard helfer={statistik.topHelfer} />
+      </div>
+
+      {/* Anmeldungstrend */}
+      {statistik.anmeldungsTrend.length > 0 && (
+        <AnmeldungsTrendCard trend={statistik.anmeldungsTrend} />
+      )}
+    </div>
+  )
+}
+
+function ZeitblockAuslastungCard({ zeitbloecke }: { zeitbloecke: ZeitblockAuslastung[] }) {
+  // Sort by auslastung (lowest first to highlight problem areas)
+  const sorted = [...zeitbloecke].sort((a, b) => a.auslastungProzent - b.auslastungProzent)
+
+  return (
+    <div className="rounded-lg border border-neutral-200 bg-white p-4">
+      <h3 className="font-medium text-neutral-900">Zeitblock-Auslastung</h3>
+      <p className="mt-1 text-sm text-neutral-500">
+        Sortiert nach niedrigster Auslastung
+      </p>
+
+      <div className="mt-4 space-y-3">
+        {sorted.map((zb) => (
+          <div key={zb.id}>
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-neutral-700">{zb.name}</span>
+              <span className={`font-medium ${
+                zb.auslastungProzent >= 80 ? 'text-green-600' :
+                zb.auslastungProzent >= 50 ? 'text-yellow-600' :
+                'text-red-600'
+              }`}>
+                {zb.auslastungProzent}%
+              </span>
+            </div>
+            <div className="mt-1 h-2 overflow-hidden rounded-full bg-neutral-200">
+              <div
+                className={`h-full ${
+                  zb.auslastungProzent >= 80 ? 'bg-green-500' :
+                  zb.auslastungProzent >= 50 ? 'bg-yellow-500' :
+                  'bg-red-500'
+                }`}
+                style={{ width: `${Math.min(zb.auslastungProzent, 100)}%` }}
+              />
+            </div>
+            <p className="mt-0.5 text-xs text-neutral-400">
+              {zb.besetztSlots}/{zb.gesamtSlots} Slots
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function KritischeSchichtenCard({ schichten }: { schichten: KritischeSchicht[] }) {
+  if (schichten.length === 0) {
+    return (
+      <div className="rounded-lg border border-green-200 bg-green-50 p-4">
+        <h3 className="font-medium text-green-900">Keine kritischen Schichten</h3>
+        <p className="mt-1 text-sm text-green-700">
+          Alle Schichten sind mindestens zu 50% besetzt.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-lg border border-red-200 bg-red-50 p-4">
+      <h3 className="font-medium text-red-900">Kritische Schichten</h3>
+      <p className="mt-1 text-sm text-red-700">
+        Schichten mit weniger als 50% Besetzung
+      </p>
+
+      <div className="mt-4 space-y-2">
+        {schichten.map((s) => (
+          <div
+            key={s.id}
+            className="flex items-center justify-between rounded bg-white px-3 py-2"
+          >
+            <div>
+              <p className="text-sm font-medium text-neutral-900">{s.rolle}</p>
+              {s.zeitblockName && (
+                <p className="text-xs text-neutral-500">
+                  {s.zeitblockName}
+                  {s.startzeit && ` (${s.startzeit.slice(0, 5)} - ${s.endzeit?.slice(0, 5)})`}
+                </p>
+              )}
+            </div>
+            <div className="text-right">
+              <p className={`text-sm font-medium ${
+                s.auslastungProzent < 30 ? 'text-red-600' : 'text-orange-600'
+              }`}>
+                {s.auslastungProzent}%
+              </p>
+              <p className="text-xs text-neutral-500">
+                {s.besetzt}/{s.benoetigt}
+              </p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function TopHelferCard({ helfer }: { helfer: TopHelfer[] }) {
+  if (helfer.length === 0) {
+    return (
+      <div className="rounded-lg border border-neutral-200 bg-white p-4">
+        <h3 className="font-medium text-neutral-900">Top-Helfer</h3>
+        <p className="mt-2 text-sm text-neutral-500">
+          Noch keine Helfer angemeldet.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-lg border border-neutral-200 bg-white p-4">
+      <h3 className="font-medium text-neutral-900">Top-Helfer</h3>
+      <p className="mt-1 text-sm text-neutral-500">
+        Helfer mit den meisten Schichten
+      </p>
+
+      <div className="mt-4 space-y-2">
+        {helfer.map((h, index) => (
+          <div
+            key={h.id}
+            className="flex items-center justify-between rounded bg-neutral-50 px-3 py-2"
+          >
+            <div className="flex items-center gap-3">
+              <span className={`flex h-6 w-6 items-center justify-center rounded-full text-xs font-medium ${
+                index === 0 ? 'bg-yellow-100 text-yellow-800' :
+                index === 1 ? 'bg-neutral-200 text-neutral-700' :
+                index === 2 ? 'bg-orange-100 text-orange-800' :
+                'bg-neutral-100 text-neutral-600'
+              }`}>
+                {index + 1}
+              </span>
+              <div>
+                <p className="text-sm font-medium text-neutral-900">{h.name}</p>
+                {h.email && (
+                  <p className="text-xs text-neutral-500">{h.email}</p>
+                )}
+              </div>
+            </div>
+            <div className="flex items-center gap-1">
+              <span className="text-sm font-medium text-primary-600">
+                {h.anzahlSchichten}
+              </span>
+              <span className="text-xs text-neutral-500">Schichten</span>
+              {h.anzahlSchichten >= 3 && (
+                <span className="ml-1 rounded bg-primary-100 px-1.5 py-0.5 text-xs text-primary-700">
+                  Top
+                </span>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function AnmeldungsTrendCard({ trend }: { trend: { datum: string; anzahl: number; kumuliert: number }[] }) {
+  const maxKumuliert = Math.max(...trend.map((t) => t.kumuliert))
+
+  return (
+    <div className="rounded-lg border border-neutral-200 bg-white p-4">
+      <h3 className="font-medium text-neutral-900">Anmeldungsverlauf</h3>
+      <p className="mt-1 text-sm text-neutral-500">
+        Kumulierte Anmeldungen ueber Zeit
+      </p>
+
+      <div className="mt-4">
+        <div className="flex h-32 items-end gap-1">
+          {trend.map((t) => (
+            <div
+              key={t.datum}
+              className="flex-1 group relative"
+              title={`${new Date(t.datum).toLocaleDateString('de-CH')}: ${t.kumuliert} Anmeldungen`}
+            >
+              <div
+                className="w-full bg-primary-500 rounded-t transition-all hover:bg-primary-600"
+                style={{ height: `${(t.kumuliert / maxKumuliert) * 100}%`, minHeight: '4px' }}
+              />
+              <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 hidden rounded bg-neutral-800 px-2 py-1 text-xs text-white group-hover:block whitespace-nowrap">
+                {new Date(t.datum).toLocaleDateString('de-CH', { day: '2-digit', month: '2-digit' })}: {t.kumuliert}
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="mt-2 flex justify-between text-xs text-neutral-500">
+          <span>{new Date(trend[0].datum).toLocaleDateString('de-CH', { day: '2-digit', month: '2-digit' })}</span>
+          <span>{new Date(trend[trend.length - 1].datum).toLocaleDateString('de-CH', { day: '2-digit', month: '2-digit' })}</span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/koordination/ZeitblockAccordion.tsx
+++ b/apps/web/components/koordination/ZeitblockAccordion.tsx
@@ -1,0 +1,133 @@
+'use client'
+
+import { useState } from 'react'
+import type { ZeitblockMitSchichten } from '@/lib/actions/koordination'
+import { SchichtDetailCard } from './SchichtDetailCard'
+
+interface ZeitblockAccordionProps {
+  zeitbloecke: ZeitblockMitSchichten[]
+  onAssign: (schichtId: string) => void
+  onRemoveHelfer: (zuweisungId: string, helferName: string) => void
+}
+
+export function ZeitblockAccordion({
+  zeitbloecke,
+  onAssign,
+  onRemoveHelfer,
+}: ZeitblockAccordionProps) {
+  const [expandedBlocks, setExpandedBlocks] = useState<Set<string>>(
+    new Set(zeitbloecke.map((zb) => zb.id))
+  )
+
+  const toggleBlock = (id: string) => {
+    const newExpanded = new Set(expandedBlocks)
+    if (newExpanded.has(id)) {
+      newExpanded.delete(id)
+    } else {
+      newExpanded.add(id)
+    }
+    setExpandedBlocks(newExpanded)
+  }
+
+  const formatTime = (time: string) => time.slice(0, 5)
+
+  const getAuslastungColor = (gesamtSlots: number, besetztSlots: number) => {
+    if (gesamtSlots === 0) return 'bg-gray-200'
+    const prozent = (besetztSlots / gesamtSlots) * 100
+    if (prozent >= 100) return 'bg-green-500'
+    if (prozent >= 50) return 'bg-yellow-500'
+    return 'bg-red-500'
+  }
+
+  const getAuslastungBgColor = (gesamtSlots: number, besetztSlots: number) => {
+    if (gesamtSlots === 0) return 'bg-gray-100'
+    const prozent = (besetztSlots / gesamtSlots) * 100
+    if (prozent >= 100) return 'bg-green-50'
+    if (prozent >= 50) return 'bg-yellow-50'
+    return 'bg-red-50'
+  }
+
+  return (
+    <div className="space-y-4">
+      {zeitbloecke.map((zb) => {
+        const isExpanded = expandedBlocks.has(zb.id)
+        const auslastungProzent = zb.gesamtSlots > 0
+          ? Math.round((zb.besetztSlots / zb.gesamtSlots) * 100)
+          : 0
+
+        return (
+          <div
+            key={zb.id}
+            className="overflow-hidden rounded-lg border border-neutral-200 bg-white"
+          >
+            {/* Header */}
+            <button
+              onClick={() => toggleBlock(zb.id)}
+              className={`flex w-full items-center justify-between p-4 text-left transition-colors hover:bg-neutral-50 ${getAuslastungBgColor(zb.gesamtSlots, zb.besetztSlots)}`}
+            >
+              <div className="flex items-center gap-4">
+                {/* Expand/Collapse Icon */}
+                <svg
+                  className={`h-5 w-5 text-neutral-500 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                </svg>
+
+                <div>
+                  <h3 className="font-semibold text-neutral-900">{zb.name}</h3>
+                  <p className="text-sm text-neutral-500">
+                    {formatTime(zb.startzeit)} - {formatTime(zb.endzeit)}
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-4">
+                {/* Progress Bar */}
+                <div className="w-32">
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="text-neutral-600">
+                      {zb.besetztSlots}/{zb.gesamtSlots}
+                    </span>
+                    <span className="font-medium text-neutral-900">
+                      {auslastungProzent}%
+                    </span>
+                  </div>
+                  <div className="mt-1 h-2 overflow-hidden rounded-full bg-neutral-200">
+                    <div
+                      className={`h-full transition-all ${getAuslastungColor(zb.gesamtSlots, zb.besetztSlots)}`}
+                      style={{ width: `${Math.min(auslastungProzent, 100)}%` }}
+                    />
+                  </div>
+                </div>
+
+                {/* Schichten Count */}
+                <span className="rounded-full bg-neutral-100 px-2.5 py-0.5 text-sm text-neutral-600">
+                  {zb.schichten.length} Schichten
+                </span>
+              </div>
+            </button>
+
+            {/* Content */}
+            {isExpanded && (
+              <div className="border-t border-neutral-200 p-4">
+                <div className="space-y-3">
+                  {zb.schichten.map((schicht) => (
+                    <SchichtDetailCard
+                      key={schicht.id}
+                      schicht={schicht}
+                      onAssign={() => onAssign(schicht.id)}
+                      onRemoveHelfer={onRemoveHelfer}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/web/components/koordination/index.ts
+++ b/apps/web/components/koordination/index.ts
@@ -1,0 +1,8 @@
+export { KoordinationView } from './KoordinationView'
+export { MetricsCards } from './MetricsCards'
+export { ZeitblockAccordion } from './ZeitblockAccordion'
+export { SchichtDetailCard } from './SchichtDetailCard'
+export { HelferAssignmentModal } from './HelferAssignmentModal'
+export { QuickActions } from './QuickActions'
+export { StatistikSection } from './StatistikSection'
+export { ExportHandler } from './ExportHandler'

--- a/apps/web/lib/actions/helfer-export.ts
+++ b/apps/web/lib/actions/helfer-export.ts
@@ -1,0 +1,295 @@
+'use server'
+
+import { createClient } from '../supabase/server'
+import { requirePermission } from '../supabase/auth-helpers'
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type ExportSchicht = {
+  zeitblockName: string
+  zeitblockStart: string
+  zeitblockEnd: string
+  schichtId: string
+  rolle: string
+  benoetigt: number
+  helfer: {
+    name: string
+    email: string
+    telefon: string
+    status: string
+    isExtern: boolean
+  }[]
+}
+
+export type ExportHelferUebersicht = {
+  name: string
+  email: string
+  telefon: string
+  anzahlSchichten: number
+  schichten: string[]
+}
+
+export type ExportData = {
+  veranstaltung: {
+    titel: string
+    datum: string
+    ort: string
+    startzeit: string
+    endzeit: string
+  }
+  schichten: ExportSchicht[]
+  helferUebersicht: ExportHelferUebersicht[]
+  generatedAt: string
+}
+
+// =============================================================================
+// Data Fetching for Export
+// =============================================================================
+
+/**
+ * Get all data needed for export
+ */
+export async function getExportData(
+  veranstaltungId: string
+): Promise<ExportData | null> {
+  await requirePermission('veranstaltungen:write')
+
+  const supabase = await createClient()
+
+  // Get veranstaltung
+  const { data: veranstaltung } = await supabase
+    .from('veranstaltungen')
+    .select('titel, datum, ort, startzeit, endzeit')
+    .eq('id', veranstaltungId)
+    .single()
+
+  if (!veranstaltung) {
+    return null
+  }
+
+  // Get zeitbloecke with schichten
+  const { data: zeitbloecke } = await supabase
+    .from('zeitbloecke')
+    .select(`
+      id,
+      name,
+      startzeit,
+      endzeit,
+      schichten:auffuehrung_schichten(
+        id,
+        rolle,
+        anzahl_benoetigt,
+        zuweisungen:auffuehrung_zuweisungen(
+          id,
+          status,
+          person:personen(id, vorname, nachname, email, telefon)
+        )
+      )
+    `)
+    .eq('veranstaltung_id', veranstaltungId)
+    .order('sortierung', { ascending: true })
+
+  // Get orphan schichten
+  const { data: orphanSchichten } = await supabase
+    .from('auffuehrung_schichten')
+    .select(`
+      id,
+      rolle,
+      anzahl_benoetigt,
+      zuweisungen:auffuehrung_zuweisungen(
+        id,
+        status,
+        person:personen(id, vorname, nachname, email, telefon)
+      )
+    `)
+    .eq('veranstaltung_id', veranstaltungId)
+    .is('zeitblock_id', null)
+
+  // Build export schichten
+  const schichten: ExportSchicht[] = []
+  const helferMap: Record<string, {
+    name: string
+    email: string
+    telefon: string
+    schichten: string[]
+  }> = {}
+
+  interface ZuweisungType {
+    id: string
+    status: string
+    person: { id: string; vorname: string; nachname: string; email: string | null; telefon: string | null } | null
+  }
+
+  interface SchichtType {
+    id: string
+    rolle: string
+    anzahl_benoetigt: number
+    zuweisungen: ZuweisungType[]
+  }
+
+  const processSchicht = (
+    s: SchichtType,
+    zeitblockName: string,
+    zeitblockStart: string,
+    zeitblockEnd: string
+  ) => {
+    const helfer = (s.zuweisungen || [])
+      .filter((z) => z.status !== 'abgesagt')
+      .map((z) => {
+        const person = z.person
+        const name = person ? `${person.vorname} ${person.nachname}` : 'Unbekannt'
+        const email = person?.email || ''
+        const telefon = person?.telefon || ''
+
+        // Track in helferMap
+        if (person?.id) {
+          if (!helferMap[person.id]) {
+            helferMap[person.id] = {
+              name,
+              email,
+              telefon,
+              schichten: [],
+            }
+          }
+          helferMap[person.id].schichten.push(`${s.rolle} (${zeitblockStart} - ${zeitblockEnd})`)
+        }
+
+        return {
+          name,
+          email,
+          telefon,
+          status: z.status,
+          isExtern: false,
+        }
+      })
+
+    schichten.push({
+      zeitblockName,
+      zeitblockStart,
+      zeitblockEnd,
+      schichtId: s.id,
+      rolle: s.rolle,
+      benoetigt: s.anzahl_benoetigt,
+      helfer,
+    })
+  }
+
+  // Process zeitbloecke
+  zeitbloecke?.forEach((zb) => {
+    (zb.schichten as unknown as SchichtType[])?.forEach((s) => {
+      processSchicht(s, zb.name, zb.startzeit, zb.endzeit)
+    })
+  })
+
+  // Process orphan schichten
+  ;(orphanSchichten as unknown as SchichtType[])?.forEach((s) => {
+    processSchicht(
+      s,
+      'Ohne Zeitblock',
+      veranstaltung.startzeit || '00:00',
+      veranstaltung.endzeit || '23:59'
+    )
+  })
+
+  // Build helper overview
+  const helferUebersicht: ExportHelferUebersicht[] = Object.values(helferMap)
+    .map((h) => ({
+      ...h,
+      anzahlSchichten: h.schichten.length,
+    }))
+    .sort((a, b) => b.anzahlSchichten - a.anzahlSchichten)
+
+  return {
+    veranstaltung: {
+      titel: veranstaltung.titel,
+      datum: veranstaltung.datum,
+      ort: veranstaltung.ort || '',
+      startzeit: veranstaltung.startzeit || '',
+      endzeit: veranstaltung.endzeit || '',
+    },
+    schichten,
+    helferUebersicht,
+    generatedAt: new Date().toISOString(),
+  }
+}
+
+/**
+ * Generate Excel data (returns JSON that can be converted to Excel client-side)
+ */
+export async function generateExcelData(
+  veranstaltungId: string
+): Promise<{
+  success: boolean
+  data?: {
+    schichten: Record<string, string | number>[]
+    helfer: Record<string, string | number>[]
+    meta: Record<string, string>
+  }
+  error?: string
+}> {
+  const exportData = await getExportData(veranstaltungId)
+
+  if (!exportData) {
+    return { success: false, error: 'Veranstaltung nicht gefunden' }
+  }
+
+  // Build schichten sheet data
+  const schichtenRows: Record<string, string | number>[] = []
+
+  exportData.schichten.forEach((s) => {
+    if (s.helfer.length === 0) {
+      // Empty slot
+      schichtenRows.push({
+        Zeitblock: s.zeitblockName,
+        Start: s.zeitblockStart,
+        Ende: s.zeitblockEnd,
+        Rolle: s.rolle,
+        'Helfer Name': '',
+        'Helfer Email': '',
+        'Helfer Telefon': '',
+        Status: 'Unbesetzt',
+      })
+    } else {
+      s.helfer.forEach((h) => {
+        schichtenRows.push({
+          Zeitblock: s.zeitblockName,
+          Start: s.zeitblockStart,
+          Ende: s.zeitblockEnd,
+          Rolle: s.rolle,
+          'Helfer Name': h.name,
+          'Helfer Email': h.email,
+          'Helfer Telefon': h.telefon,
+          Status: h.status,
+        })
+      })
+    }
+  })
+
+  // Build helfer sheet data
+  const helferRows = exportData.helferUebersicht.map((h) => ({
+    Name: h.name,
+    Email: h.email,
+    Telefon: h.telefon,
+    'Anzahl Schichten': h.anzahlSchichten,
+    Schichten: h.schichten.join('; '),
+  }))
+
+  // Build meta
+  const meta = {
+    Veranstaltung: exportData.veranstaltung.titel,
+    Datum: new Date(exportData.veranstaltung.datum).toLocaleDateString('de-CH'),
+    Ort: exportData.veranstaltung.ort,
+    'Generiert am': new Date(exportData.generatedAt).toLocaleString('de-CH'),
+  }
+
+  return {
+    success: true,
+    data: {
+      schichten: schichtenRows,
+      helfer: helferRows,
+      meta,
+    },
+  }
+}

--- a/apps/web/lib/actions/helfer-statistiken.ts
+++ b/apps/web/lib/actions/helfer-statistiken.ts
@@ -1,0 +1,279 @@
+'use server'
+
+import { createClient } from '../supabase/server'
+import { requirePermission } from '../supabase/auth-helpers'
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type ZeitblockAuslastung = {
+  id: string
+  name: string
+  startzeit: string
+  endzeit: string
+  gesamtSlots: number
+  besetztSlots: number
+  auslastungProzent: number
+}
+
+export type KritischeSchicht = {
+  id: string
+  rolle: string
+  zeitblockName: string | null
+  startzeit: string | null
+  endzeit: string | null
+  benoetigt: number
+  besetzt: number
+  auslastungProzent: number
+}
+
+export type TopHelfer = {
+  id: string
+  name: string
+  email: string | null
+  anzahlSchichten: number
+}
+
+export type AnmeldungsTrendPunkt = {
+  datum: string
+  anzahl: number
+  kumuliert: number
+}
+
+export type HelferStatistik = {
+  // Overview
+  totalSlots: number
+  besetztSlots: number
+  offeneSlots: number
+  auslastungProzent: number
+
+  // By Zeitblock
+  zeitblockAuslastung: ZeitblockAuslastung[]
+
+  // Internal vs External
+  interneCount: number
+  externeCount: number
+
+  // Trend
+  anmeldungsTrend: AnmeldungsTrendPunkt[]
+
+  // Critical shifts
+  kritischeSchichten: KritischeSchicht[]
+
+  // Top helpers
+  topHelfer: TopHelfer[]
+}
+
+// =============================================================================
+// Main Function
+// =============================================================================
+
+/**
+ * Get comprehensive statistics for a performance's helper list
+ */
+export async function getHelferStatistik(
+  veranstaltungId: string
+): Promise<HelferStatistik | null> {
+  await requirePermission('veranstaltungen:write')
+
+  const supabase = await createClient()
+
+  // Get zeitbloecke with schichten
+  const { data: zeitbloecke, error: zeitblockError } = await supabase
+    .from('zeitbloecke')
+    .select(`
+      id,
+      name,
+      startzeit,
+      endzeit,
+      schichten:auffuehrung_schichten(
+        id,
+        rolle,
+        anzahl_benoetigt,
+        zuweisungen:auffuehrung_zuweisungen(id, status, person_id, created_at)
+      )
+    `)
+    .eq('veranstaltung_id', veranstaltungId)
+    .order('sortierung', { ascending: true })
+
+  if (zeitblockError) {
+    console.error('Error fetching zeitbloecke:', zeitblockError)
+    return null
+  }
+
+  // Get orphan schichten
+  const { data: orphanSchichten } = await supabase
+    .from('auffuehrung_schichten')
+    .select(`
+      id,
+      rolle,
+      anzahl_benoetigt,
+      zuweisungen:auffuehrung_zuweisungen(id, status, person_id, created_at)
+    `)
+    .eq('veranstaltung_id', veranstaltungId)
+    .is('zeitblock_id', null)
+
+  // Calculate totals
+  let totalSlots = 0
+  let besetztSlots = 0
+  const kritischeSchichten: KritischeSchicht[] = []
+  const personCounts: Record<string, number> = {}
+  const allZuweisungen: { created_at: string }[] = []
+
+  // Process zeitbloecke
+  const zeitblockAuslastung: ZeitblockAuslastung[] = []
+
+  zeitbloecke?.forEach((zb) => {
+    let zbGesamtSlots = 0
+    let zbBesetztSlots = 0
+
+    interface SchichtType {
+      id: string
+      rolle: string
+      anzahl_benoetigt: number
+      zuweisungen: { id: string; status: string; person_id: string; created_at: string }[]
+    }
+
+    (zb.schichten as SchichtType[])?.forEach((s) => {
+      const activeZuweisungen = s.zuweisungen?.filter((z) => z.status !== 'abgesagt') || []
+      const benoetigt = s.anzahl_benoetigt
+      const besetzt = activeZuweisungen.length
+
+      zbGesamtSlots += benoetigt
+      zbBesetztSlots += besetzt
+      totalSlots += benoetigt
+      besetztSlots += besetzt
+
+      // Track person assignments
+      activeZuweisungen.forEach((z) => {
+        personCounts[z.person_id] = (personCounts[z.person_id] || 0) + 1
+        allZuweisungen.push({ created_at: z.created_at })
+      })
+
+      // Check if critical
+      const auslastung = benoetigt > 0 ? (besetzt / benoetigt) * 100 : 100
+      if (auslastung < 50) {
+        kritischeSchichten.push({
+          id: s.id,
+          rolle: s.rolle,
+          zeitblockName: zb.name,
+          startzeit: zb.startzeit,
+          endzeit: zb.endzeit,
+          benoetigt,
+          besetzt,
+          auslastungProzent: Math.round(auslastung),
+        })
+      }
+    })
+
+    zeitblockAuslastung.push({
+      id: zb.id,
+      name: zb.name,
+      startzeit: zb.startzeit,
+      endzeit: zb.endzeit,
+      gesamtSlots: zbGesamtSlots,
+      besetztSlots: zbBesetztSlots,
+      auslastungProzent: zbGesamtSlots > 0 ? Math.round((zbBesetztSlots / zbGesamtSlots) * 100) : 100,
+    })
+  })
+
+  // Process orphan schichten
+  interface OrphanSchichtType {
+    id: string
+    rolle: string
+    anzahl_benoetigt: number
+    zuweisungen: { id: string; status: string; person_id: string; created_at: string }[]
+  }
+
+  (orphanSchichten as OrphanSchichtType[])?.forEach((s) => {
+    const activeZuweisungen = s.zuweisungen?.filter((z) => z.status !== 'abgesagt') || []
+    const benoetigt = s.anzahl_benoetigt
+    const besetzt = activeZuweisungen.length
+
+    totalSlots += benoetigt
+    besetztSlots += besetzt
+
+    activeZuweisungen.forEach((z) => {
+      personCounts[z.person_id] = (personCounts[z.person_id] || 0) + 1
+      allZuweisungen.push({ created_at: z.created_at })
+    })
+
+    const auslastung = benoetigt > 0 ? (besetzt / benoetigt) * 100 : 100
+    if (auslastung < 50) {
+      kritischeSchichten.push({
+        id: s.id,
+        rolle: s.rolle,
+        zeitblockName: null,
+        startzeit: null,
+        endzeit: null,
+        benoetigt,
+        besetzt,
+        auslastungProzent: Math.round(auslastung),
+      })
+    }
+  })
+
+  // Sort kritische schichten by auslastung (lowest first)
+  kritischeSchichten.sort((a, b) => a.auslastungProzent - b.auslastungProzent)
+
+  // Get top helpers
+  const topPersonIds = Object.entries(personCounts)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10)
+    .map(([id]) => id)
+
+  let topHelfer: TopHelfer[] = []
+  if (topPersonIds.length > 0) {
+    const { data: persons } = await supabase
+      .from('personen')
+      .select('id, vorname, nachname, email')
+      .in('id', topPersonIds)
+
+    topHelfer = topPersonIds.map((id) => {
+      const person = persons?.find((p) => p.id === id)
+      return {
+        id,
+        name: person ? `${person.vorname} ${person.nachname}` : 'Unbekannt',
+        email: person?.email || null,
+        anzahlSchichten: personCounts[id],
+      }
+    })
+  }
+
+  // Calculate trend (group by day)
+  const trendByDay: Record<string, number> = {}
+  allZuweisungen.forEach((z) => {
+    const date = z.created_at.split('T')[0]
+    trendByDay[date] = (trendByDay[date] || 0) + 1
+  })
+
+  const sortedDates = Object.keys(trendByDay).sort()
+  let kumuliert = 0
+  const anmeldungsTrend: AnmeldungsTrendPunkt[] = sortedDates.map((datum) => {
+    kumuliert += trendByDay[datum]
+    return {
+      datum,
+      anzahl: trendByDay[datum],
+      kumuliert,
+    }
+  })
+
+  // Count internal vs external (for now, all are internal since we use personen table)
+  // External helpers would be tracked differently
+  const interneCount = Object.keys(personCounts).length
+  const externeCount = 0
+
+  return {
+    totalSlots,
+    besetztSlots,
+    offeneSlots: totalSlots - besetztSlots,
+    auslastungProzent: totalSlots > 0 ? Math.round((besetztSlots / totalSlots) * 100) : 0,
+    zeitblockAuslastung,
+    interneCount,
+    externeCount,
+    anmeldungsTrend,
+    kritischeSchichten: kritischeSchichten.slice(0, 5), // Top 5 critical
+    topHelfer: topHelfer.slice(0, 5), // Top 5 helpers
+  }
+}

--- a/apps/web/lib/actions/koordination.ts
+++ b/apps/web/lib/actions/koordination.ts
@@ -1,0 +1,415 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { createClient } from '../supabase/server'
+import { requirePermission } from '../supabase/auth-helpers'
+import type {
+  Zeitblock,
+  AuffuehrungSchicht,
+  AuffuehrungZuweisung,
+  Person,
+  ExterneHelferProfil,
+  HelferWarteliste,
+  Profile,
+} from '../supabase/types'
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type HelferDetails = {
+  id: string
+  name: string
+  email: string | null
+  telefon: string | null
+  isExtern: boolean
+  zuweisungId: string
+  status: string
+  notizen: string | null
+}
+
+export type SchichtMitHelfer = AuffuehrungSchicht & {
+  zeitblock: Pick<Zeitblock, 'id' | 'name' | 'startzeit' | 'endzeit' | 'typ'> | null
+  sichtbarkeit?: 'intern' | 'public'
+  helfer: HelferDetails[]
+  anzahlBesetzt: number
+  warteliste: WartelisteEintrag[]
+}
+
+export type ZeitblockMitSchichten = Zeitblock & {
+  schichten: SchichtMitHelfer[]
+  gesamtSlots: number
+  besetztSlots: number
+}
+
+export type WartelisteEintrag = {
+  id: string
+  position: number
+  status: string
+  name: string
+  email: string | null
+  isExtern: boolean
+  erstelltAm: string
+}
+
+export type KoordinationMetrics = {
+  gesamtSlots: number
+  besetztSlots: number
+  offeneSlots: number
+  warteliste: number
+  auslastungProzent: number
+}
+
+export type KoordinationData = {
+  veranstaltung: {
+    id: string
+    titel: string
+    datum: string
+    startzeit: string | null
+    endzeit: string | null
+    ort: string | null
+    helfer_status: string | null
+  }
+  metrics: KoordinationMetrics
+  zeitbloecke: ZeitblockMitSchichten[]
+  alleWarteliste: WartelisteEintrag[]
+}
+
+// =============================================================================
+// Main Data Fetching
+// =============================================================================
+
+/**
+ * Get all coordination data for a performance
+ */
+export async function getKoordinationData(
+  veranstaltungId: string
+): Promise<KoordinationData | null> {
+  await requirePermission('veranstaltungen:write')
+
+  const supabase = await createClient()
+
+  // Get veranstaltung
+  const { data: veranstaltung, error: veranstaltungError } = await supabase
+    .from('veranstaltungen')
+    .select('id, titel, datum, startzeit, endzeit, ort, helfer_status')
+    .eq('id', veranstaltungId)
+    .single()
+
+  if (veranstaltungError || !veranstaltung) {
+    console.error('Error fetching veranstaltung:', veranstaltungError)
+    return null
+  }
+
+  // Get zeitbloecke with schichten
+  const { data: zeitbloecke, error: zeitblockError } = await supabase
+    .from('zeitbloecke')
+    .select(`
+      *,
+      schichten:auffuehrung_schichten(
+        *,
+        zuweisungen:auffuehrung_zuweisungen(
+          *,
+          person:personen(id, vorname, nachname, email, telefon)
+        )
+      )
+    `)
+    .eq('veranstaltung_id', veranstaltungId)
+    .order('sortierung', { ascending: true })
+
+  if (zeitblockError) {
+    console.error('Error fetching zeitbloecke:', zeitblockError)
+    return null
+  }
+
+  // Get orphan schichten (without zeitblock)
+  const { data: orphanSchichten } = await supabase
+    .from('auffuehrung_schichten')
+    .select(`
+      *,
+      zuweisungen:auffuehrung_zuweisungen(
+        *,
+        person:personen(id, vorname, nachname, email, telefon)
+      )
+    `)
+    .eq('veranstaltung_id', veranstaltungId)
+    .is('zeitblock_id', null)
+
+  // Get all schicht IDs for waitlist query
+  const allSchichtIds = [
+    ...(zeitbloecke?.flatMap((zb) =>
+      (zb.schichten || []).map((s: AuffuehrungSchicht) => s.id)
+    ) || []),
+    ...(orphanSchichten?.map((s) => s.id) || []),
+  ]
+
+  // Get waitlist entries
+  let wartelisteData: (HelferWarteliste & {
+    profile: Pick<Profile, 'id' | 'display_name' | 'email'> | null
+    external_helper: Pick<ExterneHelferProfil, 'id' | 'vorname' | 'nachname' | 'email'> | null
+  })[] = []
+
+  if (allSchichtIds.length > 0) {
+    const { data: wl } = await supabase
+      .from('helfer_warteliste')
+      .select(`
+        *,
+        profile:profiles(id, display_name, email),
+        external_helper:externe_helfer_profile(id, vorname, nachname, email)
+      `)
+      .in('schicht_id', allSchichtIds)
+      .order('position', { ascending: true })
+
+    if (wl) {
+      wartelisteData = wl as typeof wartelisteData
+    }
+  }
+
+  // Group waitlist by schicht_id
+  const wartelisteBySchicht = new Map<string, WartelisteEintrag[]>()
+  wartelisteData.forEach((entry) => {
+    const schichtId = entry.schicht_id
+    if (!wartelisteBySchicht.has(schichtId)) {
+      wartelisteBySchicht.set(schichtId, [])
+    }
+    const profileData = entry.profile as { id: string; display_name: string | null; email: string } | null
+    const externalData = entry.external_helper as { id: string; vorname: string; nachname: string; email: string } | null
+
+    wartelisteBySchicht.get(schichtId)!.push({
+      id: entry.id,
+      position: entry.position,
+      status: entry.status,
+      name: externalData
+        ? `${externalData.vorname} ${externalData.nachname}`
+        : profileData?.display_name || profileData?.email || 'Unbekannt',
+      email: externalData?.email || profileData?.email || null,
+      isExtern: !!externalData,
+      erstelltAm: entry.erstellt_am,
+    })
+  })
+
+  // Transform data
+  const transformSchicht = (
+    schicht: AuffuehrungSchicht & {
+      zuweisungen: (AuffuehrungZuweisung & { person: Pick<Person, 'id' | 'vorname' | 'nachname' | 'email' | 'telefon'> | null })[]
+    },
+    zeitblock: Pick<Zeitblock, 'id' | 'name' | 'startzeit' | 'endzeit' | 'typ'> | null
+  ): SchichtMitHelfer => {
+    const activeZuweisungen = (schicht.zuweisungen || []).filter(
+      (z) => z.status !== 'abgesagt'
+    )
+
+    return {
+      ...schicht,
+      zeitblock,
+      helfer: activeZuweisungen.map((z) => ({
+        id: z.person?.id || '',
+        name: z.person ? `${z.person.vorname} ${z.person.nachname}` : 'Unbekannt',
+        email: z.person?.email || null,
+        telefon: z.person?.telefon || null,
+        isExtern: false, // Internal zuweisungen are always from personen
+        zuweisungId: z.id,
+        status: z.status,
+        notizen: z.notizen,
+      })),
+      anzahlBesetzt: activeZuweisungen.length,
+      warteliste: wartelisteBySchicht.get(schicht.id) || [],
+    }
+  }
+
+  // Build transformed zeitbloecke
+  const transformedZeitbloecke: ZeitblockMitSchichten[] = (zeitbloecke || []).map((zb) => {
+    const schichten = (zb.schichten || []).map((s: AuffuehrungSchicht & { zuweisungen: (AuffuehrungZuweisung & { person: Pick<Person, 'id' | 'vorname' | 'nachname' | 'email' | 'telefon'> | null })[] }) =>
+      transformSchicht(s, {
+        id: zb.id,
+        name: zb.name,
+        startzeit: zb.startzeit,
+        endzeit: zb.endzeit,
+        typ: zb.typ,
+      })
+    )
+
+    const gesamtSlots = schichten.reduce((sum: number, s: SchichtMitHelfer) => sum + s.anzahl_benoetigt, 0)
+    const besetztSlots = schichten.reduce((sum: number, s: SchichtMitHelfer) => sum + s.anzahlBesetzt, 0)
+
+    return {
+      ...zb,
+      schichten,
+      gesamtSlots,
+      besetztSlots,
+    }
+  })
+
+  // Add orphan schichten as virtual zeitblock
+  if (orphanSchichten && orphanSchichten.length > 0) {
+    const orphanTransformed = orphanSchichten.map((s: AuffuehrungSchicht & { zuweisungen: (AuffuehrungZuweisung & { person: Pick<Person, 'id' | 'vorname' | 'nachname' | 'email' | 'telefon'> | null })[] }) =>
+      transformSchicht(s, null)
+    )
+
+    const gesamtSlots = orphanTransformed.reduce((sum, s) => sum + s.anzahl_benoetigt, 0)
+    const besetztSlots = orphanTransformed.reduce((sum, s) => sum + s.anzahlBesetzt, 0)
+
+    transformedZeitbloecke.push({
+      id: 'no-zeitblock',
+      veranstaltung_id: veranstaltungId,
+      name: 'Ohne Zeitblock',
+      startzeit: veranstaltung.startzeit || '00:00',
+      endzeit: veranstaltung.endzeit || '23:59',
+      typ: 'standard',
+      sortierung: 9999,
+      created_at: new Date().toISOString(),
+      schichten: orphanTransformed,
+      gesamtSlots,
+      besetztSlots,
+    })
+  }
+
+  // Calculate metrics
+  const gesamtSlots = transformedZeitbloecke.reduce((sum, zb) => sum + zb.gesamtSlots, 0)
+  const besetztSlots = transformedZeitbloecke.reduce((sum, zb) => sum + zb.besetztSlots, 0)
+  const totalWarteliste = wartelisteData.filter((w) => w.status === 'wartend').length
+
+  const metrics: KoordinationMetrics = {
+    gesamtSlots,
+    besetztSlots,
+    offeneSlots: gesamtSlots - besetztSlots,
+    warteliste: totalWarteliste,
+    auslastungProzent: gesamtSlots > 0 ? Math.round((besetztSlots / gesamtSlots) * 100) : 0,
+  }
+
+  // Flatten all warteliste entries
+  const alleWarteliste: WartelisteEintrag[] = wartelisteData
+    .filter((w) => w.status === 'wartend')
+    .map((entry) => {
+      const profileData = entry.profile as { id: string; display_name: string | null; email: string } | null
+      const externalData = entry.external_helper as { id: string; vorname: string; nachname: string; email: string } | null
+      return {
+        id: entry.id,
+        position: entry.position,
+        status: entry.status,
+        name: externalData
+          ? `${externalData.vorname} ${externalData.nachname}`
+          : profileData?.display_name || profileData?.email || 'Unbekannt',
+        email: externalData?.email || profileData?.email || null,
+        isExtern: !!externalData,
+        erstelltAm: entry.erstellt_am,
+      }
+    })
+
+  return {
+    veranstaltung,
+    metrics,
+    zeitbloecke: transformedZeitbloecke,
+    alleWarteliste,
+  }
+}
+
+// =============================================================================
+// Actions
+// =============================================================================
+
+/**
+ * Remove a helper from a shift (admin action)
+ */
+export async function removeHelferFromSchicht(
+  zuweisungId: string
+): Promise<{ success: boolean; error?: string }> {
+  await requirePermission('veranstaltungen:write')
+
+  const supabase = await createClient()
+
+  // Get zuweisung for revalidation path
+  const { data: zuweisung } = await supabase
+    .from('auffuehrung_zuweisungen')
+    .select('schicht_id, schicht:auffuehrung_schichten(veranstaltung_id)')
+    .eq('id', zuweisungId)
+    .single()
+
+  const { error } = await supabase
+    .from('auffuehrung_zuweisungen')
+    .delete()
+    .eq('id', zuweisungId)
+
+  if (error) {
+    console.error('Error removing helfer:', error)
+    return { success: false, error: 'Fehler beim Entfernen des Helfers' }
+  }
+
+  if (zuweisung?.schicht) {
+    const schichtData = zuweisung.schicht as unknown as { veranstaltung_id: string }
+    revalidatePath(`/auffuehrungen/${schichtData.veranstaltung_id}/helfer-koordination`)
+    revalidatePath(`/auffuehrungen/${schichtData.veranstaltung_id}/helferliste`)
+  }
+
+  return { success: true }
+}
+
+/**
+ * Copy all helper emails to clipboard (returns comma-separated list)
+ */
+export async function getAllHelferEmails(
+  veranstaltungId: string
+): Promise<{ success: boolean; emails?: string; count?: number; error?: string }> {
+  await requirePermission('veranstaltungen:write')
+
+  const supabase = await createClient()
+
+  // Get all schicht IDs for this veranstaltung
+  const { data: schichten } = await supabase
+    .from('auffuehrung_schichten')
+    .select('id')
+    .eq('veranstaltung_id', veranstaltungId)
+
+  if (!schichten || schichten.length === 0) {
+    return { success: true, emails: '', count: 0 }
+  }
+
+  const schichtIds = schichten.map((s) => s.id)
+
+  // Get all zuweisungen with person emails
+  const { data: zuweisungen } = await supabase
+    .from('auffuehrung_zuweisungen')
+    .select('person:personen(email)')
+    .in('schicht_id', schichtIds)
+    .neq('status', 'abgesagt')
+
+  const emails = new Set<string>()
+
+  zuweisungen?.forEach((z) => {
+    const person = z.person as unknown as { email: string | null }
+    if (person?.email) {
+      emails.add(person.email)
+    }
+  })
+
+  const emailList = Array.from(emails).sort().join(', ')
+
+  return { success: true, emails: emailList, count: emails.size }
+}
+
+/**
+ * Update helper status (publish, close, etc.)
+ */
+export async function updateHelferStatus(
+  veranstaltungId: string,
+  status: 'entwurf' | 'veroeffentlicht' | 'abgeschlossen'
+): Promise<{ success: boolean; error?: string }> {
+  await requirePermission('veranstaltungen:write')
+
+  const supabase = await createClient()
+
+  const { error } = await supabase
+    .from('veranstaltungen')
+    .update({ helfer_status: status } as never)
+    .eq('id', veranstaltungId)
+
+  if (error) {
+    console.error('Error updating helfer status:', error)
+    return { success: false, error: 'Fehler beim Aktualisieren des Status' }
+  }
+
+  revalidatePath(`/auffuehrungen/${veranstaltungId}/helfer-koordination`)
+  revalidatePath(`/auffuehrungen/${veranstaltungId}`)
+
+  return { success: true }
+}

--- a/apps/web/lib/actions/manual-assignment.ts
+++ b/apps/web/lib/actions/manual-assignment.ts
@@ -1,0 +1,433 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { createClient, getUserProfile } from '../supabase/server'
+import { requirePermission } from '../supabase/auth-helpers'
+// Types used for reference but not directly imported
+// Person, Profile, ExterneHelferProfil are used in runtime queries
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type HelferSearchResult = {
+  id: string
+  type: 'intern' | 'extern'
+  name: string
+  email: string
+  telefon: string | null
+  einsaetzeCount: number
+  letzterEinsatz: string | null
+}
+
+export type TimeConflict = {
+  schichtId: string
+  rolle: string
+  startzeit: string
+  endzeit: string
+  ueberschneidungMinuten: number
+}
+
+export type AssignmentValidation = {
+  hasConflict: boolean
+  conflicts: TimeConflict[]
+  bookingLimitReached: boolean
+  currentBookings: number
+  maxBookings: number | null
+}
+
+// =============================================================================
+// Search
+// =============================================================================
+
+/**
+ * Search for helpers by name or email
+ */
+export async function searchHelfer(
+  query: string,
+  veranstaltungId: string
+): Promise<HelferSearchResult[]> {
+  await requirePermission('veranstaltungen:write')
+
+  if (!query || query.length < 2) {
+    return []
+  }
+
+  const supabase = await createClient()
+  const searchPattern = `%${query}%`
+
+  // Search internal profiles (via personen table)
+  const { data: personen } = await supabase
+    .from('personen')
+    .select('id, vorname, nachname, email, telefon')
+    .or(`vorname.ilike.${searchPattern},nachname.ilike.${searchPattern},email.ilike.${searchPattern}`)
+    .eq('aktiv', true)
+    .limit(10)
+
+  // Search external helpers
+  const { data: externeHelfer } = await supabase
+    .from('externe_helfer_profile')
+    .select('id, vorname, nachname, email, telefon, letzter_einsatz')
+    .or(`vorname.ilike.${searchPattern},nachname.ilike.${searchPattern},email.ilike.${searchPattern}`)
+    .limit(10)
+
+  // Get schicht IDs for counting previous assignments
+  const { data: schichten } = await supabase
+    .from('auffuehrung_schichten')
+    .select('id')
+    .eq('veranstaltung_id', veranstaltungId)
+
+  const schichtIds = schichten?.map((s) => s.id) || []
+
+  // Count assignments for internal helpers
+  const personIds = personen?.map((p) => p.id) || []
+  const assignmentCounts: Record<string, number> = {}
+
+  if (personIds.length > 0 && schichtIds.length > 0) {
+    const { data: assignments } = await supabase
+      .from('auffuehrung_zuweisungen')
+      .select('person_id')
+      .in('person_id', personIds)
+      .in('schicht_id', schichtIds)
+      .neq('status', 'abgesagt')
+
+    assignments?.forEach((a) => {
+      assignmentCounts[a.person_id] = (assignmentCounts[a.person_id] || 0) + 1
+    })
+  }
+
+  const results: HelferSearchResult[] = []
+
+  // Add internal helpers
+  personen?.forEach((p) => {
+    results.push({
+      id: p.id,
+      type: 'intern',
+      name: `${p.vorname} ${p.nachname}`,
+      email: p.email || '',
+      telefon: p.telefon,
+      einsaetzeCount: assignmentCounts[p.id] || 0,
+      letzterEinsatz: null,
+    })
+  })
+
+  // Add external helpers
+  externeHelfer?.forEach((e) => {
+    results.push({
+      id: e.id,
+      type: 'extern',
+      name: `${e.vorname} ${e.nachname}`,
+      email: e.email,
+      telefon: e.telefon,
+      einsaetzeCount: 0, // TODO: Count external assignments
+      letzterEinsatz: e.letzter_einsatz,
+    })
+  })
+
+  return results
+}
+
+// =============================================================================
+// Validation
+// =============================================================================
+
+/**
+ * Validate assignment before creating it
+ */
+export async function validateAssignment(
+  schichtId: string,
+  personId: string,
+  personType: 'intern' | 'extern'
+): Promise<AssignmentValidation> {
+  await requirePermission('veranstaltungen:write')
+
+  const supabase = await createClient()
+
+  // Get schicht and veranstaltung info
+  const { data: schicht } = await supabase
+    .from('auffuehrung_schichten')
+    .select(`
+      id,
+      veranstaltung_id,
+      zeitblock_id,
+      zeitblock:zeitbloecke(startzeit, endzeit)
+    `)
+    .eq('id', schichtId)
+    .single()
+
+  if (!schicht) {
+    return {
+      hasConflict: false,
+      conflicts: [],
+      bookingLimitReached: false,
+      currentBookings: 0,
+      maxBookings: null,
+    }
+  }
+
+  // Get veranstaltung booking limits
+  const { data: veranstaltung } = await supabase
+    .from('veranstaltungen')
+    .select('max_schichten_pro_helfer, helfer_buchung_limit_aktiv')
+    .eq('id', schicht.veranstaltung_id)
+    .single()
+
+  const conflicts: TimeConflict[] = []
+  let currentBookings = 0
+
+  if (personType === 'intern') {
+    // Get all other schichten for this veranstaltung
+    const { data: alleSchichten } = await supabase
+      .from('auffuehrung_schichten')
+      .select(`
+        id,
+        rolle,
+        zeitblock:zeitbloecke(startzeit, endzeit)
+      `)
+      .eq('veranstaltung_id', schicht.veranstaltung_id)
+      .neq('id', schichtId)
+
+    // Get existing assignments for this person
+    const { data: assignments } = await supabase
+      .from('auffuehrung_zuweisungen')
+      .select('schicht_id')
+      .eq('person_id', personId)
+      .in('schicht_id', alleSchichten?.map((s) => s.id) || [])
+      .neq('status', 'abgesagt')
+
+    currentBookings = assignments?.length || 0
+
+    // Check for time conflicts
+    const targetZeitblock = schicht.zeitblock as unknown as { startzeit: string; endzeit: string } | null
+    if (targetZeitblock && assignments) {
+      const assignedSchichtIds = new Set(assignments.map((a) => a.schicht_id))
+
+      alleSchichten?.forEach((s) => {
+        if (assignedSchichtIds.has(s.id)) {
+          const zb = s.zeitblock as unknown as { startzeit: string; endzeit: string } | null
+          if (zb) {
+            // Check overlap
+            if (targetZeitblock.startzeit < zb.endzeit && targetZeitblock.endzeit > zb.startzeit) {
+              // Calculate overlap in minutes
+              const overlapStart = targetZeitblock.startzeit > zb.startzeit
+                ? targetZeitblock.startzeit
+                : zb.startzeit
+              const overlapEnd = targetZeitblock.endzeit < zb.endzeit
+                ? targetZeitblock.endzeit
+                : zb.endzeit
+
+              const startMinutes = parseInt(overlapStart.split(':')[0]) * 60 + parseInt(overlapStart.split(':')[1])
+              const endMinutes = parseInt(overlapEnd.split(':')[0]) * 60 + parseInt(overlapEnd.split(':')[1])
+
+              conflicts.push({
+                schichtId: s.id,
+                rolle: s.rolle,
+                startzeit: zb.startzeit,
+                endzeit: zb.endzeit,
+                ueberschneidungMinuten: endMinutes - startMinutes,
+              })
+            }
+          }
+        }
+      })
+    }
+  }
+
+  const maxBookings = veranstaltung?.helfer_buchung_limit_aktiv
+    ? veranstaltung.max_schichten_pro_helfer
+    : null
+
+  return {
+    hasConflict: conflicts.length > 0,
+    conflicts,
+    bookingLimitReached: maxBookings !== null && currentBookings >= maxBookings,
+    currentBookings,
+    maxBookings,
+  }
+}
+
+// =============================================================================
+// Assignment
+// =============================================================================
+
+/**
+ * Manually assign a helper to a shift
+ */
+export async function assignHelferManual(
+  schichtId: string,
+  personId: string,
+  personType: 'intern' | 'extern',
+  override = false,
+  notizen?: string
+): Promise<{ success: boolean; error?: string }> {
+  await requirePermission('veranstaltungen:write')
+
+  const supabase = await createClient()
+  const profile = await getUserProfile()
+
+  // Validate if not overriding
+  if (!override) {
+    const validation = await validateAssignment(schichtId, personId, personType)
+
+    if (validation.hasConflict) {
+      const conflictRoles = validation.conflicts.map((c) => c.rolle).join(', ')
+      return { success: false, error: `Zeitkonflikt mit: ${conflictRoles}` }
+    }
+
+    if (validation.bookingLimitReached) {
+      return {
+        success: false,
+        error: `Buchungslimit erreicht: ${validation.currentBookings}/${validation.maxBookings} Schichten`,
+      }
+    }
+  } else {
+    // Override requires admin permission
+    await requirePermission('admin:access')
+  }
+
+  // Get veranstaltung_id for revalidation
+  const { data: schicht } = await supabase
+    .from('auffuehrung_schichten')
+    .select('veranstaltung_id')
+    .eq('id', schichtId)
+    .single()
+
+  if (!schicht) {
+    return { success: false, error: 'Schicht nicht gefunden' }
+  }
+
+  if (personType === 'intern') {
+    // Check for existing assignment
+    const { data: existing } = await supabase
+      .from('auffuehrung_zuweisungen')
+      .select('id')
+      .eq('schicht_id', schichtId)
+      .eq('person_id', personId)
+      .single()
+
+    if (existing) {
+      return { success: false, error: 'Diese Person ist bereits für diese Schicht zugewiesen' }
+    }
+
+    // Create assignment
+    const assignmentNotizen = notizen
+      ? `${notizen}\n\nManuell zugewiesen von ${profile?.display_name || profile?.email}`
+      : `Manuell zugewiesen von ${profile?.display_name || profile?.email}`
+
+    const { error } = await supabase
+      .from('auffuehrung_zuweisungen')
+      .insert({
+        schicht_id: schichtId,
+        person_id: personId,
+        status: 'zugesagt',
+        notizen: assignmentNotizen,
+      } as never)
+
+    if (error) {
+      console.error('Error creating assignment:', error)
+      if (error.code === '23505') {
+        return { success: false, error: 'Diese Person ist bereits für diese Schicht zugewiesen' }
+      }
+      return { success: false, error: 'Fehler beim Zuweisen' }
+    }
+  } else {
+    // External helper - need to handle differently
+    // For now, external helpers cannot be assigned directly to auffuehrung_zuweisungen
+    // They would need to be added to personen first or use a different mechanism
+    return {
+      success: false,
+      error: 'Externe Helfer koennen derzeit nicht direkt zugewiesen werden. Bitte legen Sie zuerst ein Mitgliederprofil an.',
+    }
+  }
+
+  revalidatePath(`/auffuehrungen/${schicht.veranstaltung_id}/helfer-koordination`)
+  revalidatePath(`/auffuehrungen/${schicht.veranstaltung_id}/helferliste`)
+
+  return { success: true }
+}
+
+/**
+ * Create external helper and assign to shift
+ */
+export async function createExternalAndAssign(
+  schichtId: string,
+  helferData: {
+    vorname: string
+    nachname: string
+    email: string
+    telefon?: string
+  }
+): Promise<{ success: boolean; error?: string; helperId?: string }> {
+  await requirePermission('veranstaltungen:write')
+
+  const supabase = await createClient()
+  const profile = await getUserProfile()
+
+  // Get veranstaltung_id
+  const { data: schicht } = await supabase
+    .from('auffuehrung_schichten')
+    .select('veranstaltung_id')
+    .eq('id', schichtId)
+    .single()
+
+  if (!schicht) {
+    return { success: false, error: 'Schicht nicht gefunden' }
+  }
+
+  // First, check if person already exists in personen table
+  const { data: existingPerson } = await supabase
+    .from('personen')
+    .select('id')
+    .ilike('email', helferData.email)
+    .single()
+
+  if (existingPerson) {
+    // Person exists, just assign
+    return assignHelferManual(schichtId, existingPerson.id, 'intern', false)
+  }
+
+  // Create new person
+  const { data: newPerson, error: createError } = await supabase
+    .from('personen')
+    .insert({
+      vorname: helferData.vorname,
+      nachname: helferData.nachname,
+      email: helferData.email,
+      telefon: helferData.telefon || null,
+      rolle: 'gast',
+      aktiv: true,
+      skills: [],
+      telefon_nummern: helferData.telefon
+        ? [{ typ: 'mobil', nummer: helferData.telefon, ist_bevorzugt: true }]
+        : [],
+    } as never)
+    .select('id')
+    .single()
+
+  if (createError) {
+    console.error('Error creating person:', createError)
+    return { success: false, error: 'Fehler beim Anlegen der Person' }
+  }
+
+  // Now assign
+  const assignmentNotizen = `Manuell zugewiesen von ${profile?.display_name || profile?.email}\nNeu angelegt als externer Helfer`
+
+  const { error: assignError } = await supabase
+    .from('auffuehrung_zuweisungen')
+    .insert({
+      schicht_id: schichtId,
+      person_id: newPerson.id,
+      status: 'zugesagt',
+      notizen: assignmentNotizen,
+    } as never)
+
+  if (assignError) {
+    console.error('Error assigning new person:', assignError)
+    return { success: false, error: 'Fehler beim Zuweisen' }
+  }
+
+  revalidatePath(`/auffuehrungen/${schicht.veranstaltung_id}/helfer-koordination`)
+  revalidatePath(`/auffuehrungen/${schicht.veranstaltung_id}/helferliste`)
+
+  return { success: true, helperId: newPerson.id }
+}

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -16,6 +16,7 @@
         "papaparse": "^5.5.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "xlsx": "^0.18.5",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -2866,6 +2867,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -3455,6 +3465,19 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -3543,6 +3566,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3599,6 +3631,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -4730,6 +4774,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fraction.js": {
@@ -7437,6 +7490,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -8675,6 +8740,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -8799,6 +8882,27 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/yocto-queue": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,6 +28,7 @@
     "papaparse": "^5.5.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "xlsx": "^0.18.5",
     "zod": "^4.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Implementiert Milestone M5: Admin-Ansichten & Koordination für das Helper List & Shift Planning System.

### Issue #216: Koordinator-Dashboard für Aufführung
- Neue Route `/auffuehrungen/[id]/helfer-koordination`
- MetricsCards: Gesamt-Slots, besetzte/offene Slots, Warteliste
- ZeitblockAccordion mit Fortschrittsbalken und Farbcodierung
- SchichtDetailCard mit Helfer-Liste und Kontaktdaten
- Filter nach Zeitblock und Status (alle/kritisch/voll)

### Issue #217: Manuelle Helfer-Zuweisung
- HelferAssignmentModal mit Autocomplete-Suche
- Suche in internen Mitgliedern und externen Helfern
- Automatische Konfliktprüfung (Zeitüberschneidung, Buchungslimit)
- Admin-Override mit Bestätigung
- Inline-Formular für neue externe Helfer

### Issue #218: Helfer-Kontaktliste Export
- PDF-Export via Browser-Print (öffnet Druckansicht)
- Excel-Export via xlsx-Library (XLSX-Download)
- QuickActions-Komponente mit Export-Buttons
- "Alle Emails kopieren" Funktion

### Issue #219: Statistik-Übersicht pro Aufführung
- Zeitblock-Auslastung mit visuellen Fortschrittsbalken
- Kritische Schichten Alert (<50% Auslastung)
- Top-Helfer Ranking (meiste Schichten)
- Anmeldungstrend-Visualisierung

## Test plan

- [ ] Koordinator-Dashboard zeigt alle Schichten gruppiert nach Zeitblöcken
- [ ] Fortschrittsbalken zeigen korrekte Auslastung (grün/gelb/rot)
- [ ] Filter funktioniert (kritisch, voll, alle)
- [ ] Manuelle Zuweisung: Helfer-Suche findet interne und externe
- [ ] Konfliktwarnung erscheint bei Zeitüberschneidung
- [ ] Admin-Override erlaubt Zuweisung trotz Konflikt
- [ ] PDF-Export öffnet Druckvorschau
- [ ] Excel-Download enthält alle Helfer-Daten
- [ ] Statistik zeigt kritische Schichten korrekt an

🤖 Generated with [Claude Code](https://claude.com/claude-code)