### PR TITLE
feat: zeitblock grouping, filters & info blocks for public event page (US-1)

### DIFF
--- a/apps/web/lib/supabase/types.ts
+++ b/apps/web/lib/supabase/types.ts
@@ -1659,6 +1659,10 @@ export type HelferEventMitRollen = HelferEvent & {
   rollen: RollenInstanzMitAnmeldungen[]
 }
 
+export type PublicHelferEventData = HelferEventMitRollen & {
+  infoBloecke: InfoBlock[]
+}
+
 export type HelferAnmeldungMitDetails = HelferAnmeldung & {
   rollen_instanz: HelferRollenInstanz & {
     template: Pick<HelferRollenTemplate, 'id' | 'name'> | null

--- a/supabase/migrations/20260211200000_info_bloecke_helferliste_rls.sql
+++ b/supabase/migrations/20260211200000_info_bloecke_helferliste_rls.sql
@@ -1,0 +1,23 @@
+-- =============================================================================
+-- Migration: RLS Policy for info_bloecke via helfer_events
+-- Created: 2026-02-11
+-- Issue: US-1 (#243)
+-- Description: Allow anon users to read info_bloecke when the linked
+--   veranstaltung has an active helfer_event with a public_token.
+--   The existing info_bloecke_select_public policy only covers the legacy
+--   system (checks veranstaltungen.public_helfer_token). This adds coverage
+--   for the new helferliste system.
+-- =============================================================================
+
+DROP POLICY IF EXISTS "info_bloecke_select_via_helfer_events" ON info_bloecke;
+CREATE POLICY "info_bloecke_select_via_helfer_events"
+  ON info_bloecke FOR SELECT
+  TO anon
+  USING (
+    EXISTS (
+      SELECT 1 FROM helfer_events he
+      WHERE he.veranstaltung_id = info_bloecke.veranstaltung_id
+      AND he.public_token IS NOT NULL
+      AND he.status = 'aktiv'
+    )
+  );


### PR DESCRIPTION
## Summary
- **Zeitblock grouping**: Roles on the public event page (`/helfer/[token]`) are now grouped by their zeitblock (time window), with an "Allgemein" fallback group for roles without timestamps
- **Filter bar**: Added search-by-role-name input and zeitblock chip filter for quick navigation
- **Info blocks**: Display event info blocks (e.g. Briefing, Helferessen) fetched from `info_bloecke` table with a new RLS policy for anon access via `helfer_events`
- **Improved capacity display**: Changed from `X Plätze frei` to `X von Y Plätze frei` for better clarity

## Changes
| File | Change |
|---|---|
| `supabase/migrations/20260211200000_info_bloecke_helferliste_rls.sql` | New RLS policy for anon access to `info_bloecke` via `helfer_events` |
| `apps/web/lib/supabase/types.ts` | Added `PublicHelferEventData` type |
| `apps/web/lib/actions/helferliste.ts` | Extended `getPublicEventByToken` to fetch info_bloecke |
| `apps/web/components/helferliste/PublicEventView.tsx` | Zeitblock grouping, filter bar, info blocks section, capacity display |
| `apps/web/lib/actions/helferliste.test.ts` | New test for infoBloecke, updated existing test assertions |

## Test plan
- [x] `npm run typecheck` — no errors
- [x] `npm run lint` — no new warnings
- [x] `npm run test:run` — all 87 tests pass

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)