### PR TITLE
feat: DSGVO consent tracking & vorname/nachname fields (US-3, US-4)

### DIFF
--- a/apps/web/components/helferliste/MultiSelectContext.tsx
+++ b/apps/web/components/helferliste/MultiSelectContext.tsx
@@ -22,7 +22,7 @@ export type WizardStep = 'select' | 'contact' | 'confirmation'
 export interface MultiSelectState {
   step: WizardStep
   selectedIds: Set<string>
-  contactData: { name: string; email: string; telefon: string }
+  contactData: { vorname: string; nachname: string; email: string; telefon: string; datenschutz: boolean }
   clientConflicts: HelferTimeConflict[]
   bookingResults: BookHelferSlotResult[]
   isSubmitting: boolean
@@ -84,7 +84,7 @@ function detectClientConflicts(
 const initialState: MultiSelectState = {
   step: 'select',
   selectedIds: new Set(),
-  contactData: { name: '', email: '', telefon: '' },
+  contactData: { vorname: '', nachname: '', email: '', telefon: '', datenschutz: false },
   clientConflicts: [],
   bookingResults: [],
   isSubmitting: false,

--- a/apps/web/lib/actions/helferliste.ts
+++ b/apps/web/lib/actions/helferliste.ts
@@ -26,6 +26,7 @@ import {
   notifyRegistrationConfirmed,
   notifyStatusChange,
 } from './helferliste-notifications'
+import { externeHelferRegistrierungFormSchema } from '../validations/externe-helfer'
 
 // =============================================================================
 // Helfer Events
@@ -763,17 +764,21 @@ export async function anmeldenPublic(
 /**
  * Register for multiple public roles at once (external helper)
  * Uses atomic DB function book_helfer_slots() for all-or-nothing booking
+ * Validates with externeHelferRegistrierungFormSchema (DSGVO consent required)
  */
 export async function anmeldenPublicMulti(
   rollenInstanzIds: string[],
   data: {
-    name: string
-    email?: string
+    vorname: string
+    nachname: string
+    email: string
     telefon?: string
+    datenschutz: boolean
   }
 ): Promise<{
   success: boolean
   error?: string
+  fieldErrors?: Record<string, string>
   results?: BookHelferSlotResult[]
   conflicts?: HelferTimeConflict[]
 }> {
@@ -781,37 +786,43 @@ export async function anmeldenPublicMulti(
     return { success: false, error: 'Mindestens eine Rolle muss ausgewählt werden' }
   }
 
-  if (!data.name.trim()) {
-    return { success: false, error: 'Name ist erforderlich' }
+  // Server-side validation with Zod schema
+  const parsed = externeHelferRegistrierungFormSchema.safeParse(data)
+  if (!parsed.success) {
+    const fieldErrors: Record<string, string> = {}
+    for (const issue of parsed.error.issues) {
+      const key = issue.path[0]?.toString()
+      if (key && !fieldErrors[key]) {
+        fieldErrors[key] = issue.message
+      }
+    }
+    return {
+      success: false,
+      error: Object.values(fieldErrors)[0] || 'Ungültige Eingabe',
+      fieldErrors,
+    }
   }
 
+  const validated = parsed.data
   const supabase = await createClient()
 
-  // If email provided, find or create the external helper profile
-  let externalHelperId: string | null = null
-  if (data.email) {
-    const nameParts = data.name.trim().split(/\s+/)
-    const vorname = nameParts[0] || data.name
-    const nachname = nameParts.length > 1 ? nameParts.slice(1).join(' ') : vorname
+  // Find or create the external helper profile (email is now required)
+  const { data: helperId, error: helperError } = await supabase
+    .rpc('find_or_create_external_helper', {
+      p_email: validated.email,
+      p_vorname: validated.vorname,
+      p_nachname: validated.nachname,
+      p_telefon: data.telefon || null,
+    })
 
-    const { data: helperId, error: helperError } = await supabase
-      .rpc('find_or_create_external_helper', {
-        p_email: data.email,
-        p_vorname: vorname,
-        p_nachname: nachname,
-        p_telefon: data.telefon || null,
-      })
-
-    if (helperError) {
-      console.error('Error finding/creating helper profile:', helperError)
-      return { success: false, error: 'Fehler bei der Registrierung' }
-    }
-
-    externalHelperId = helperId as string
+  if (helperError) {
+    console.error('Error finding/creating helper profile:', helperError)
+    return { success: false, error: 'Fehler bei der Registrierung' }
   }
 
+  const externalHelperId = helperId as string
+
   // Check max_anmeldungen_pro_helfer limit
-  // Get the event for the first role to check the limit
   const { data: instanzData } = await supabase
     .from('helfer_rollen_instanzen')
     .select('helfer_event_id')
@@ -827,27 +838,22 @@ export async function anmeldenPublicMulti(
 
     const maxLimit = (eventData as HelferEvent | null)?.max_anmeldungen_pro_helfer
     if (maxLimit !== null && maxLimit !== undefined) {
-      // Count existing registrations for this helper in this event
-      let existingCount = 0
-      if (externalHelperId) {
-        const { count } = await supabase
-          .from('helfer_anmeldungen')
-          .select('id', { count: 'exact', head: true })
-          .eq('external_helper_id', externalHelperId)
-          .in(
-            'rollen_instanz_id',
-            (
-              await supabase
-                .from('helfer_rollen_instanzen')
-                .select('id')
-                .eq('helfer_event_id', instanzData[0].helfer_event_id)
-            ).data?.map((r: { id: string }) => r.id) || []
-          )
-          .neq('status', 'abgelehnt')
+      const { count } = await supabase
+        .from('helfer_anmeldungen')
+        .select('id', { count: 'exact', head: true })
+        .eq('external_helper_id', externalHelperId)
+        .in(
+          'rollen_instanz_id',
+          (
+            await supabase
+              .from('helfer_rollen_instanzen')
+              .select('id')
+              .eq('helfer_event_id', instanzData[0].helfer_event_id)
+          ).data?.map((r: { id: string }) => r.id) || []
+        )
+        .neq('status', 'abgelehnt')
 
-        existingCount = count || 0
-      }
-
+      const existingCount = count || 0
       if (existingCount + rollenInstanzIds.length > maxLimit) {
         return {
           success: false,
@@ -858,21 +864,16 @@ export async function anmeldenPublicMulti(
   }
 
   // Check for time conflicts via DB function
-  const conflictParams: Record<string, unknown> = {
-    p_rollen_instanz_ids: rollenInstanzIds,
-  }
-  if (externalHelperId) {
-    conflictParams.p_external_helper_id = externalHelperId
-  }
-
   const { data: conflictCheck } = await supabase.rpc(
     'check_helfer_time_conflicts',
-    conflictParams
+    {
+      p_rollen_instanz_ids: rollenInstanzIds,
+      p_external_helper_id: externalHelperId,
+    }
   )
 
   const conflicts = conflictCheck as CheckHelferTimeConflictsResult | null
   if (conflicts?.has_conflicts) {
-    // Only block if conflicts are with existing registrations (not among selected)
     const existingConflicts = conflicts.conflicts.filter(
       (c) =>
         !rollenInstanzIds.includes(c.instanz_a) ||
@@ -888,19 +889,11 @@ export async function anmeldenPublicMulti(
   }
 
   // Atomic multi-slot booking via DB function
-  const rpcParams: Record<string, unknown> = {
+  const { data: result, error } = await supabase.rpc('book_helfer_slots', {
     p_rollen_instanz_ids: rollenInstanzIds,
-  }
-
-  if (externalHelperId) {
-    rpcParams.p_external_helper_id = externalHelperId
-  } else {
-    rpcParams.p_external_name = data.name
-    rpcParams.p_external_email = data.email || null
-    rpcParams.p_external_telefon = data.telefon || null
-  }
-
-  const { data: result, error } = await supabase.rpc('book_helfer_slots', rpcParams)
+    p_external_helper_id: externalHelperId,
+    p_datenschutz_akzeptiert: new Date().toISOString(),
+  })
 
   if (error) {
     console.error('Error booking helfer slots:', error)
@@ -913,7 +906,7 @@ export async function anmeldenPublicMulti(
   }
 
   // Send confirmation emails async (don't block)
-  if (data.email && booking.results) {
+  if (booking.results) {
     for (const slot of booking.results) {
       if (slot.anmeldung_id) {
         notifyRegistrationConfirmed(

--- a/apps/web/lib/supabase/types.ts
+++ b/apps/web/lib/supabase/types.ts
@@ -1633,6 +1633,7 @@ export type HelferAnmeldung = {
   external_email: string | null      // Legacy: inline email
   external_telefon: string | null    // Legacy: inline phone
   abmeldung_token: string | null     // Public cancellation token (US-7)
+  datenschutz_akzeptiert: string | null // GDPR consent timestamp (US-3)
   status: HelferAnmeldungStatus
   created_at: string
 }

--- a/supabase/migrations/20260212121834_helfer_anmeldung_datenschutz.sql
+++ b/supabase/migrations/20260212121834_helfer_anmeldung_datenschutz.sql
@@ -1,0 +1,216 @@
+-- =============================================================================
+-- Migration: datenschutz_akzeptiert for helfer_anmeldungen
+-- Created: 2026-02-12
+-- Issue: US-3
+-- Description: Track GDPR consent timestamp on helper registrations.
+--   - Add datenschutz_akzeptiert column
+--   - Update book_helfer_slot() to accept and store it
+--   - Update book_helfer_slots() to pass it through
+-- =============================================================================
+
+-- =============================================================================
+-- ADD COLUMN
+-- =============================================================================
+
+ALTER TABLE helfer_anmeldungen
+  ADD COLUMN IF NOT EXISTS datenschutz_akzeptiert TIMESTAMPTZ DEFAULT NULL;
+
+COMMENT ON COLUMN helfer_anmeldungen.datenschutz_akzeptiert IS
+  'Timestamp when the volunteer accepted the privacy policy. NULL for legacy/internal registrations.';
+
+-- =============================================================================
+-- UPDATE FUNCTION: book_helfer_slot() - accept datenschutz_akzeptiert
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION book_helfer_slot(
+  p_rollen_instanz_id UUID,
+  p_profile_id UUID DEFAULT NULL,
+  p_external_helper_id UUID DEFAULT NULL,
+  p_external_name TEXT DEFAULT NULL,
+  p_external_email TEXT DEFAULT NULL,
+  p_external_telefon TEXT DEFAULT NULL,
+  p_datenschutz_akzeptiert TIMESTAMPTZ DEFAULT NULL
+) RETURNS JSONB AS $$
+DECLARE
+  v_instanz RECORD;
+  v_active_count INTEGER;
+  v_status TEXT;
+  v_anmeldung_id UUID;
+  v_abmeldung_token UUID;
+  v_is_waitlist BOOLEAN;
+BEGIN
+  -- Validate: exactly one identity must be provided
+  IF (
+    (p_profile_id IS NOT NULL)::INTEGER +
+    (p_external_helper_id IS NOT NULL)::INTEGER +
+    (p_external_name IS NOT NULL)::INTEGER
+  ) != 1 THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Genau eine Identität muss angegeben werden'
+    );
+  END IF;
+
+  -- Lock the rollen_instanz row to prevent concurrent capacity changes
+  SELECT id, anzahl_benoetigt, sichtbarkeit
+  INTO v_instanz
+  FROM helfer_rollen_instanzen
+  WHERE id = p_rollen_instanz_id
+  FOR UPDATE;
+
+  IF v_instanz IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Rolleninstanz nicht gefunden'
+    );
+  END IF;
+
+  -- For external registrations, verify the role is public
+  IF p_profile_id IS NULL AND v_instanz.sichtbarkeit != 'public' THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Rolle nicht öffentlich zugänglich'
+    );
+  END IF;
+
+  -- Count active registrations atomically (while row is locked)
+  SELECT COUNT(*) INTO v_active_count
+  FROM helfer_anmeldungen
+  WHERE rollen_instanz_id = p_rollen_instanz_id
+  AND status != 'abgelehnt';
+
+  -- Determine status based on capacity
+  IF v_active_count >= v_instanz.anzahl_benoetigt THEN
+    v_status := 'warteliste';
+    v_is_waitlist := true;
+  ELSE
+    v_status := 'angemeldet';
+    v_is_waitlist := false;
+  END IF;
+
+  -- Insert the registration
+  INSERT INTO helfer_anmeldungen (
+    rollen_instanz_id,
+    profile_id,
+    external_helper_id,
+    external_name,
+    external_email,
+    external_telefon,
+    status,
+    datenschutz_akzeptiert
+  ) VALUES (
+    p_rollen_instanz_id,
+    p_profile_id,
+    p_external_helper_id,
+    p_external_name,
+    p_external_email,
+    p_external_telefon,
+    v_status,
+    p_datenschutz_akzeptiert
+  )
+  RETURNING id, abmeldung_token INTO v_anmeldung_id, v_abmeldung_token;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'anmeldung_id', v_anmeldung_id,
+    'status', v_status,
+    'is_waitlist', v_is_waitlist,
+    'abmeldung_token', v_abmeldung_token
+  );
+
+EXCEPTION
+  WHEN unique_violation THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Bereits für diese Rolle angemeldet'
+    );
+  WHEN check_violation THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Ungültige Anmeldedaten'
+    );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION book_helfer_slot TO anon;
+GRANT EXECUTE ON FUNCTION book_helfer_slot TO authenticated;
+
+-- =============================================================================
+-- UPDATE FUNCTION: book_helfer_slots() - pass datenschutz_akzeptiert through
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION book_helfer_slots(
+  p_rollen_instanz_ids UUID[],
+  p_profile_id UUID DEFAULT NULL,
+  p_external_helper_id UUID DEFAULT NULL,
+  p_external_name TEXT DEFAULT NULL,
+  p_external_email TEXT DEFAULT NULL,
+  p_external_telefon TEXT DEFAULT NULL,
+  p_datenschutz_akzeptiert TIMESTAMPTZ DEFAULT NULL
+) RETURNS JSONB AS $$
+DECLARE
+  v_instanz_id UUID;
+  v_result JSONB;
+  v_results JSONB := '[]'::JSONB;
+  v_has_failure BOOLEAN := false;
+  v_sorted_ids UUID[];
+BEGIN
+  -- Validate input
+  IF array_length(p_rollen_instanz_ids, 1) IS NULL OR
+     array_length(p_rollen_instanz_ids, 1) = 0 THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Keine Rolleninstanzen angegeben'
+    );
+  END IF;
+
+  -- Sort IDs to prevent deadlocks (consistent lock ordering)
+  SELECT array_agg(id ORDER BY id) INTO v_sorted_ids
+  FROM unnest(p_rollen_instanz_ids) AS id;
+
+  -- Book each slot sequentially (within the same transaction)
+  FOREACH v_instanz_id IN ARRAY v_sorted_ids
+  LOOP
+    v_result := book_helfer_slot(
+      p_rollen_instanz_id := v_instanz_id,
+      p_profile_id := p_profile_id,
+      p_external_helper_id := p_external_helper_id,
+      p_external_name := p_external_name,
+      p_external_email := p_external_email,
+      p_external_telefon := p_external_telefon,
+      p_datenschutz_akzeptiert := p_datenschutz_akzeptiert
+    );
+
+    v_results := v_results || jsonb_build_array(v_result);
+
+    -- If a booking fails (not waitlist, but actual error), mark failure
+    IF NOT (v_result->>'success')::BOOLEAN THEN
+      v_has_failure := true;
+    END IF;
+  END LOOP;
+
+  -- If any booking failed, rollback the entire transaction
+  IF v_has_failure THEN
+    RAISE EXCEPTION 'multi_slot_booking_failed';
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'results', v_results
+  );
+
+EXCEPTION
+  WHEN OTHERS THEN
+    IF SQLERRM = 'multi_slot_booking_failed' THEN
+      RETURN jsonb_build_object(
+        'success', false,
+        'error', 'Einige Anmeldungen sind fehlgeschlagen',
+        'results', v_results
+      );
+    END IF;
+    RAISE;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION book_helfer_slots TO anon;
+GRANT EXECUTE ON FUNCTION book_helfer_slots TO authenticated;


### PR DESCRIPTION
## Summary
- **US-3**: Replace single name field with Vorname/Nachname, require Email, add DSGVO checkbox with link to `/datenschutz`. Server-side Zod validation via `externeHelferRegistrierungFormSchema` with field-level error display.
- **US-4**: All public registrations now always create an `externe_helfer_profile` via `find_or_create_external_helper` RPC (no more legacy name-only fallback).
- New migration adds `datenschutz_akzeptiert TIMESTAMPTZ` column to `helfer_anmeldungen` and updates `book_helfer_slot()`/`book_helfer_slots()` to accept and store the consent timestamp.

## Test plan
- [x] `npm run typecheck` — pass
- [x] `npm run lint` — 0 warnings/errors
- [x] `npm run test:run` — 96/96 pass (3 new: datenschutz rejection, invalid email, empty vorname)
- [ ] Manual: Public page shows Vorname/Nachname/Email as required, DSGVO checkbox blocks submit if unchecked
- [ ] Manual: Field-level validation errors display correctly on submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)