### PR TITLE
feat: multi-shift selection wizard with conflict detection (US-2)

### DIFF
--- a/apps/web/components/helferliste/MultiSelectContext.tsx
+++ b/apps/web/components/helferliste/MultiSelectContext.tsx
@@ -1,0 +1,233 @@
+'use client'
+
+import {
+  createContext,
+  useContext,
+  useReducer,
+  useCallback,
+  type ReactNode,
+} from 'react'
+import type {
+  RollenInstanzMitAnmeldungen,
+  BookHelferSlotResult,
+  HelferTimeConflict,
+} from '@/lib/supabase/types'
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type WizardStep = 'select' | 'contact' | 'confirmation'
+
+export interface MultiSelectState {
+  step: WizardStep
+  selectedIds: Set<string>
+  contactData: { name: string; email: string; telefon: string }
+  clientConflicts: HelferTimeConflict[]
+  bookingResults: BookHelferSlotResult[]
+  isSubmitting: boolean
+  error: string | null
+}
+
+type Action =
+  | { type: 'TOGGLE_ROLE'; id: string; allRollen: RollenInstanzMitAnmeldungen[]; eventDatumStart: string; eventDatumEnd: string }
+  | { type: 'SET_STEP'; step: WizardStep }
+  | { type: 'SET_CONTACT_DATA'; data: Partial<MultiSelectState['contactData']> }
+  | { type: 'SET_SUBMITTING'; isSubmitting: boolean }
+  | { type: 'SET_ERROR'; error: string | null }
+  | { type: 'SET_BOOKING_RESULTS'; results: BookHelferSlotResult[]; conflicts?: HelferTimeConflict[] }
+  | { type: 'RESET' }
+
+// =============================================================================
+// Client-side conflict detection
+// =============================================================================
+
+function detectClientConflicts(
+  selectedIds: Set<string>,
+  allRollen: RollenInstanzMitAnmeldungen[],
+  eventDatumStart: string,
+  eventDatumEnd: string
+): HelferTimeConflict[] {
+  const conflicts: HelferTimeConflict[] = []
+  const selected = allRollen.filter((r) => selectedIds.has(r.id))
+
+  for (let i = 0; i < selected.length; i++) {
+    for (let j = i + 1; j < selected.length; j++) {
+      const a = selected[i]
+      const b = selected[j]
+
+      const startA = a.zeitblock_start || eventDatumStart
+      const endA = a.zeitblock_end || eventDatumEnd
+      const startB = b.zeitblock_start || eventDatumStart
+      const endB = b.zeitblock_end || eventDatumEnd
+
+      if (startA < endB && endA > startB) {
+        conflicts.push({
+          instanz_a: a.id,
+          rolle_a: a.template?.name || a.custom_name || 'Unbekannt',
+          event_a: '',
+          instanz_b: b.id,
+          rolle_b: b.template?.name || b.custom_name || 'Unbekannt',
+          event_b: '',
+        })
+      }
+    }
+  }
+
+  return conflicts
+}
+
+// =============================================================================
+// Reducer
+// =============================================================================
+
+const initialState: MultiSelectState = {
+  step: 'select',
+  selectedIds: new Set(),
+  contactData: { name: '', email: '', telefon: '' },
+  clientConflicts: [],
+  bookingResults: [],
+  isSubmitting: false,
+  error: null,
+}
+
+function reducer(state: MultiSelectState, action: Action): MultiSelectState {
+  switch (action.type) {
+    case 'TOGGLE_ROLE': {
+      const newSelected = new Set(state.selectedIds)
+      if (newSelected.has(action.id)) {
+        newSelected.delete(action.id)
+      } else {
+        newSelected.add(action.id)
+      }
+      const clientConflicts = detectClientConflicts(
+        newSelected,
+        action.allRollen,
+        action.eventDatumStart,
+        action.eventDatumEnd
+      )
+      return { ...state, selectedIds: newSelected, clientConflicts, error: null }
+    }
+    case 'SET_STEP':
+      return { ...state, step: action.step, error: null }
+    case 'SET_CONTACT_DATA':
+      return {
+        ...state,
+        contactData: { ...state.contactData, ...action.data },
+      }
+    case 'SET_SUBMITTING':
+      return { ...state, isSubmitting: action.isSubmitting }
+    case 'SET_ERROR':
+      return { ...state, error: action.error }
+    case 'SET_BOOKING_RESULTS':
+      return {
+        ...state,
+        bookingResults: action.results,
+        clientConflicts: action.conflicts || [],
+        step: 'confirmation',
+        isSubmitting: false,
+      }
+    case 'RESET':
+      return initialState
+    default:
+      return state
+  }
+}
+
+// =============================================================================
+// Context
+// =============================================================================
+
+interface MultiSelectContextValue {
+  state: MultiSelectState
+  toggleRole: (id: string) => void
+  setStep: (step: WizardStep) => void
+  setContactData: (data: Partial<MultiSelectState['contactData']>) => void
+  setSubmitting: (isSubmitting: boolean) => void
+  setError: (error: string | null) => void
+  setBookingResults: (results: BookHelferSlotResult[], conflicts?: HelferTimeConflict[]) => void
+  reset: () => void
+}
+
+const MultiSelectContext = createContext<MultiSelectContextValue | null>(null)
+
+export function MultiSelectProvider({
+  children,
+  allRollen,
+  eventDatumStart,
+  eventDatumEnd,
+}: {
+  children: ReactNode
+  allRollen: RollenInstanzMitAnmeldungen[]
+  eventDatumStart: string
+  eventDatumEnd: string
+}) {
+  const [state, dispatch] = useReducer(reducer, initialState)
+
+  const toggleRole = useCallback(
+    (id: string) =>
+      dispatch({
+        type: 'TOGGLE_ROLE',
+        id,
+        allRollen,
+        eventDatumStart,
+        eventDatumEnd,
+      }),
+    [allRollen, eventDatumStart, eventDatumEnd]
+  )
+
+  const setStep = useCallback(
+    (step: WizardStep) => dispatch({ type: 'SET_STEP', step }),
+    []
+  )
+
+  const setContactData = useCallback(
+    (data: Partial<MultiSelectState['contactData']>) =>
+      dispatch({ type: 'SET_CONTACT_DATA', data }),
+    []
+  )
+
+  const setSubmitting = useCallback(
+    (isSubmitting: boolean) =>
+      dispatch({ type: 'SET_SUBMITTING', isSubmitting }),
+    []
+  )
+
+  const setError = useCallback(
+    (error: string | null) => dispatch({ type: 'SET_ERROR', error }),
+    []
+  )
+
+  const setBookingResults = useCallback(
+    (results: BookHelferSlotResult[], conflicts?: HelferTimeConflict[]) =>
+      dispatch({ type: 'SET_BOOKING_RESULTS', results, conflicts }),
+    []
+  )
+
+  const reset = useCallback(() => dispatch({ type: 'RESET' }), [])
+
+  return (
+    <MultiSelectContext.Provider
+      value={{
+        state,
+        toggleRole,
+        setStep,
+        setContactData,
+        setSubmitting,
+        setError,
+        setBookingResults,
+        reset,
+      }}
+    >
+      {children}
+    </MultiSelectContext.Provider>
+  )
+}
+
+export function useMultiSelect() {
+  const ctx = useContext(MultiSelectContext)
+  if (!ctx) {
+    throw new Error('useMultiSelect must be used within MultiSelectProvider')
+  }
+  return ctx
+}

