### PR TITLE
feat: atomic slot booking for helfer registration (#248)

### DIFF
--- a/apps/web/components/helferliste/PublicEventView.tsx
+++ b/apps/web/components/helferliste/PublicEventView.tsx
@@ -39,6 +39,7 @@ function PublicRolleCard({ rolle }: { rolle: RollenInstanzMitAnmeldungen }) {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState(false)
+  const [isWaitlist, setIsWaitlist] = useState(false)
 
   const [formData, setFormData] = useState({
     name: '',
@@ -74,6 +75,7 @@ function PublicRolleCard({ rolle }: { rolle: RollenInstanzMitAnmeldungen }) {
     }
 
     setSuccess(true)
+    setIsWaitlist(result.isWaitlist ?? false)
     setIsSubmitting(false)
     router.refresh()
   }
@@ -97,10 +99,13 @@ function PublicRolleCard({ rolle }: { rolle: RollenInstanzMitAnmeldungen }) {
               />
             </svg>
           </div>
-          <h3 className="font-medium text-gray-900">Anmeldung erfolgreich!</h3>
+          <h3 className="font-medium text-gray-900">
+            {isWaitlist ? 'Auf Warteliste gesetzt!' : 'Anmeldung erfolgreich!'}
+          </h3>
           <p className="mt-1 text-sm text-gray-600">
-            Du hast dich für &quot;{rollenName}&quot; angemeldet.
-            {isFull && ' Du bist auf der Warteliste.'}
+            {isWaitlist
+              ? `Du stehst auf der Warteliste für "${rollenName}". Wir melden uns, sobald ein Platz frei wird.`
+              : `Du hast dich für "${rollenName}" angemeldet.`}
           </p>
         </div>
       </div>

--- a/apps/web/lib/supabase/types.ts
+++ b/apps/web/lib/supabase/types.ts
@@ -1670,6 +1670,38 @@ export type HelferAnmeldungMitDetails = HelferAnmeldung & {
 }
 
 // =============================================================================
+// Atomic Booking RPC Return Types (Issue #248)
+// =============================================================================
+
+export type BookHelferSlotResult = {
+  success: boolean
+  anmeldung_id?: string
+  status?: HelferAnmeldungStatus
+  is_waitlist?: boolean
+  error?: string
+}
+
+export type BookHelferSlotsResult = {
+  success: boolean
+  results?: BookHelferSlotResult[]
+  error?: string
+}
+
+export type HelferTimeConflict = {
+  instanz_a: string
+  rolle_a: string
+  event_a: string
+  instanz_b: string
+  rolle_b: string
+  event_b: string
+}
+
+export type CheckHelferTimeConflictsResult = {
+  has_conflicts: boolean
+  conflicts: HelferTimeConflict[]
+}
+
+// =============================================================================
 // Produktionen (Issue #156)
 // =============================================================================
 

--- a/apps/web/tests/mocks/supabase.ts
+++ b/apps/web/tests/mocks/supabase.ts
@@ -52,6 +52,7 @@ export function createMockClient(overrides?: {
       const result = overrides?.fromResults?.[table] || defaultResult
       return createMockQueryBuilder(result)
     }),
+    rpc: vi.fn().mockResolvedValue({ data: null, error: null }),
     auth: {
       getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: null }),
       getSession: vi.fn().mockResolvedValue({ data: { session: null }, error: null }),

--- a/supabase/migrations/20260211000000_atomic_helfer_booking.sql
+++ b/supabase/migrations/20260211000000_atomic_helfer_booking.sql
@@ -1,0 +1,351 @@
+-- =============================================================================
+-- Migration: Atomic Helfer Booking (Race-Condition Safe)
+-- Created: 2026-02-11
+-- Issue: #248
+-- Description: Atomic slot booking for helfer registration system
+--   - Partial unique indexes for duplicate prevention
+--   - book_helfer_slot(): Single slot booking with FOR UPDATE lock
+--   - book_helfer_slots(): Multi-slot transactional booking
+--   - check_helfer_time_conflicts(): Overlap detection for helpers
+-- =============================================================================
+
+-- =============================================================================
+-- PARTIAL UNIQUE INDEXES: Prevent duplicate registrations
+-- Only active registrations count (status != 'abgelehnt')
+-- =============================================================================
+
+CREATE UNIQUE INDEX IF NOT EXISTS helfer_anmeldungen_unique_external_helper
+  ON helfer_anmeldungen(rollen_instanz_id, external_helper_id)
+  WHERE external_helper_id IS NOT NULL AND status != 'abgelehnt';
+
+CREATE UNIQUE INDEX IF NOT EXISTS helfer_anmeldungen_unique_profile
+  ON helfer_anmeldungen(rollen_instanz_id, profile_id)
+  WHERE profile_id IS NOT NULL AND status != 'abgelehnt';
+
+-- =============================================================================
+-- FUNCTION: book_helfer_slot()
+-- Atomic single-slot booking with row-level lock
+-- Returns JSONB: {success, anmeldung_id, status, is_waitlist, error}
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION book_helfer_slot(
+  p_rollen_instanz_id UUID,
+  p_profile_id UUID DEFAULT NULL,
+  p_external_helper_id UUID DEFAULT NULL,
+  p_external_name TEXT DEFAULT NULL,
+  p_external_email TEXT DEFAULT NULL,
+  p_external_telefon TEXT DEFAULT NULL
+) RETURNS JSONB AS $$
+DECLARE
+  v_instanz RECORD;
+  v_active_count INTEGER;
+  v_status TEXT;
+  v_anmeldung_id UUID;
+  v_is_waitlist BOOLEAN;
+BEGIN
+  -- Validate: exactly one identity must be provided
+  IF (
+    (p_profile_id IS NOT NULL)::INTEGER +
+    (p_external_helper_id IS NOT NULL)::INTEGER +
+    (p_external_name IS NOT NULL)::INTEGER
+  ) != 1 THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Genau eine Identität muss angegeben werden'
+    );
+  END IF;
+
+  -- Lock the rollen_instanz row to prevent concurrent capacity changes
+  SELECT id, anzahl_benoetigt, sichtbarkeit
+  INTO v_instanz
+  FROM helfer_rollen_instanzen
+  WHERE id = p_rollen_instanz_id
+  FOR UPDATE;
+
+  IF v_instanz IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Rolleninstanz nicht gefunden'
+    );
+  END IF;
+
+  -- For external registrations, verify the role is public
+  IF p_profile_id IS NULL AND v_instanz.sichtbarkeit != 'public' THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Rolle nicht öffentlich zugänglich'
+    );
+  END IF;
+
+  -- Count active registrations atomically (while row is locked)
+  SELECT COUNT(*) INTO v_active_count
+  FROM helfer_anmeldungen
+  WHERE rollen_instanz_id = p_rollen_instanz_id
+  AND status != 'abgelehnt';
+
+  -- Determine status based on capacity
+  IF v_active_count >= v_instanz.anzahl_benoetigt THEN
+    v_status := 'warteliste';
+    v_is_waitlist := true;
+  ELSE
+    v_status := 'angemeldet';
+    v_is_waitlist := false;
+  END IF;
+
+  -- Insert the registration
+  INSERT INTO helfer_anmeldungen (
+    rollen_instanz_id,
+    profile_id,
+    external_helper_id,
+    external_name,
+    external_email,
+    external_telefon,
+    status
+  ) VALUES (
+    p_rollen_instanz_id,
+    p_profile_id,
+    p_external_helper_id,
+    p_external_name,
+    p_external_email,
+    p_external_telefon,
+    v_status
+  )
+  RETURNING id INTO v_anmeldung_id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'anmeldung_id', v_anmeldung_id,
+    'status', v_status,
+    'is_waitlist', v_is_waitlist
+  );
+
+EXCEPTION
+  WHEN unique_violation THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Bereits für diese Rolle angemeldet'
+    );
+  WHEN check_violation THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Ungültige Anmeldedaten'
+    );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION book_helfer_slot TO anon;
+GRANT EXECUTE ON FUNCTION book_helfer_slot TO authenticated;
+
+-- =============================================================================
+-- FUNCTION: book_helfer_slots()
+-- Atomic multi-slot booking (all-or-nothing transaction)
+-- Sorts IDs before locking to prevent deadlocks
+-- Returns JSONB: {success, results[], error}
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION book_helfer_slots(
+  p_rollen_instanz_ids UUID[],
+  p_profile_id UUID DEFAULT NULL,
+  p_external_helper_id UUID DEFAULT NULL,
+  p_external_name TEXT DEFAULT NULL,
+  p_external_email TEXT DEFAULT NULL,
+  p_external_telefon TEXT DEFAULT NULL
+) RETURNS JSONB AS $$
+DECLARE
+  v_instanz_id UUID;
+  v_result JSONB;
+  v_results JSONB := '[]'::JSONB;
+  v_has_failure BOOLEAN := false;
+  v_sorted_ids UUID[];
+BEGIN
+  -- Validate input
+  IF array_length(p_rollen_instanz_ids, 1) IS NULL OR
+     array_length(p_rollen_instanz_ids, 1) = 0 THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Keine Rolleninstanzen angegeben'
+    );
+  END IF;
+
+  -- Sort IDs to prevent deadlocks (consistent lock ordering)
+  SELECT array_agg(id ORDER BY id) INTO v_sorted_ids
+  FROM unnest(p_rollen_instanz_ids) AS id;
+
+  -- Book each slot sequentially (within the same transaction)
+  FOREACH v_instanz_id IN ARRAY v_sorted_ids
+  LOOP
+    v_result := book_helfer_slot(
+      p_rollen_instanz_id := v_instanz_id,
+      p_profile_id := p_profile_id,
+      p_external_helper_id := p_external_helper_id,
+      p_external_name := p_external_name,
+      p_external_email := p_external_email,
+      p_external_telefon := p_external_telefon
+    );
+
+    v_results := v_results || jsonb_build_array(v_result);
+
+    -- If a booking fails (not waitlist, but actual error), mark failure
+    IF NOT (v_result->>'success')::BOOLEAN THEN
+      v_has_failure := true;
+    END IF;
+  END LOOP;
+
+  -- If any booking failed, rollback the entire transaction
+  IF v_has_failure THEN
+    RAISE EXCEPTION 'multi_slot_booking_failed';
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'results', v_results
+  );
+
+EXCEPTION
+  WHEN OTHERS THEN
+    IF SQLERRM = 'multi_slot_booking_failed' THEN
+      RETURN jsonb_build_object(
+        'success', false,
+        'error', 'Einige Anmeldungen sind fehlgeschlagen',
+        'results', v_results
+      );
+    END IF;
+    RAISE;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION book_helfer_slots TO anon;
+GRANT EXECUTE ON FUNCTION book_helfer_slots TO authenticated;
+
+-- =============================================================================
+-- FUNCTION: check_helfer_time_conflicts()
+-- Detect overlapping zeitblocks for selected shifts and existing registrations
+-- Returns JSONB: {has_conflicts, conflicts[]}
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION check_helfer_time_conflicts(
+  p_rollen_instanz_ids UUID[],
+  p_external_helper_id UUID DEFAULT NULL,
+  p_profile_id UUID DEFAULT NULL
+) RETURNS JSONB AS $$
+DECLARE
+  v_conflicts JSONB := '[]'::JSONB;
+  v_selected RECORD;
+  v_other RECORD;
+BEGIN
+  -- Check conflicts among the selected slots themselves
+  FOR v_selected IN
+    SELECT ri.id AS instanz_id,
+           COALESCE(ri.zeitblock_start, he.datum_start) AS start_time,
+           COALESCE(ri.zeitblock_end, he.datum_end) AS end_time,
+           COALESCE(t.name, ri.custom_name, 'Unbekannt') AS rolle_name,
+           he.name AS event_name
+    FROM unnest(p_rollen_instanz_ids) AS sel_id
+    JOIN helfer_rollen_instanzen ri ON ri.id = sel_id
+    JOIN helfer_events he ON he.id = ri.helfer_event_id
+    LEFT JOIN helfer_rollen_templates t ON t.id = ri.template_id
+    WHERE COALESCE(ri.zeitblock_start, he.datum_start) IS NOT NULL
+      AND COALESCE(ri.zeitblock_end, he.datum_end) IS NOT NULL
+  LOOP
+    -- Check against OTHER selected slots (one direction only to avoid duplicates)
+    FOR v_other IN
+      SELECT ri2.id AS instanz_id,
+             COALESCE(ri2.zeitblock_start, he2.datum_start) AS start_time,
+             COALESCE(ri2.zeitblock_end, he2.datum_end) AS end_time,
+             COALESCE(t2.name, ri2.custom_name, 'Unbekannt') AS rolle_name,
+             he2.name AS event_name
+      FROM unnest(p_rollen_instanz_ids) AS sel_id2
+      JOIN helfer_rollen_instanzen ri2 ON ri2.id = sel_id2
+      JOIN helfer_events he2 ON he2.id = ri2.helfer_event_id
+      LEFT JOIN helfer_rollen_templates t2 ON t2.id = ri2.template_id
+      WHERE ri2.id > v_selected.instanz_id
+        AND COALESCE(ri2.zeitblock_start, he2.datum_start) IS NOT NULL
+        AND COALESCE(ri2.zeitblock_end, he2.datum_end) IS NOT NULL
+    LOOP
+      IF v_selected.start_time < v_other.end_time AND
+         v_selected.end_time > v_other.start_time THEN
+        v_conflicts := v_conflicts || jsonb_build_array(jsonb_build_object(
+          'instanz_a', v_selected.instanz_id,
+          'rolle_a', v_selected.rolle_name,
+          'event_a', v_selected.event_name,
+          'instanz_b', v_other.instanz_id,
+          'rolle_b', v_other.rolle_name,
+          'event_b', v_other.event_name
+        ));
+      END IF;
+    END LOOP;
+
+    -- Check against EXISTING registrations for external helper
+    IF p_external_helper_id IS NOT NULL THEN
+      FOR v_other IN
+        SELECT ri2.id AS instanz_id,
+               COALESCE(ri2.zeitblock_start, he2.datum_start) AS start_time,
+               COALESCE(ri2.zeitblock_end, he2.datum_end) AS end_time,
+               COALESCE(t2.name, ri2.custom_name, 'Unbekannt') AS rolle_name,
+               he2.name AS event_name
+        FROM helfer_anmeldungen ha
+        JOIN helfer_rollen_instanzen ri2 ON ri2.id = ha.rollen_instanz_id
+        JOIN helfer_events he2 ON he2.id = ri2.helfer_event_id
+        LEFT JOIN helfer_rollen_templates t2 ON t2.id = ri2.template_id
+        WHERE ha.external_helper_id = p_external_helper_id
+          AND ha.status != 'abgelehnt'
+          AND ri2.id != ALL(p_rollen_instanz_ids)
+          AND COALESCE(ri2.zeitblock_start, he2.datum_start) IS NOT NULL
+          AND COALESCE(ri2.zeitblock_end, he2.datum_end) IS NOT NULL
+      LOOP
+        IF v_selected.start_time < v_other.end_time AND
+           v_selected.end_time > v_other.start_time THEN
+          v_conflicts := v_conflicts || jsonb_build_array(jsonb_build_object(
+            'instanz_a', v_selected.instanz_id,
+            'rolle_a', v_selected.rolle_name,
+            'event_a', v_selected.event_name,
+            'instanz_b', v_other.instanz_id,
+            'rolle_b', v_other.rolle_name,
+            'event_b', v_other.event_name
+          ));
+        END IF;
+      END LOOP;
+    END IF;
+
+    -- Check against EXISTING registrations for internal profile
+    IF p_profile_id IS NOT NULL THEN
+      FOR v_other IN
+        SELECT ri2.id AS instanz_id,
+               COALESCE(ri2.zeitblock_start, he2.datum_start) AS start_time,
+               COALESCE(ri2.zeitblock_end, he2.datum_end) AS end_time,
+               COALESCE(t2.name, ri2.custom_name, 'Unbekannt') AS rolle_name,
+               he2.name AS event_name
+        FROM helfer_anmeldungen ha
+        JOIN helfer_rollen_instanzen ri2 ON ri2.id = ha.rollen_instanz_id
+        JOIN helfer_events he2 ON he2.id = ri2.helfer_event_id
+        LEFT JOIN helfer_rollen_templates t2 ON t2.id = ri2.template_id
+        WHERE ha.profile_id = p_profile_id
+          AND ha.status != 'abgelehnt'
+          AND ri2.id != ALL(p_rollen_instanz_ids)
+          AND COALESCE(ri2.zeitblock_start, he2.datum_start) IS NOT NULL
+          AND COALESCE(ri2.zeitblock_end, he2.datum_end) IS NOT NULL
+      LOOP
+        IF v_selected.start_time < v_other.end_time AND
+           v_selected.end_time > v_other.start_time THEN
+          v_conflicts := v_conflicts || jsonb_build_array(jsonb_build_object(
+            'instanz_a', v_selected.instanz_id,
+            'rolle_a', v_selected.rolle_name,
+            'event_a', v_selected.event_name,
+            'instanz_b', v_other.instanz_id,
+            'rolle_b', v_other.rolle_name,
+            'event_b', v_other.event_name
+          ));
+        END IF;
+      END LOOP;
+    END IF;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'has_conflicts', jsonb_array_length(v_conflicts) > 0,
+    'conflicts', v_conflicts
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION check_helfer_time_conflicts TO anon;
+GRANT EXECUTE ON FUNCTION check_helfer_time_conflicts TO authenticated;


