### PR TITLE
feat: confirmation screen with ICS download and cancellation link (US-7)

### DIFF
--- a/apps/web/app/(public)/helfer/helferliste/abmeldung/[token]/CancellationForm.tsx
+++ b/apps/web/app/(public)/helfer/helferliste/abmeldung/[token]/CancellationForm.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button, Alert } from '@/components/ui'
+import { cancelHelferlisteRegistration } from './actions'
+
+interface Props {
+  token: string
+}
+
+export function CancellationForm({ token }: Props) {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+
+  const handleCancel = () => {
+    setError(null)
+
+    startTransition(async () => {
+      const result = await cancelHelferlisteRegistration(token)
+
+      if (result.success) {
+        setSuccess(true)
+      } else {
+        setError(result.error || 'Fehler beim Stornieren')
+      }
+    })
+  }
+
+  if (success) {
+    return (
+      <div className="space-y-4">
+        <Alert variant="success">
+          Deine Anmeldung wurde erfolgreich storniert.
+        </Alert>
+        <p className="text-center text-sm text-neutral-600">
+          Vielen Dank, dass du uns Bescheid gegeben hast. So können wir den Platz an jemand anderen vergeben.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {error && <Alert variant="error">{error}</Alert>}
+
+      <div className="rounded-lg border border-warning-200 bg-warning-50 p-4">
+        <p className="text-sm text-warning-800">
+          <strong>Hinweis:</strong> Durch die Stornierung wird dein Platz für andere Helfer freigegeben.
+          Falls sich jemand auf der Warteliste befindet, wird diese Person automatisch nachrücken.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-3 sm:flex-row-reverse">
+        <Button
+          onClick={handleCancel}
+          disabled={isPending}
+          className="bg-error-600 hover:bg-error-700"
+        >
+          {isPending ? 'Wird storniert...' : 'Ja, Anmeldung stornieren'}
+        </Button>
+        <Button
+          variant="secondary"
+          onClick={() => router.back()}
+          disabled={isPending}
+        >
+          Abbrechen
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/(public)/helfer/helferliste/abmeldung/[token]/actions.ts
+++ b/apps/web/app/(public)/helfer/helferliste/abmeldung/[token]/actions.ts
@@ -1,0 +1,72 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { createClient } from '@/lib/supabase/server'
+
+/**
+ * Cancel a helferliste registration using the abmeldung_token.
+ * This is a public action - no authentication required.
+ * Deletes the helfer_anmeldungen row (freeing the slot).
+ */
+export async function cancelHelferlisteRegistration(
+  token: string
+): Promise<{ success: boolean; error?: string }> {
+  const supabase = await createClient()
+
+  // Find the anmeldung by abmeldung_token
+  const { data: anmeldung, error: fetchError } = await supabase
+    .from('helfer_anmeldungen')
+    .select(`
+      id,
+      status,
+      rollen_instanz_id,
+      rollen_instanz:helfer_rollen_instanzen(
+        helfer_event_id,
+        helfer_event:helfer_events(datum_start)
+      )
+    `)
+    .eq('abmeldung_token', token)
+    .single()
+
+  if (fetchError || !anmeldung) {
+    return { success: false, error: 'Anmeldung nicht gefunden oder Link ungültig' }
+  }
+
+  // Check 6-hour rule
+  const rollenInstanz = anmeldung.rollen_instanz as unknown as {
+    helfer_event_id: string
+    helfer_event: { datum_start: string } | null
+  } | null
+
+  if (rollenInstanz?.helfer_event?.datum_start) {
+    const eventStart = new Date(rollenInstanz.helfer_event.datum_start)
+    const now = new Date()
+    const hoursUntilEvent = (eventStart.getTime() - now.getTime()) / (1000 * 60 * 60)
+
+    if (hoursUntilEvent < 6) {
+      return {
+        success: false,
+        error: 'Die Veranstaltung beginnt in weniger als 6 Stunden. Eine Online-Abmeldung ist nicht mehr möglich.',
+      }
+    }
+  }
+
+  // Delete the registration (frees the slot)
+  const { error: deleteError } = await supabase
+    .from('helfer_anmeldungen')
+    .delete()
+    .eq('id', anmeldung.id)
+
+  if (deleteError) {
+    console.error('Error cancelling helferliste registration:', deleteError)
+    return { success: false, error: 'Fehler beim Stornieren der Anmeldung' }
+  }
+
+  // Revalidate paths
+  revalidatePath('/helferliste')
+  if (rollenInstanz?.helfer_event_id) {
+    revalidatePath(`/helferliste/${rollenInstanz.helfer_event_id}`)
+  }
+
+  return { success: true }
+}

--- a/apps/web/app/(public)/helfer/helferliste/abmeldung/[token]/page.tsx
+++ b/apps/web/app/(public)/helfer/helferliste/abmeldung/[token]/page.tsx
@@ -1,0 +1,161 @@
+import { notFound } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui'
+import { CancellationForm } from './CancellationForm'
+
+export const metadata = {
+  title: 'Helfer-Anmeldung stornieren',
+  description: 'Storniere deine Helfer-Anmeldung',
+}
+
+async function getAnmeldungByToken(token: string) {
+  const supabase = await createClient()
+
+  const { data, error } = await supabase
+    .from('helfer_anmeldungen')
+    .select(`
+      id,
+      status,
+      external_name,
+      rollen_instanz:helfer_rollen_instanzen(
+        id,
+        zeitblock_start,
+        zeitblock_end,
+        template:helfer_rollen_templates(name),
+        helfer_event:helfer_events(id, name, datum_start, datum_end, ort)
+      ),
+      profile:profiles(display_name)
+    `)
+    .eq('abmeldung_token', token)
+    .single()
+
+  if (error || !data) {
+    return null
+  }
+
+  return data
+}
+
+export default async function HelferlisteCancellationPage({
+  params,
+}: {
+  params: Promise<{ token: string }>
+}) {
+  const { token } = await params
+  const anmeldung = await getAnmeldungByToken(token)
+
+  if (!anmeldung) {
+    notFound()
+  }
+
+  const rollenInstanz = anmeldung.rollen_instanz as unknown as {
+    id: string
+    zeitblock_start: string | null
+    zeitblock_end: string | null
+    template: { name: string } | null
+    helfer_event: {
+      id: string
+      name: string
+      datum_start: string
+      datum_end: string
+      ort: string | null
+    } | null
+  } | null
+
+  const profile = anmeldung.profile as unknown as { display_name: string } | null
+  const helferEvent = rollenInstanz?.helfer_event
+  const rollenName = rollenInstanz?.template?.name || 'Unbekannte Rolle'
+  const helferName = profile?.display_name || anmeldung.external_name
+
+  // Check 6-hour rule
+  if (helferEvent) {
+    const eventStart = new Date(helferEvent.datum_start)
+    const now = new Date()
+    const hoursUntilEvent = (eventStart.getTime() - now.getTime()) / (1000 * 60 * 60)
+
+    if (hoursUntilEvent < 6) {
+      return (
+        <div className="mx-auto max-w-lg px-4 py-12">
+          <Card>
+            <CardHeader>
+              <CardTitle>Abmeldung nicht mehr möglich</CardTitle>
+              <CardDescription>
+                Die Veranstaltung beginnt in weniger als 6 Stunden. Eine Online-Abmeldung ist nicht mehr möglich.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <p className="text-neutral-600">
+                Bitte kontaktiere das Organisationsteam direkt, wenn du nicht teilnehmen kannst.
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      )
+    }
+  }
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleDateString('de-CH', {
+      weekday: 'long',
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    })
+  }
+
+  const formatTime = (dateStr: string) => {
+    return new Date(dateStr).toLocaleTimeString('de-CH', {
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  }
+
+  return (
+    <div className="mx-auto max-w-lg px-4 py-12">
+      <Card>
+        <CardHeader>
+          <CardTitle>Anmeldung stornieren?</CardTitle>
+          <CardDescription>
+            Du möchtest deine Helfer-Anmeldung für den folgenden Einsatz stornieren:
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="rounded-lg bg-neutral-50 p-4">
+            {helferName && (
+              <p className="mb-2 text-sm text-neutral-600">
+                Helfer: <span className="font-medium">{helferName}</span>
+              </p>
+            )}
+            {helferEvent && (
+              <>
+                <p className="font-semibold text-neutral-900">{helferEvent.name}</p>
+                <p className="text-sm text-neutral-600">{formatDate(helferEvent.datum_start)}</p>
+                {helferEvent.ort && (
+                  <p className="text-sm text-neutral-600">{helferEvent.ort}</p>
+                )}
+              </>
+            )}
+            <div className="mt-3 border-t border-neutral-200 pt-3">
+              <p className="text-sm">
+                <span className="text-neutral-600">Rolle: </span>
+                <span className="font-medium">{rollenName}</span>
+              </p>
+              {rollenInstanz?.zeitblock_start && (
+                <p className="text-sm">
+                  <span className="text-neutral-600">Zeit: </span>
+                  <span className="font-medium">
+                    {formatTime(rollenInstanz.zeitblock_start)}
+                    {rollenInstanz.zeitblock_end && ` - ${formatTime(rollenInstanz.zeitblock_end)}`}
+                    {' Uhr'}
+                  </span>
+                </p>
+              )}
+            </div>
+          </div>
+
+          <CancellationForm token={token} />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/apps/web/lib/actions/helferliste.test.ts
+++ b/apps/web/lib/actions/helferliste.test.ts
@@ -260,6 +260,7 @@ describe('Helferliste Actions', () => {
             anmeldung_id: 'new-anmeldung-1',
             status: 'angemeldet',
             is_waitlist: false,
+            abmeldung_token: 'abmeldung-token-new',
           },
           error: null,
         })
@@ -269,6 +270,7 @@ describe('Helferliste Actions', () => {
       expect(result.success).toBe(true)
       expect(result.id).toBe('new-anmeldung-1')
       expect(result.isWaitlist).toBe(false)
+      expect(result.abmeldungToken).toBe('abmeldung-token-new')
       expect(mockSupabase.rpc).toHaveBeenCalledWith('check_helfer_time_conflicts', {
         p_rollen_instanz_ids: ['instanz-1'],
         p_profile_id: 'user-1',
@@ -431,6 +433,7 @@ describe('Helferliste Actions', () => {
             anmeldung_id: 'new-anmeldung',
             status: 'angemeldet',
             is_waitlist: false,
+            abmeldung_token: 'abmeldung-token-ext',
           },
           error: null,
         })
@@ -443,6 +446,7 @@ describe('Helferliste Actions', () => {
       expect(result.success).toBe(true)
       expect(result.id).toBe('new-anmeldung')
       expect(result.isWaitlist).toBe(false)
+      expect(result.abmeldungToken).toBe('abmeldung-token-ext')
       expect(mockSupabase.rpc).toHaveBeenCalledWith(
         'find_or_create_external_helper',
         expect.objectContaining({ p_email: 'helper@example.com' })
@@ -463,6 +467,7 @@ describe('Helferliste Actions', () => {
             anmeldung_id: 'waitlist-anmeldung',
             status: 'warteliste',
             is_waitlist: true,
+            abmeldung_token: 'abmeldung-token-wl',
           },
           error: null,
         })
@@ -474,6 +479,7 @@ describe('Helferliste Actions', () => {
 
       expect(result.success).toBe(true)
       expect(result.isWaitlist).toBe(true)
+      expect(result.abmeldungToken).toBe('abmeldung-token-wl')
     })
 
     it('rejects registration for non-public roles via atomic booking', async () => {

--- a/apps/web/lib/actions/helferliste.ts
+++ b/apps/web/lib/actions/helferliste.ts
@@ -468,7 +468,7 @@ export async function getOwnAnmeldungen(): Promise<
  */
 export async function anmelden(
   rollenInstanzId: string
-): Promise<{ success: boolean; error?: string; id?: string; isWaitlist?: boolean }> {
+): Promise<{ success: boolean; error?: string; id?: string; isWaitlist?: boolean; abmeldungToken?: string }> {
   const profile = await getUserProfile()
   if (!profile) {
     return { success: false, error: 'Nicht eingeloggt' }
@@ -517,7 +517,7 @@ export async function anmelden(
 
   revalidatePath('/helferliste')
   revalidatePath('/mein-bereich')
-  return { success: true, id: booking.anmeldung_id, isWaitlist: booking.is_waitlist }
+  return { success: true, id: booking.anmeldung_id, isWaitlist: booking.is_waitlist, abmeldungToken: booking.abmeldung_token }
 }
 
 /**
@@ -670,7 +670,7 @@ export async function anmeldenPublic(
     email?: string
     telefon?: string
   }
-): Promise<{ success: boolean; error?: string; id?: string; isWaitlist?: boolean }> {
+): Promise<{ success: boolean; error?: string; id?: string; isWaitlist?: boolean; abmeldungToken?: string }> {
   const supabase = await createClient()
 
   // If email provided, find or create the external helper profile
@@ -737,5 +737,6 @@ export async function anmeldenPublic(
     success: true,
     id: booking.anmeldung_id,
     isWaitlist: booking.is_waitlist,
+    abmeldungToken: booking.abmeldung_token,
   }
 }

--- a/apps/web/lib/supabase/types.ts
+++ b/apps/web/lib/supabase/types.ts
@@ -1629,6 +1629,7 @@ export type HelferAnmeldung = {
   external_name: string | null       // Legacy: inline name for external helpers
   external_email: string | null      // Legacy: inline email
   external_telefon: string | null    // Legacy: inline phone
+  abmeldung_token: string | null     // Public cancellation token (US-7)
   status: HelferAnmeldungStatus
   created_at: string
 }
@@ -1678,6 +1679,7 @@ export type BookHelferSlotResult = {
   anmeldung_id?: string
   status?: HelferAnmeldungStatus
   is_waitlist?: boolean
+  abmeldung_token?: string
   error?: string
 }
 

--- a/apps/web/tests/mocks/supabase.ts
+++ b/apps/web/tests/mocks/supabase.ts
@@ -102,6 +102,7 @@ export const mockAnmeldung = {
   external_name: null,
   external_email: null,
   external_telefon: null,
+  abmeldung_token: 'abmeldung-token-1',
   status: 'angemeldet' as const,
   created_at: '2026-01-01T00:00:00Z',
 }

--- a/supabase/migrations/20260211100000_helfer_anmeldung_abmeldung_token.sql
+++ b/supabase/migrations/20260211100000_helfer_anmeldung_abmeldung_token.sql
@@ -1,0 +1,162 @@
+-- =============================================================================
+-- Migration: Abmeldung Token for helfer_anmeldungen
+-- Created: 2026-02-11
+-- Issue: US-7
+-- Description: Add abmeldung_token for public cancellation links
+--   - Add UUID column with unique constraint
+--   - Backfill existing rows
+--   - RLS policy for anon SELECT by token
+--   - Update book_helfer_slot() to return abmeldung_token
+-- =============================================================================
+
+-- =============================================================================
+-- ADD COLUMN: abmeldung_token
+-- =============================================================================
+
+ALTER TABLE helfer_anmeldungen
+  ADD COLUMN IF NOT EXISTS abmeldung_token UUID DEFAULT gen_random_uuid() UNIQUE;
+
+-- Backfill existing rows that might have NULL
+UPDATE helfer_anmeldungen
+SET abmeldung_token = gen_random_uuid()
+WHERE abmeldung_token IS NULL;
+
+-- =============================================================================
+-- RLS POLICY: Allow anonymous SELECT by abmeldung_token
+-- =============================================================================
+
+DROP POLICY IF EXISTS "helfer_anmeldungen_select_by_abmeldung_token" ON helfer_anmeldungen;
+CREATE POLICY "helfer_anmeldungen_select_by_abmeldung_token"
+  ON helfer_anmeldungen FOR SELECT
+  TO anon
+  USING (
+    abmeldung_token IS NOT NULL
+    AND abmeldung_token = current_setting('request.headers', true)::json->>'x-abmeldung-token'
+  );
+
+-- =============================================================================
+-- RLS POLICY: Allow anonymous DELETE by abmeldung_token (for cancellation)
+-- =============================================================================
+
+DROP POLICY IF EXISTS "helfer_anmeldungen_delete_by_abmeldung_token" ON helfer_anmeldungen;
+CREATE POLICY "helfer_anmeldungen_delete_by_abmeldung_token"
+  ON helfer_anmeldungen FOR DELETE
+  TO anon
+  USING (
+    abmeldung_token IS NOT NULL
+    AND abmeldung_token = current_setting('request.headers', true)::json->>'x-abmeldung-token'
+  );
+
+-- =============================================================================
+-- UPDATE FUNCTION: book_helfer_slot() - include abmeldung_token in result
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION book_helfer_slot(
+  p_rollen_instanz_id UUID,
+  p_profile_id UUID DEFAULT NULL,
+  p_external_helper_id UUID DEFAULT NULL,
+  p_external_name TEXT DEFAULT NULL,
+  p_external_email TEXT DEFAULT NULL,
+  p_external_telefon TEXT DEFAULT NULL
+) RETURNS JSONB AS $$
+DECLARE
+  v_instanz RECORD;
+  v_active_count INTEGER;
+  v_status TEXT;
+  v_anmeldung_id UUID;
+  v_abmeldung_token UUID;
+  v_is_waitlist BOOLEAN;
+BEGIN
+  -- Validate: exactly one identity must be provided
+  IF (
+    (p_profile_id IS NOT NULL)::INTEGER +
+    (p_external_helper_id IS NOT NULL)::INTEGER +
+    (p_external_name IS NOT NULL)::INTEGER
+  ) != 1 THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Genau eine Identität muss angegeben werden'
+    );
+  END IF;
+
+  -- Lock the rollen_instanz row to prevent concurrent capacity changes
+  SELECT id, anzahl_benoetigt, sichtbarkeit
+  INTO v_instanz
+  FROM helfer_rollen_instanzen
+  WHERE id = p_rollen_instanz_id
+  FOR UPDATE;
+
+  IF v_instanz IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Rolleninstanz nicht gefunden'
+    );
+  END IF;
+
+  -- For external registrations, verify the role is public
+  IF p_profile_id IS NULL AND v_instanz.sichtbarkeit != 'public' THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Rolle nicht öffentlich zugänglich'
+    );
+  END IF;
+
+  -- Count active registrations atomically (while row is locked)
+  SELECT COUNT(*) INTO v_active_count
+  FROM helfer_anmeldungen
+  WHERE rollen_instanz_id = p_rollen_instanz_id
+  AND status != 'abgelehnt';
+
+  -- Determine status based on capacity
+  IF v_active_count >= v_instanz.anzahl_benoetigt THEN
+    v_status := 'warteliste';
+    v_is_waitlist := true;
+  ELSE
+    v_status := 'angemeldet';
+    v_is_waitlist := false;
+  END IF;
+
+  -- Insert the registration
+  INSERT INTO helfer_anmeldungen (
+    rollen_instanz_id,
+    profile_id,
+    external_helper_id,
+    external_name,
+    external_email,
+    external_telefon,
+    status
+  ) VALUES (
+    p_rollen_instanz_id,
+    p_profile_id,
+    p_external_helper_id,
+    p_external_name,
+    p_external_email,
+    p_external_telefon,
+    v_status
+  )
+  RETURNING id, abmeldung_token INTO v_anmeldung_id, v_abmeldung_token;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'anmeldung_id', v_anmeldung_id,
+    'status', v_status,
+    'is_waitlist', v_is_waitlist,
+    'abmeldung_token', v_abmeldung_token
+  );
+
+EXCEPTION
+  WHEN unique_violation THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Bereits für diese Rolle angemeldet'
+    );
+  WHEN check_violation THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Ungültige Anmeldedaten'
+    );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION book_helfer_slot TO anon;
+GRANT EXECUTE ON FUNCTION book_helfer_slot TO authenticated;


### PR DESCRIPTION
## Summary
- Replace simple success message after helfer registration with a full confirmation screen showing status badge, event details, ICS calendar download button, and public cancellation link
- Add `abmeldung_token` UUID column to `helfer_anmeldungen` with migration, RLS policies, and updated `book_helfer_slot()` function
- Create public cancellation page at `/helfer/helferliste/abmeldung/[token]` with 6-hour cancellation rule

## Test plan
- [ ] Verify `npm run typecheck` passes with no errors
- [ ] Verify `npm run test:run` — all 86 tests pass (including updated abmeldungToken assertions)
- [ ] Register as external helper on a public event → confirmation screen shows event details, status badge, ICS download, and cancellation link
- [ ] Click ICS download → valid `.ics` file is generated with correct event data
- [ ] Click cancellation link → cancellation page shows event/role details with confirm/cancel buttons
- [ ] Confirm cancellation → registration is deleted, success message shown
- [ ] Test 6-hour rule: cancellation blocked when event starts within 6 hours
- [ ] Waitlist registration shows yellow "Warteliste" badge instead of green "Bestätigt"
- [ ] Migration applies cleanly: `abmeldung_token` column added, existing rows backfilled

🤖 Generated with [Claude Code](https://claude.com/claude-code)