### PR TITLE
feat: batched confirmation email with cancellation links and ICS (US-8)

### DIFF
--- a/apps/web/components/helferliste/PublicEventView.tsx
+++ b/apps/web/components/helferliste/PublicEventView.tsx
@@ -8,6 +8,7 @@ import {
   generateICalEvent,
   icalToDataUrl,
   generateIcalFilename,
+  mergeICalEvents,
 } from '@/lib/utils/ical-generator'
 import type {
   PublicHelferEventData,
@@ -1076,27 +1077,3 @@ function triggerDownload(dataUrl: string, filename: string) {
   document.body.removeChild(link)
 }
 
-function mergeICalEvents(icsContents: string[]): string {
-  if (icsContents.length === 0) return ''
-  if (icsContents.length === 1) return icsContents[0]
-
-  // Extract VEVENT blocks from each ICS content and merge into one VCALENDAR
-  const vevents: string[] = []
-  let preamble = ''
-
-  for (let i = 0; i < icsContents.length; i++) {
-    const content = icsContents[i]
-    const veventMatch = content.match(
-      /BEGIN:VEVENT[\s\S]*?END:VEVENT/
-    )
-    if (veventMatch) {
-      vevents.push(veventMatch[0])
-    }
-    if (i === 0) {
-      // Use preamble from first event (VCALENDAR header + VTIMEZONE)
-      preamble = content.substring(0, content.indexOf('BEGIN:VEVENT'))
-    }
-  }
-
-  return preamble + vevents.join('\r\n') + '\r\nEND:VCALENDAR'
-}

--- a/apps/web/lib/actions/helferliste.test.ts
+++ b/apps/web/lib/actions/helferliste.test.ts
@@ -24,6 +24,7 @@ vi.mock('@/lib/supabase/server', () => ({
 vi.mock('./helferliste-notifications', () => ({
   notifyRegistrationConfirmed: vi.fn().mockResolvedValue({ success: true }),
   notifyStatusChange: vi.fn().mockResolvedValue({ success: true }),
+  notifyMultiRegistrationConfirmed: vi.fn().mockResolvedValue({ success: true }),
 }))
 
 // Import after mocking
@@ -624,6 +625,11 @@ describe('Helferliste Actions', () => {
           },
           error: null,
         })
+        // Mock: get_externe_helfer_dashboard_token
+        .mockResolvedValueOnce({
+          data: 'dashboard-token-uuid',
+          error: null,
+        })
 
       const result = await anmeldenPublicMulti(
         ['instanz-1', 'instanz-2'],
@@ -640,6 +646,17 @@ describe('Helferliste Actions', () => {
           p_rollen_instanz_ids: ['instanz-1', 'instanz-2'],
           p_external_helper_id: 'helper-uuid-1',
         })
+      )
+
+      // Verify batched notification is called once (not per-slot)
+      const { notifyMultiRegistrationConfirmed } = await import('./helferliste-notifications')
+      expect(notifyMultiRegistrationConfirmed).toHaveBeenCalledTimes(1)
+      expect(notifyMultiRegistrationConfirmed).toHaveBeenCalledWith(
+        ['anmeldung-1', 'anmeldung-2'],
+        'helper-uuid-1',
+        'dashboard-token-uuid',
+        'max@example.com',
+        'Max Muster'
       )
     })
 
@@ -798,6 +815,11 @@ describe('Helferliste Actions', () => {
               },
             ],
           },
+          error: null,
+        })
+        // Mock: get_externe_helfer_dashboard_token
+        .mockResolvedValueOnce({
+          data: 'dashboard-token-uuid',
           error: null,
         })
 

--- a/apps/web/lib/supabase/types.ts
+++ b/apps/web/lib/supabase/types.ts
@@ -1474,6 +1474,7 @@ export type ExterneHelferProfil = {
   nachname: string
   telefon: string | null
   notizen: string | null
+  dashboard_token: string               // Public dashboard access token (US-8)
   erstellt_am: string
   letzter_einsatz: string | null
 }