### PR DESCRIPTION
## Summary

- **Race-condition-safe booking**: Replaces client-side capacity check + separate INSERT with atomic PostgreSQL functions using `SELECT ... FOR UPDATE` row-level locking
- **New DB functions**: `book_helfer_slot()` (single booking), `book_helfer_slots()` (multi-booking, all-or-nothing), `check_helfer_time_conflicts()` (overlap detection)
- **Partial unique indexes** on `helfer_anmeldungen` to prevent duplicate registrations at the database level
- **Simplified server actions**: `anmelden()` and `anmeldenPublic()` now use RPC calls instead of manual queries; removed obsolete `checkDoubleBooking()` function
- **Waitlist handling**: Actual waitlist status from server response instead of stale client-side `isFull` prop

Closes #248

## Changed Files

| File | Change |
|---|---|
| `supabase/migrations/20260211000000_atomic_helfer_booking.sql` | New migration with atomic booking functions + indexes |
| `apps/web/lib/supabase/types.ts` | Added RPC return types (`BookHelferSlotResult`, `CheckHelferTimeConflictsResult`, etc.) |
| `apps/web/lib/actions/helferliste.ts` | Replaced `anmelden`/`anmeldenPublic` with RPC calls, removed `checkDoubleBooking` |
| `apps/web/components/helferliste/PublicEventView.tsx` | Use actual `isWaitlist` from server response |
| `apps/web/lib/actions/helferliste.test.ts` | Updated tests to mock RPC calls |
| `apps/web/tests/mocks/supabase.ts` | Added `rpc` mock to Supabase client |

## Test plan

- [x] All 86 unit tests pass (`npm run test:run`)
- [x] TypeScript typecheck passes (`npm run typecheck`)
- [x] Migration applied successfully to Supabase (Block 1: externe_helfer_profile, Block 2: atomic booking)
- [ ] Manual E2E: Public registration form → verify atomic booking works under concurrent load

🤖 Generated with [Claude Code](https://claude.com/claude-code)