--- a/apps/web/components/helferliste/PublicEventView.tsx
+++ b/apps/web/components/helferliste/PublicEventView.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
-import { anmeldenPublic } from '@/lib/actions/helferliste'
+import { anmeldenPublicMulti } from '@/lib/actions/helferliste'
 import {
   generateICalEvent,
   icalToDataUrl,
@@ -12,8 +12,13 @@ import {
 import type {
   PublicHelferEventData,
   RollenInstanzMitAnmeldungen,
+  BookHelferSlotResult,
   InfoBlock,
 } from '@/lib/supabase/types'
+import {
+  MultiSelectProvider,
+  useMultiSelect,
+} from './MultiSelectContext'
 
 // =============================================================================
 // Types
@@ -44,6 +49,16 @@ interface PublicEventViewProps {
 
 function formatTime(dateStr: string): string {
   return new Date(dateStr).toLocaleTimeString('de-CH', {
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function formatDateTime(dateStr: string | null): string | null {
+  if (!dateStr) return null
+  return new Date(dateStr).toLocaleString('de-CH', {
+    day: '2-digit',
+    month: '2-digit',
     hour: '2-digit',
     minute: '2-digit',
   })
@@ -84,15 +99,42 @@ function groupRollenByZeitblock(
   })
 }
 
+function getRollenName(rolle: RollenInstanzMitAnmeldungen): string {
+  return rolle.template?.name || rolle.custom_name || 'Unbekannte Rolle'
+}
+
 // =============================================================================
-// Main Component
+// Main Component (Wrapper)
 // =============================================================================
 
 export function PublicEventView({ event }: PublicEventViewProps) {
-  const [searchQuery, setSearchQuery] = useState('')
-  const [selectedZeitblock, setSelectedZeitblock] = useState<string | null>(
-    null
+  if (event.rollen.length === 0) {
+    return (
+      <div className="rounded-lg bg-white p-8 text-center shadow">
+        <p className="text-gray-500">
+          Derzeit keine öffentlichen Rollen verfügbar.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <MultiSelectProvider
+      allRollen={event.rollen}
+      eventDatumStart={event.datum_start}
+      eventDatumEnd={event.datum_end}
+    >
+      <PublicEventViewInner event={event} />
+    </MultiSelectProvider>
   )
+}
+
+// =============================================================================
+// Inner Component (uses MultiSelect context)
+// =============================================================================
+
+function PublicEventViewInner({ event }: PublicEventViewProps) {
+  const { state } = useMultiSelect()
 
   const eventInfo: EventInfo = {
     name: event.name,
@@ -100,6 +142,43 @@ export function PublicEventView({ event }: PublicEventViewProps) {
     datum_end: event.datum_end,
     ort: event.ort ?? null,
   }
+
+  return (
+    <div className="space-y-6">
+      {/* Info Blocks */}
+      {event.infoBloecke.length > 0 && (
+        <InfoBlocksSection infoBloecke={event.infoBloecke} />
+      )}
+
+      {state.step === 'select' && (
+        <SelectStep event={event} eventInfo={eventInfo} />
+      )}
+      {state.step === 'contact' && (
+        <ContactFormStep event={event} eventInfo={eventInfo} />
+      )}
+      {state.step === 'confirmation' && (
+        <ConfirmationStep event={event} eventInfo={eventInfo} />
+      )}
+    </div>
+  )
+}
+
+// =============================================================================
+// Step 1: Select Roles
+// =============================================================================
+
+function SelectStep({
+  event,
+  eventInfo,
+}: {
+  event: PublicHelferEventData
+  eventInfo: EventInfo
+}) {
+  const [searchQuery, setSearchQuery] = useState('')
+  const [selectedZeitblock, setSelectedZeitblock] = useState<string | null>(
+    null
+  )
+  const { state } = useMultiSelect()
 
   const groups = useMemo(
     () => groupRollenByZeitblock(event.rollen),
@@ -111,8 +190,7 @@ export function PublicEventView({ event }: PublicEventViewProps) {
       .map((group) => ({
         ...group,
         rollen: group.rollen.filter((rolle) => {
-          const name =
-            rolle.template?.name || rolle.custom_name || ''
+          const name = rolle.template?.name || rolle.custom_name || ''
           return name.toLowerCase().includes(searchQuery.toLowerCase())
         }),
       }))
@@ -125,29 +203,12 @@ export function PublicEventView({ event }: PublicEventViewProps) {
 
   const showFilters = groups.length > 1 || event.rollen.length > 3
 
-  if (event.rollen.length === 0) {
-    return (
-      <div className="rounded-lg bg-white p-8 text-center shadow">
-        <p className="text-gray-500">
-          Derzeit keine öffentlichen Rollen verfügbar.
-        </p>
-      </div>
-    )
-  }
-
   return (
-    <div className="space-y-6">
-      {/* Info Blocks */}
-      {event.infoBloecke.length > 0 && (
-        <InfoBlocksSection infoBloecke={event.infoBloecke} />
-      )}
-
-      {/* Section Header */}
+    <>
       <h2 className="text-lg font-semibold text-gray-900">
         Verfügbare Rollen
       </h2>
 
-      {/* Filters */}
       {showFilters && (
         <FilterBar
           groups={groups}
@@ -158,7 +219,9 @@ export function PublicEventView({ event }: PublicEventViewProps) {
         />
       )}
 
-      {/* Grouped Roles */}
+      {/* Conflict Warning */}
+      {state.clientConflicts.length > 0 && <ConflictWarningBanner />}
+
       {filteredGroups.length > 0 ? (
         <div className="space-y-6">
           {filteredGroups.map((group) => (
@@ -184,7 +247,10 @@ export function PublicEventView({ event }: PublicEventViewProps) {
           </button>
         </div>
       )}
-    </div>
+
+      {/* Bottom Bar */}
+      <SelectionBottomBar />
+    </>
   )
 }
 
@@ -320,353 +386,633 @@ function ZeitblockGroupSection({
 }
 
 // =============================================================================
-// Role Card (with Registration Form + Confirmation Screen from US-7)
+// Role Card (Multi-Select with Checkbox)
 // =============================================================================
 
 function PublicRolleCard({
   rolle,
-  eventInfo,
+  eventInfo: _eventInfo,
 }: {
   rolle: RollenInstanzMitAnmeldungen
   eventInfo: EventInfo
 }) {
-  const router = useRouter()
-  const [isOpen, setIsOpen] = useState(false)
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [success, setSuccess] = useState(false)
-  const [isWaitlist, setIsWaitlist] = useState(false)
-  const [abmeldungToken, setAbmeldungToken] = useState<string | null>(null)
+  const { state, toggleRole } = useMultiSelect()
+  const isSelected = state.selectedIds.has(rolle.id)
 
-  const [formData, setFormData] = useState({
-    name: '',
-    email: '',
-    telefon: '',
-  })
-
-  const rollenName =
-    rolle.template?.name || rolle.custom_name || 'Unbekannte Rolle'
+  const rollenName = getRollenName(rolle)
   const isFull = rolle.angemeldet_count >= rolle.anzahl_benoetigt
   const spotsLeft = rolle.anzahl_benoetigt - rolle.angemeldet_count
 
-  const formatDateTime = (dateStr: string | null) => {
-    if (!dateStr) return null
-    return new Date(dateStr).toLocaleString('de-CH', {
-      day: '2-digit',
-      month: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
-    })
-  }
+  return (
+    <button
+      type="button"
+      onClick={() => toggleRole(rolle.id)}
+      className={`w-full rounded-lg bg-white p-6 text-left shadow transition-all ${
+        isSelected
+          ? 'border-2 border-primary-500 bg-primary-50 ring-2 ring-primary-200'
+          : 'border-2 border-transparent hover:border-gray-200'
+      }`}
+    >
+      <div className="flex items-start gap-3">
+        {/* Checkbox */}
+        <div className="flex-shrink-0 pt-0.5">
+          <div
+            className={`flex h-5 w-5 items-center justify-center rounded border-2 transition-colors ${
+              isSelected
+                ? 'border-primary-600 bg-primary-600'
+                : 'border-gray-300 bg-white'
+            }`}
+          >
+            {isSelected && (
+              <svg
+                className="h-3.5 w-3.5 text-white"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={3}
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+            )}
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start justify-between">
+            <div>
+              <h3 className="text-lg font-medium text-gray-900">
+                {rollenName}
+              </h3>
+              {(rolle.zeitblock_start || rolle.zeitblock_end) && (
+                <p className="mt-1 text-sm text-gray-500">
+                  {formatDateTime(rolle.zeitblock_start)}
+                  {rolle.zeitblock_end &&
+                    ` - ${formatDateTime(rolle.zeitblock_end)}`}
+                </p>
+              )}
+            </div>
+            <div className="ml-2 text-right">
+              <span
+                className={`text-sm font-medium ${isFull ? 'text-warning-600' : 'text-success-600'}`}
+              >
+                {isFull
+                  ? 'Voll (Warteliste)'
+                  : `${spotsLeft} ${spotsLeft === 1 ? 'Platz' : 'Plätze'} frei`}
+              </span>
+            </div>
+          </div>
+
+          {rolle.anmeldungen.length > 0 && (
+            <p className="mt-2 text-sm text-gray-400">
+              {rolle.anmeldungen.length} Anmeldung
+              {rolle.anmeldungen.length > 1 ? 'en' : ''}
+            </p>
+          )}
+        </div>
+      </div>
+    </button>
+  )
+}
+
+// =============================================================================
+// Selection Bottom Bar
+// =============================================================================
+
+function SelectionBottomBar() {
+  const { state, setStep } = useMultiSelect()
+  const count = state.selectedIds.size
+
+  if (count === 0) return null
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-50 border-t border-gray-200 bg-white p-4 shadow-lg">
+      <div className="mx-auto flex max-w-2xl items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-gray-900">
+            {count} {count === 1 ? 'Rolle' : 'Rollen'} ausgewählt
+          </span>
+          {state.clientConflicts.length > 0 && (
+            <span
+              className="text-warning-600"
+              title="Zeitüberschneidungen vorhanden"
+            >
+              <svg
+                className="h-5 w-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4.832c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z"
+                />
+              </svg>
+            </span>
+          )}
+        </div>
+        <button
+          onClick={() => setStep('contact')}
+          className="rounded-lg bg-primary-600 px-6 py-2 font-medium text-white transition-colors hover:bg-primary-700"
+        >
+          Weiter
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// =============================================================================
+// Conflict Warning Banner
+// =============================================================================
+
+function ConflictWarningBanner() {
+  const { state } = useMultiSelect()
+
+  return (
+    <div className="rounded-lg border border-warning-200 bg-warning-50 p-4">
+      <div className="flex gap-3">
+        <svg
+          className="h-5 w-5 flex-shrink-0 text-warning-600"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4.832c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z"
+          />
+        </svg>
+        <div>
+          <h4 className="text-sm font-medium text-warning-800">
+            Zeitüberschneidungen erkannt
+          </h4>
+          <ul className="mt-1 space-y-1">
+            {state.clientConflicts.map((conflict, i) => (
+              <li key={i} className="text-sm text-warning-700">
+                &laquo;{conflict.rolle_a}&raquo; und &laquo;{conflict.rolle_b}
+                &raquo; überschneiden sich zeitlich
+              </li>
+            ))}
+          </ul>
+          <p className="mt-2 text-xs text-warning-600">
+            Du kannst trotzdem fortfahren, aber beachte die Überschneidungen.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// =============================================================================
+// Step 2: Contact Form
+// =============================================================================
+
+function ContactFormStep({
+  event,
+}: {
+  event: PublicHelferEventData
+  eventInfo: EventInfo
+}) {
+  const router = useRouter()
+  const {
+    state,
+    setStep,
+    setContactData,
+    setSubmitting,
+    setError,
+    setBookingResults,
+  } = useMultiSelect()
+
+  const selectedRollen = event.rollen.filter((r) =>
+    state.selectedIds.has(r.id)
+  )
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    setIsSubmitting(true)
-    setError(null)
-
-    const result = await anmeldenPublic(rolle.id, formData)
-    if (!result.success) {
-      setError(result.error || 'Fehler bei der Anmeldung')
-      setIsSubmitting(false)
+    if (!state.contactData.name.trim()) {
+      setError('Name ist erforderlich')
       return
     }
 
-    setSuccess(true)
-    setIsWaitlist(result.isWaitlist ?? false)
-    setAbmeldungToken(result.abmeldungToken ?? null)
-    setIsSubmitting(false)
+    setSubmitting(true)
+    setError(null)
+
+    const result = await anmeldenPublicMulti(
+      Array.from(state.selectedIds),
+      {
+        name: state.contactData.name.trim(),
+        email: state.contactData.email.trim() || undefined,
+        telefon: state.contactData.telefon.trim() || undefined,
+      }
+    )
+
+    if (!result.success) {
+      setError(result.error || 'Fehler bei der Anmeldung')
+      setSubmitting(false)
+      return
+    }
+
+    setBookingResults(result.results || [], result.conflicts)
     router.refresh()
   }
 
-  const handleIcsDownload = () => {
-    const startDate = new Date(rolle.zeitblock_start || eventInfo.datum_start)
-    const endDate = new Date(rolle.zeitblock_end || eventInfo.datum_end)
+  return (
+    <div className="space-y-6">
+      <h2 className="text-lg font-semibold text-gray-900">Kontaktdaten</h2>
 
-    const icsContent = generateICalEvent({
-      title: `Helfereinsatz: ${rollenName} - ${eventInfo.name}`,
-      description: `Rolle: ${rollenName}\nVeranstaltung: ${eventInfo.name}`,
-      location: eventInfo.ort || undefined,
-      startDate,
-      endDate,
-    })
-
-    const dataUrl = icalToDataUrl(icsContent)
-    const filename = generateIcalFilename(eventInfo.name, rollenName)
-
-    const link = document.createElement('a')
-    link.href = dataUrl
-    link.download = filename
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
-  }
-
-  if (success) {
-    return (
-      <div className="rounded-lg bg-white p-6 shadow">
-        {/* Status Badge */}
-        <div className="mb-4 flex items-center justify-center">
-          <span
-            className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-medium ${
-              isWaitlist
-                ? 'bg-warning-100 text-warning-800'
-                : 'bg-success-100 text-success-800'
-            }`}
-          >
-            {isWaitlist ? 'Warteliste' : 'Bestätigt'}
-          </span>
-        </div>
-
-        {/* Success Icon */}
-        <div className="text-center">
-          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-success-100">
-            <svg
-              className="h-6 w-6 text-success-600"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M5 13l4 4L19 7"
-              />
-            </svg>
-          </div>
-          <h3 className="text-lg font-medium text-gray-900">
-            {isWaitlist ? 'Auf Warteliste gesetzt!' : 'Anmeldung erfolgreich!'}
-          </h3>
-        </div>
-
-        {/* Event Details */}
-        <div className="mt-6 rounded-lg bg-gray-50 p-4">
-          <dl className="space-y-2 text-sm">
-            <div className="flex justify-between">
-              <dt className="text-gray-500">Veranstaltung</dt>
-              <dd className="font-medium text-gray-900">{eventInfo.name}</dd>
-            </div>
-            <div className="flex justify-between">
-              <dt className="text-gray-500">Datum</dt>
-              <dd className="font-medium text-gray-900">
-                {new Date(eventInfo.datum_start).toLocaleDateString('de-CH', {
-                  weekday: 'short',
-                  day: '2-digit',
-                  month: 'long',
-                  year: 'numeric',
-                })}
-              </dd>
-            </div>
-            <div className="flex justify-between">
-              <dt className="text-gray-500">Zeit</dt>
-              <dd className="font-medium text-gray-900">
-                {formatDateTime(rolle.zeitblock_start || eventInfo.datum_start)}
-                {' - '}
-                {formatDateTime(rolle.zeitblock_end || eventInfo.datum_end)}
-              </dd>
-            </div>
-            {eventInfo.ort && (
-              <div className="flex justify-between">
-                <dt className="text-gray-500">Ort</dt>
-                <dd className="font-medium text-gray-900">{eventInfo.ort}</dd>
-              </div>
-            )}
-            <div className="flex justify-between">
-              <dt className="text-gray-500">Rolle</dt>
-              <dd className="font-medium text-gray-900">{rollenName}</dd>
-            </div>
-          </dl>
-        </div>
-
-        {/* Waitlist note */}
-        {isWaitlist && (
-          <div className="mt-4 rounded-lg border border-warning-200 bg-warning-50 p-3">
-            <p className="text-sm text-warning-800">
-              Du stehst auf der Warteliste. Wir melden uns, sobald ein Platz
-              frei wird.
-            </p>
-          </div>
-        )}
-
-        {/* Actions */}
-        <div className="mt-6 space-y-3">
-          {/* ICS Download */}
-          <button
-            onClick={handleIcsDownload}
-            className="flex w-full items-center justify-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
-          >
-            <svg
-              className="h-4 w-4"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-              />
-            </svg>
-            Zum Kalender hinzufügen (.ics)
-          </button>
-
-          {/* Cancellation Link */}
-          {abmeldungToken && (
-            <Link
-              href={
-                `/helfer/helferliste/abmeldung/${abmeldungToken}` as never
-              }
-              className="block w-full rounded-lg border border-error-200 bg-white px-4 py-2 text-center text-sm font-medium text-error-600 transition-colors hover:bg-error-50"
-            >
-              Anmeldung stornieren
-            </Link>
-          )}
-        </div>
-
-        {/* Hint */}
-        {formData.email && (
-          <p className="mt-4 text-center text-xs text-gray-500">
-            Du erhältst eine Bestätigung per E-Mail an {formData.email}.
-          </p>
-        )}
+      {/* Summary of selected roles */}
+      <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+        <h3 className="mb-2 text-sm font-medium text-gray-700">
+          Ausgewählte Rollen ({selectedRollen.length})
+        </h3>
+        <ul className="space-y-1">
+          {selectedRollen.map((rolle) => (
+            <li key={rolle.id} className="flex items-center gap-2 text-sm">
+              <span className="text-primary-600">&#x2713;</span>
+              <span className="font-medium text-gray-900">
+                {getRollenName(rolle)}
+              </span>
+              {(rolle.zeitblock_start || rolle.zeitblock_end) && (
+                <span className="text-gray-500">
+                  ({formatDateTime(rolle.zeitblock_start)}
+                  {rolle.zeitblock_end &&
+                    ` - ${formatDateTime(rolle.zeitblock_end)}`}
+                  )
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
       </div>
+
+      {state.error && (
+        <div className="rounded border border-error-200 bg-error-50 px-3 py-2 text-sm text-error-700">
+          {state.error}
+        </div>
+      )}
+
+      {/* Contact Form */}
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label
+            htmlFor="contact-name"
+            className="block text-sm font-medium text-gray-700"
+          >
+            Name *
+          </label>
+          <input
+            type="text"
+            id="contact-name"
+            required
+            value={state.contactData.name}
+            onChange={(e) => setContactData({ name: e.target.value })}
+            className="mt-1 block w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-primary-500 focus:ring-2 focus:ring-primary-500"
+            placeholder="Dein Name"
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="contact-email"
+            className="block text-sm font-medium text-gray-700"
+          >
+            E-Mail (optional)
+          </label>
+          <input
+            type="email"
+            id="contact-email"
+            value={state.contactData.email}
+            onChange={(e) => setContactData({ email: e.target.value })}
+            className="mt-1 block w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-primary-500 focus:ring-2 focus:ring-primary-500"
+            placeholder="name@beispiel.ch"
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="contact-telefon"
+            className="block text-sm font-medium text-gray-700"
+          >
+            Telefon (optional)
+          </label>
+          <input
+            type="tel"
+            id="contact-telefon"
+            value={state.contactData.telefon}
+            onChange={(e) => setContactData({ telefon: e.target.value })}
+            className="mt-1 block w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-primary-500 focus:ring-2 focus:ring-primary-500"
+            placeholder="+41 79 123 45 67"
+          />
+        </div>
+
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={() => setStep('select')}
+            disabled={state.isSubmitting}
+            className="flex-1 rounded-lg border border-gray-300 px-4 py-2 text-gray-600 hover:text-gray-800 disabled:opacity-50"
+          >
+            Zurück
+          </button>
+          <button
+            type="submit"
+            disabled={state.isSubmitting}
+            className="flex-1 rounded-lg bg-primary-600 px-4 py-2 font-medium text-white transition-colors hover:bg-primary-700 disabled:opacity-50"
+          >
+            {state.isSubmitting
+              ? 'Anmelden...'
+              : `Jetzt anmelden (${selectedRollen.length})`}
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+// =============================================================================
+// Step 3: Confirmation
+// =============================================================================
+
+function ConfirmationStep({
+  event,
+  eventInfo,
+}: {
+  event: PublicHelferEventData
+  eventInfo: EventInfo
+}) {
+  const { state, reset } = useMultiSelect()
+
+  const confirmedCount = state.bookingResults.filter(
+    (r) => r.success && !r.is_waitlist
+  ).length
+  const waitlistCount = state.bookingResults.filter(
+    (r) => r.success && r.is_waitlist
+  ).length
+
+  // Map booking results to roles
+  const resultsByRolleId = new Map<string, BookHelferSlotResult>()
+  const selectedIdsArray = Array.from(state.selectedIds)
+  state.bookingResults.forEach((result, index) => {
+    if (selectedIdsArray[index]) {
+      resultsByRolleId.set(selectedIdsArray[index], result)
+    }
+  })
+
+  const handleIcsDownload = () => {
+    // Generate combined ICS with all booked roles
+    const selectedRollen = event.rollen.filter((r) =>
+      state.selectedIds.has(r.id)
     )
+
+    const events = selectedRollen
+      .filter((rolle) => {
+        const result = resultsByRolleId.get(rolle.id)
+        return result?.success
+      })
+      .map((rolle) => {
+        const rollenName = getRollenName(rolle)
+        const startDate = new Date(
+          rolle.zeitblock_start || eventInfo.datum_start
+        )
+        const endDate = new Date(rolle.zeitblock_end || eventInfo.datum_end)
+        return generateICalEvent({
+          title: `Helfereinsatz: ${rollenName} - ${eventInfo.name}`,
+          description: `Rolle: ${rollenName}\nVeranstaltung: ${eventInfo.name}`,
+          location: eventInfo.ort || undefined,
+          startDate,
+          endDate,
+        })
+      })
+
+    if (events.length === 0) return
+
+    // For multiple events, combine into one ICS
+    // Use the first event as base, but for simplicity just download first one
+    // (iCal format supports multi-event files by merging VEVENT blocks)
+    if (events.length === 1) {
+      const dataUrl = icalToDataUrl(events[0])
+      const filename = generateIcalFilename(eventInfo.name, 'helfereinsaetze')
+      triggerDownload(dataUrl, filename)
+    } else {
+      // Merge multiple VCALENDAR files into one
+      const merged = mergeICalEvents(events)
+      const dataUrl = icalToDataUrl(merged)
+      const filename = generateIcalFilename(eventInfo.name, 'helfereinsaetze')
+      triggerDownload(dataUrl, filename)
+    }
   }
 
   return (
-    <div className="rounded-lg bg-white p-6 shadow">
-      <div className="flex items-start justify-between">
-        <div>
-          <h3 className="text-lg font-medium text-gray-900">{rollenName}</h3>
-          {(rolle.zeitblock_start || rolle.zeitblock_end) && (
-            <p className="mt-1 text-sm text-gray-500">
-              {formatDateTime(rolle.zeitblock_start)}
-              {rolle.zeitblock_end &&
-                ` - ${formatDateTime(rolle.zeitblock_end)}`}
-            </p>
-          )}
-        </div>
-        <div className="text-right">
-          <span
-            className={`text-sm font-medium ${isFull ? 'text-warning-600' : 'text-success-600'}`}
+    <div className="space-y-6">
+      {/* Status Banner */}
+      <div className="text-center">
+        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-success-100">
+          <svg
+            className="h-6 w-6 text-success-600"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
           >
-            {isFull
-              ? 'Voll (Warteliste möglich)'
-              : `${spotsLeft} von ${rolle.anzahl_benoetigt} ${spotsLeft === 1 ? 'Platz' : 'Plätze'} frei`}
-          </span>
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M5 13l4 4L19 7"
+            />
+          </svg>
         </div>
+        <h2 className="text-lg font-semibold text-gray-900">
+          Anmeldung abgeschlossen
+        </h2>
+        <p className="mt-1 text-sm text-gray-500">
+          {confirmedCount > 0 &&
+            `${confirmedCount} bestätigt`}
+          {confirmedCount > 0 && waitlistCount > 0 && ', '}
+          {waitlistCount > 0 &&
+            `${waitlistCount} auf Warteliste`}
+        </p>
       </div>
 
-      {/* Already registered */}
-      {rolle.anmeldungen.length > 0 && (
-        <div className="mt-4 border-t border-gray-100 pt-4">
-          <p className="text-sm text-gray-500">
-            {rolle.anmeldungen.length} Anmeldung
-            {rolle.anmeldungen.length > 1 ? 'en' : ''}
+      {/* Results per Role */}
+      <div className="space-y-3">
+        {selectedIdsArray.map((rolleId) => {
+          const rolle = event.rollen.find((r) => r.id === rolleId)
+          const result = resultsByRolleId.get(rolleId)
+          if (!rolle) return null
+
+          const rollenName = getRollenName(rolle)
+
+          return (
+            <div
+              key={rolleId}
+              className="rounded-lg border border-gray-200 bg-white p-4"
+            >
+              <div className="flex items-center justify-between">
+                <div>
+                  <h3 className="font-medium text-gray-900">{rollenName}</h3>
+                  {(rolle.zeitblock_start || rolle.zeitblock_end) && (
+                    <p className="text-sm text-gray-500">
+                      {formatDateTime(rolle.zeitblock_start)}
+                      {rolle.zeitblock_end &&
+                        ` - ${formatDateTime(rolle.zeitblock_end)}`}
+                    </p>
+                  )}
+                </div>
+                <span
+                  className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                    result?.is_waitlist
+                      ? 'bg-warning-100 text-warning-800'
+                      : result?.success
+                        ? 'bg-success-100 text-success-800'
+                        : 'bg-error-100 text-error-800'
+                  }`}
+                >
+                  {result?.is_waitlist
+                    ? 'Warteliste'
+                    : result?.success
+                      ? 'Bestätigt'
+                      : 'Fehler'}
+                </span>
+              </div>
+
+              {/* Cancellation Link */}
+              {result?.abmeldung_token && (
+                <Link
+                  href={
+                    `/helfer/helferliste/abmeldung/${result.abmeldung_token}` as never
+                  }
+                  className="mt-2 inline-block text-sm text-error-600 hover:text-error-700"
+                >
+                  Stornieren
+                </Link>
+              )}
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Event Details */}
+      <div className="rounded-lg bg-gray-50 p-4">
+        <dl className="space-y-2 text-sm">
+          <div className="flex justify-between">
+            <dt className="text-gray-500">Veranstaltung</dt>
+            <dd className="font-medium text-gray-900">{eventInfo.name}</dd>
+          </div>
+          <div className="flex justify-between">
+            <dt className="text-gray-500">Datum</dt>
+            <dd className="font-medium text-gray-900">
+              {new Date(eventInfo.datum_start).toLocaleDateString('de-CH', {
+                weekday: 'short',
+                day: '2-digit',
+                month: 'long',
+                year: 'numeric',
+              })}
+            </dd>
+          </div>
+          {eventInfo.ort && (
+            <div className="flex justify-between">
+              <dt className="text-gray-500">Ort</dt>
+              <dd className="font-medium text-gray-900">{eventInfo.ort}</dd>
+            </div>
+          )}
+        </dl>
+      </div>
+
+      {/* Waitlist note */}
+      {waitlistCount > 0 && (
+        <div className="rounded-lg border border-warning-200 bg-warning-50 p-3">
+          <p className="text-sm text-warning-800">
+            Du stehst für {waitlistCount}{' '}
+            {waitlistCount === 1 ? 'Rolle' : 'Rollen'} auf der Warteliste.
+            Wir melden uns, sobald ein Platz frei wird.
           </p>
         </div>
       )}
 
-      {/* Registration Form */}
-      {!isOpen ? (
+      {/* Actions */}
+      <div className="space-y-3">
         <button
-          onClick={() => setIsOpen(true)}
-          className="mt-4 w-full rounded-lg bg-primary-600 px-4 py-2 font-medium text-white transition-colors hover:bg-primary-700"
+          onClick={handleIcsDownload}
+          className="flex w-full items-center justify-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
         >
-          {isFull ? 'Auf Warteliste setzen' : 'Jetzt anmelden'}
+          <svg
+            className="h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+            />
+          </svg>
+          Alle Termine zum Kalender hinzufügen (.ics)
         </button>
-      ) : (
-        <form
-          onSubmit={handleSubmit}
-          className="mt-4 space-y-4 border-t border-gray-100 pt-4"
+
+        <button
+          onClick={reset}
+          className="w-full rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
         >
-          {error && (
-            <div className="border-error-200 rounded border bg-error-50 px-3 py-2 text-sm text-error-700">
-              {error}
-            </div>
-          )}
+          Weitere Rollen anmelden
+        </button>
+      </div>
 
-          <div>
-            <label
-              htmlFor={`name-${rolle.id}`}
-              className="block text-sm font-medium text-gray-700"
-            >
-              Name *
-            </label>
-            <input
-              type="text"
-              id={`name-${rolle.id}`}
-              required
-              value={formData.name}
-              onChange={(e) =>
-                setFormData({ ...formData, name: e.target.value })
-              }
-              className="mt-1 block w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-primary-500 focus:ring-2 focus:ring-primary-500"
-              placeholder="Dein Name"
-            />
-          </div>
-
-          <div>
-            <label
-              htmlFor={`email-${rolle.id}`}
-              className="block text-sm font-medium text-gray-700"
-            >
-              E-Mail (optional)
-            </label>
-            <input
-              type="email"
-              id={`email-${rolle.id}`}
-              value={formData.email}
-              onChange={(e) =>
-                setFormData({ ...formData, email: e.target.value })
-              }
-              className="mt-1 block w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-primary-500 focus:ring-2 focus:ring-primary-500"
-              placeholder="name@beispiel.ch"
-            />
-          </div>
-
-          <div>
-            <label
-              htmlFor={`telefon-${rolle.id}`}
-              className="block text-sm font-medium text-gray-700"
-            >
-              Telefon (optional)
-            </label>
-            <input
-              type="tel"
-              id={`telefon-${rolle.id}`}
-              value={formData.telefon}
-              onChange={(e) =>
-                setFormData({ ...formData, telefon: e.target.value })
-              }
-              className="mt-1 block w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-primary-500 focus:ring-2 focus:ring-primary-500"
-              placeholder="+41 79 123 45 67"
-            />
-          </div>
-
-          <div className="flex gap-3">
-            <button
-              type="button"
-              onClick={() => setIsOpen(false)}
-              className="flex-1 rounded-lg border border-gray-300 px-4 py-2 text-gray-600 hover:text-gray-800"
-            >
-              Abbrechen
-            </button>
-            <button
-              type="submit"
-              disabled={isSubmitting}
-              className="flex-1 rounded-lg bg-primary-600 px-4 py-2 font-medium text-white transition-colors hover:bg-primary-700 disabled:opacity-50"
-            >
-              {isSubmitting
-                ? 'Anmelden...'
-                : isFull
-                  ? 'Auf Warteliste'
-                  : 'Anmelden'}
-            </button>
-          </div>
-        </form>
+      {/* Email Hint */}
+      {state.contactData.email && (
+        <p className="text-center text-xs text-gray-500">
+          Du erhältst eine Bestätigung per E-Mail an{' '}
+          {state.contactData.email}.
+        </p>
       )}
     </div>
   )
+}
+
+// =============================================================================
+// Utilities
+// =============================================================================
+
+function triggerDownload(dataUrl: string, filename: string) {
+  const link = document.createElement('a')
+  link.href = dataUrl
+  link.download = filename
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+}
+
+function mergeICalEvents(icsContents: string[]): string {
+  if (icsContents.length === 0) return ''
+  if (icsContents.length === 1) return icsContents[0]
+
+  // Extract VEVENT blocks from each ICS content and merge into one VCALENDAR
+  const vevents: string[] = []
+  let preamble = ''
+
+  for (let i = 0; i < icsContents.length; i++) {
+    const content = icsContents[i]
+    const veventMatch = content.match(
+      /BEGIN:VEVENT[\s\S]*?END:VEVENT/
+    )
+    if (veventMatch) {
+      vevents.push(veventMatch[0])
+    }
+    if (i === 0) {
+      // Use preamble from first event (VCALENDAR header + VTIMEZONE)
+      preamble = content.substring(0, content.indexOf('BEGIN:VEVENT'))
+    }
+  }
+
+  return preamble + vevents.join('\r\n') + '\r\nEND:VCALENDAR'
 }

--- a/apps/web/lib/supabase/types.ts
+++ b/apps/web/lib/supabase/types.ts
@@ -1577,14 +1577,17 @@ export type HelferEvent = {
   datum_end: string
   ort: string | null
   public_token: string
+  max_anmeldungen_pro_helfer: number | null
   created_at: string
   updated_at: string
 }
 
 export type HelferEventInsert = Omit<
   HelferEvent,
-  'id' | 'public_token' | 'created_at' | 'updated_at'
->
+  'id' | 'public_token' | 'max_anmeldungen_pro_helfer' | 'created_at' | 'updated_at'
+> & {
+  max_anmeldungen_pro_helfer?: number | null
+}
 export type HelferEventUpdate = Partial<HelferEventInsert>
 
 export type HelferRollenTemplate = {

--- a/supabase/migrations/20260212112403_helfer_event_max_anmeldungen.sql
+++ b/supabase/migrations/20260212112403_helfer_event_max_anmeldungen.sql
@@ -1,0 +1,12 @@
+-- =============================================================================
+-- Migration: max_anmeldungen_pro_helfer for helfer_events
+-- Created: 2026-02-12
+-- Description: Optional limit on how many roles a single helper can register
+--   for per event. NULL = unlimited.
+-- =============================================================================
+
+ALTER TABLE helfer_events
+  ADD COLUMN IF NOT EXISTS max_anmeldungen_pro_helfer INTEGER DEFAULT NULL;
+
+COMMENT ON COLUMN helfer_events.max_anmeldungen_pro_helfer IS
+  'Optional limit on registrations per helper per event. NULL = unlimited.';


### PR DESCRIPTION
## Summary
- Replace single-role registration on public helper page (`/helfer/[token]`) with a 3-step multi-select wizard: select roles via checkbox cards, enter contact data once, confirmation with per-role status badges and combined ICS download
- Add `anmeldenPublicMulti` server action using `book_helfer_slots` RPC for atomic all-or-nothing booking with conflict detection and `max_anmeldungen_pro_helfer` limit enforcement
- Add `MultiSelectContext` with client-side time overlap detection (warns but doesn't block)

## Changes
| File | Action |
|---|---|
| `supabase/migrations/..._helfer_event_max_anmeldungen.sql` | New migration: `max_anmeldungen_pro_helfer` column |
| `apps/web/lib/supabase/types.ts` | Extended `HelferEvent` type |
| `apps/web/lib/actions/helferliste.ts` | Added `anmeldenPublicMulti()` server action |
| `apps/web/components/helferliste/MultiSelectContext.tsx` | New: wizard state context + reducer |
| `apps/web/components/helferliste/PublicEventView.tsx` | Major refactor: 3-step wizard |
| `apps/web/lib/actions/helferliste.test.ts` | Added 7 new tests |

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm run test:run` passes (94/94 tests, 7 new)
- [ ] Public helper page: select multiple roles, enter contact data once, verify all bookings in confirmation
- [ ] Verify conflict warning banner appears for overlapping time blocks
- [ ] Verify ICS download contains all booked roles
- [ ] Verify storno links work per role in confirmation step

🤖 Generated with [Claude Code](https://claude.com/claude-code)