--- a/apps/web/lib/utils/ical-generator.ts
+++ b/apps/web/lib/utils/ical-generator.ts
@@ -203,6 +203,33 @@ export function icalToDataUrl(icalContent: string): string {
 }
 
 /**
+ * Merge multiple VCALENDAR contents into a single file
+ * Extracts VEVENT blocks from each and combines under one VCALENDAR header.
+ */
+export function mergeICalEvents(icsContents: string[]): string {
+  if (icsContents.length === 0) return ''
+  if (icsContents.length === 1) return icsContents[0]
+
+  const vevents: string[] = []
+  let preamble = ''
+
+  for (let i = 0; i < icsContents.length; i++) {
+    const content = icsContents[i]
+    const veventMatch = content.match(
+      /BEGIN:VEVENT[\s\S]*?END:VEVENT/
+    )
+    if (veventMatch) {
+      vevents.push(veventMatch[0])
+    }
+    if (i === 0) {
+      preamble = content.substring(0, content.indexOf('BEGIN:VEVENT'))
+    }
+  }
+
+  return preamble + vevents.join('\r\n') + '\r\nEND:VCALENDAR'
+}
+
+/**
  * Generate a filename for the iCal file
  */
 export function generateIcalFilename(veranstaltung: string, rolle: string): string {

--- a/supabase/migrations/20260212124613_externe_helfer_dashboard_token.sql
+++ b/supabase/migrations/20260212124613_externe_helfer_dashboard_token.sql
@@ -1,0 +1,41 @@
+-- =============================================================================
+-- Migration: dashboard_token for externe_helfer_profile
+-- Created: 2026-02-12
+-- Issue: US-8
+-- Description: Add dashboard_token to externe_helfer_profile for public
+--   dashboard access links in confirmation emails.
+--   - Add dashboard_token column with auto-generation
+--   - Backfill existing profiles
+--   - Add SECURITY DEFINER function for anon-safe lookup
+-- =============================================================================
+
+-- =============================================================================
+-- ADD COLUMN
+-- =============================================================================
+
+ALTER TABLE externe_helfer_profile
+  ADD COLUMN IF NOT EXISTS dashboard_token UUID DEFAULT gen_random_uuid() UNIQUE;
+
+-- Backfill existing profiles
+UPDATE externe_helfer_profile
+SET dashboard_token = gen_random_uuid()
+WHERE dashboard_token IS NULL;
+
+-- Make NOT NULL after backfill
+ALTER TABLE externe_helfer_profile
+  ALTER COLUMN dashboard_token SET NOT NULL;
+
+COMMENT ON COLUMN externe_helfer_profile.dashboard_token IS
+  'Token for public dashboard access. Used in /helfer/meine-einsaetze/[token] URL.';
+
+-- =============================================================================
+-- SECURITY DEFINER FUNCTION: get_externe_helfer_dashboard_token
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION get_externe_helfer_dashboard_token(p_helper_id UUID)
+RETURNS UUID AS $$
+  SELECT dashboard_token FROM externe_helfer_profile WHERE id = p_helper_id;
+$$ LANGUAGE sql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION get_externe_helfer_dashboard_token TO anon;
+GRANT EXECUTE ON FUNCTION get_externe_helfer_dashboard_token TO authenticated;


### PR DESCRIPTION
## Summary
- Replace per-slot notification loop with a single batched confirmation email after multi-shift booking
- Email includes shift table with per-shift status badges and cancellation links, dashboard link, coordinator contact info, and merged ICS calendar attachment for confirmed shifts
- Add `dashboard_token` column to `externe_helfer_profile` with SECURITY DEFINER RPC for anon-safe lookup
- Extract `mergeICalEvents()` from PublicEventView.tsx to shared `ical-generator.ts` utility for server-side reuse

## Test plan
- [x] `npm run typecheck` — pass
- [x] `npm run lint` — no warnings or errors
- [x] `npm run test:run` — 96/96 tests pass
- [ ] Manual: multi-slot booking sends ONE email with all shifts, cancellation links, dashboard link, ICS attachment

🤖 Generated with [Claude Code](https://claude.com/claude-code)