### PR TITLE
fix: remove typ filter from getHelferlisteData causing 404

### DIFF
--- a/apps/web/lib/actions/helfer-anmeldung.ts
+++ b/apps/web/lib/actions/helfer-anmeldung.ts
@@ -61,7 +61,6 @@ export async function getHelferlisteData(
     .from('veranstaltungen')
     .select('id, titel, datum, startzeit, endzeit, ort, helfer_status, public_helfer_token')
     .eq('id', veranstaltungId)
-    .eq('typ', 'auffuehrung')
     .single()
 
   if (veranstaltungError || !veranstaltung) {


### PR DESCRIPTION
## Summary
- Removed `.eq('typ', 'auffuehrung')` filter from `getHelferlisteData()` in `helfer-anmeldung.ts`
- This filter caused a 404 on `/auffuehrungen/[id]/helferliste` when the veranstaltung had a different `typ` value
- The helferliste should be accessible for any veranstaltung type

## Test plan
- [ ] Navigate to `/auffuehrungen/[id]/helferliste` — page loads without 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)