### PR TITLE
feat: cancellation deadline, waitlist auto-promotion, and emails (US-10)

### DIFF
--- a/apps/web/app/(public)/helfer/helferliste/abmeldung/[token]/actions.ts
+++ b/apps/web/app/(public)/helfer/helferliste/abmeldung/[token]/actions.ts
@@ -2,28 +2,41 @@
 
 import { revalidatePath } from 'next/cache'
 import { createClient } from '@/lib/supabase/server'
+import {
+  notifyCancellationConfirmed,
+  notifyWaitlistPromotion,
+} from '@/lib/actions/helferliste-notifications'
 
 /**
  * Cancel a helferliste registration using the abmeldung_token.
  * This is a public action - no authentication required.
- * Deletes the helfer_anmeldungen row (freeing the slot).
+ * Deletes the helfer_anmeldungen row, promotes waitlisted entry if applicable,
+ * and sends confirmation + promotion emails.
  */
 export async function cancelHelferlisteRegistration(
   token: string
 ): Promise<{ success: boolean; error?: string }> {
   const supabase = await createClient()
 
-  // Find the anmeldung by abmeldung_token
+  // 1. Fetch anmeldung with all needed data (before delete)
   const { data: anmeldung, error: fetchError } = await supabase
     .from('helfer_anmeldungen')
     .select(`
       id,
       status,
       rollen_instanz_id,
+      profile_id,
+      external_helper_id,
+      external_name,
+      external_email,
       rollen_instanz:helfer_rollen_instanzen(
         helfer_event_id,
-        helfer_event:helfer_events(datum_start)
-      )
+        zeitblock_start,
+        zeitblock_end,
+        template:helfer_rollen_templates(name),
+        helfer_event:helfer_events(name, datum_start, ort, abmeldung_frist)
+      ),
+      profile:profiles(email, display_name)
     `)
     .eq('abmeldung_token', token)
     .single()
@@ -32,26 +45,75 @@ export async function cancelHelferlisteRegistration(
     return { success: false, error: 'Anmeldung nicht gefunden oder Link ungültig' }
   }
 
-  // Check 6-hour rule
+  // 2. Extract nested data
   const rollenInstanz = anmeldung.rollen_instanz as unknown as {
     helfer_event_id: string
-    helfer_event: { datum_start: string } | null
+    zeitblock_start: string | null
+    zeitblock_end: string | null
+    template: { name: string } | null
+    helfer_event: {
+      name: string
+      datum_start: string
+      ort: string | null
+      abmeldung_frist: string | null
+    } | null
   } | null
 
-  if (rollenInstanz?.helfer_event?.datum_start) {
-    const eventStart = new Date(rollenInstanz.helfer_event.datum_start)
-    const now = new Date()
-    const hoursUntilEvent = (eventStart.getTime() - now.getTime()) / (1000 * 60 * 60)
+  const helferEvent = rollenInstanz?.helfer_event
 
-    if (hoursUntilEvent < 6) {
-      return {
-        success: false,
-        error: 'Die Veranstaltung beginnt in weniger als 6 Stunden. Eine Online-Abmeldung ist nicht mehr möglich.',
+  // 3. Check deadline (configurable abmeldung_frist, fallback to 6-hour rule)
+  if (helferEvent) {
+    const now = new Date()
+
+    if (helferEvent.abmeldung_frist) {
+      const frist = new Date(helferEvent.abmeldung_frist)
+      if (now > frist) {
+        return {
+          success: false,
+          error: 'Die Abmeldefrist für diese Veranstaltung ist abgelaufen. Eine Online-Abmeldung ist nicht mehr möglich.',
+        }
+      }
+    } else {
+      const eventStart = new Date(helferEvent.datum_start)
+      const hoursUntilEvent = (eventStart.getTime() - now.getTime()) / (1000 * 60 * 60)
+      if (hoursUntilEvent < 6) {
+        return {
+          success: false,
+          error: 'Die Veranstaltung beginnt in weniger als 6 Stunden. Eine Online-Abmeldung ist nicht mehr möglich.',
+        }
       }
     }
   }
 
-  // Delete the registration (frees the slot)
+  // 4. Resolve contact info BEFORE deleting the row
+  let recipientEmail: string | null = null
+  let recipientName = 'Helfer'
+
+  const profileData = anmeldung.profile as unknown as {
+    email: string
+    display_name: string
+  } | null
+
+  if (profileData?.email) {
+    recipientEmail = profileData.email
+    recipientName = profileData.display_name || 'Helfer'
+  } else if (anmeldung.external_helper_id) {
+    const { data: helper } = await supabase
+      .from('externe_helfer_profile')
+      .select('email, vorname, nachname')
+      .eq('id', anmeldung.external_helper_id)
+      .single()
+
+    if (helper?.email) {
+      recipientEmail = helper.email
+      recipientName = `${helper.vorname} ${helper.nachname}`
+    }
+  } else if (anmeldung.external_email) {
+    recipientEmail = anmeldung.external_email
+    recipientName = anmeldung.external_name || 'Helfer'
+  }
+
+  // 5. Delete the registration (frees the slot)
   const { error: deleteError } = await supabase
     .from('helfer_anmeldungen')
     .delete()
@@ -62,7 +124,36 @@ export async function cancelHelferlisteRegistration(
     return { success: false, error: 'Fehler beim Stornieren der Anmeldung' }
   }
 
-  // Revalidate paths
+  // 6. Waitlist auto-promotion (if a slot was freed by an active registration)
+  let promotedAnmeldungId: string | null = null
+  const wasActiveRegistration = anmeldung.status !== 'abgelehnt'
+
+  if (wasActiveRegistration && anmeldung.rollen_instanz_id) {
+    const { data: promotedId } = await supabase.rpc('promote_helfer_waitlist', {
+      p_rollen_instanz_id: anmeldung.rollen_instanz_id,
+    })
+    promotedAnmeldungId = (promotedId as string) || null
+  }
+
+  // 7. Fire-and-forget emails
+  if (recipientEmail && helferEvent) {
+    notifyCancellationConfirmed({
+      recipientEmail,
+      recipientName,
+      eventName: helferEvent.name,
+      eventDatumStart: helferEvent.datum_start,
+      eventOrt: helferEvent.ort,
+      rolleName: rollenInstanz?.template?.name || null,
+      zeitblockStart: rollenInstanz?.zeitblock_start || null,
+      zeitblockEnd: rollenInstanz?.zeitblock_end || null,
+    }).catch(console.error)
+  }
+
+  if (promotedAnmeldungId) {
+    notifyWaitlistPromotion(promotedAnmeldungId).catch(console.error)
+  }
+
+  // 8. Revalidate paths
   revalidatePath('/helferliste')
   if (rollenInstanz?.helfer_event_id) {
     revalidatePath(`/helferliste/${rollenInstanz.helfer_event_id}`)

--- a/apps/web/components/helferliste/HelferEventForm.tsx
+++ b/apps/web/components/helferliste/HelferEventForm.tsx
@@ -25,6 +25,9 @@ export function HelferEventForm({ event }: HelferEventFormProps) {
       ? new Date(event.datum_end).toISOString().slice(0, 16)
       : '',
     ort: event?.ort || '',
+    abmeldung_frist: event?.abmeldung_frist
+      ? new Date(event.abmeldung_frist).toISOString().slice(0, 16)
+      : '',
     veranstaltung_id: event?.veranstaltung_id || '',
   })
 
@@ -38,6 +41,9 @@ export function HelferEventForm({ event }: HelferEventFormProps) {
         ...formData,
         datum_start: new Date(formData.datum_start).toISOString(),
         datum_end: new Date(formData.datum_end).toISOString(),
+        abmeldung_frist: formData.abmeldung_frist
+          ? new Date(formData.abmeldung_frist).toISOString()
+          : null,
         veranstaltung_id: formData.veranstaltung_id || null,
       }
 
@@ -183,6 +189,27 @@ export function HelferEventForm({ event }: HelferEventFormProps) {
           className="mt-1 block w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-primary-500 focus:ring-2 focus:ring-primary-500"
           placeholder="z.B. Mehrzweckhalle Widen"
         />
+      </div>
+
+      <div>
+        <label
+          htmlFor="abmeldung_frist"
+          className="block text-sm font-medium text-gray-700"
+        >
+          Abmeldefrist
+        </label>
+        <input
+          type="datetime-local"
+          id="abmeldung_frist"
+          value={formData.abmeldung_frist}
+          onChange={(e) =>
+            setFormData({ ...formData, abmeldung_frist: e.target.value })
+          }
+          className="mt-1 block w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-primary-500 focus:ring-2 focus:ring-primary-500"
+        />
+        <p className="mt-1 text-xs text-gray-500">
+          Optional. Bis wann können sich Helfer abmelden? Standard: 6 Stunden vor Event-Beginn.
+        </p>
       </div>
 
       <div className="flex justify-end gap-3 border-t pt-4">

--- a/apps/web/lib/actions/helferliste.test.ts
+++ b/apps/web/lib/actions/helferliste.test.ts
@@ -25,6 +25,8 @@ vi.mock('./helferliste-notifications', () => ({
   notifyRegistrationConfirmed: vi.fn().mockResolvedValue({ success: true }),
   notifyStatusChange: vi.fn().mockResolvedValue({ success: true }),
   notifyMultiRegistrationConfirmed: vi.fn().mockResolvedValue({ success: true }),
+  notifyCancellationConfirmed: vi.fn().mockResolvedValue({ success: true }),
+  notifyWaitlistPromotion: vi.fn().mockResolvedValue({ success: true }),
 }))
 
 // Import after mocking

--- a/apps/web/lib/email/templates/helferliste.ts
+++ b/apps/web/lib/email/templates/helferliste.ts
@@ -385,3 +385,142 @@ BackstagePass - Theatergruppe Widen
 
   return { subject, html, text }
 }
+
+/**
+ * Email: Cancellation confirmation
+ * Sent to the helper after they cancel their registration.
+ */
+export function cancellationConfirmationEmail(
+  recipientName: string,
+  event: EventInfo
+): { subject: string; html: string; text: string } {
+  const subject = `Abmeldung bestätigt: ${event.name}`
+
+  const html = `
+    <!DOCTYPE html>
+    <html>
+    <head><style>${baseStyles}</style></head>
+    <body>
+      <div class="container">
+        <div class="header">
+          <h1>BackstagePass</h1>
+        </div>
+        <div class="content">
+          <p>Hallo ${recipientName},</p>
+          <p>Deine Anmeldung wurde erfolgreich storniert:</p>
+
+          <div class="info-box">
+            <h3 style="margin-top: 0;">${event.name}</h3>
+            <p><strong>Datum:</strong> ${event.datum}</p>
+            ${event.ort ? `<p><strong>Ort:</strong> ${event.ort}</p>` : ''}
+            ${event.rolle ? `<p><strong>Rolle:</strong> ${event.rolle}</p>` : ''}
+            ${event.zeitblock ? `<p><strong>Zeit:</strong> ${event.zeitblock}</p>` : ''}
+          </div>
+
+          <p>Danke, dass du uns rechtzeitig Bescheid gegeben hast. So können wir den Platz an jemand anderen vergeben.</p>
+        </div>
+        <div class="footer">
+          <p>Diese E-Mail wurde automatisch von BackstagePass gesendet.</p>
+          <p>Theatergruppe Widen</p>
+        </div>
+      </div>
+    </body>
+    </html>
+  `
+
+  const text = `
+Hallo ${recipientName},
+
+Deine Anmeldung wurde erfolgreich storniert:
+
+Event: ${event.name}
+Datum: ${event.datum}
+${event.ort ? `Ort: ${event.ort}` : ''}
+${event.rolle ? `Rolle: ${event.rolle}` : ''}
+${event.zeitblock ? `Zeit: ${event.zeitblock}` : ''}
+
+Danke, dass du uns rechtzeitig Bescheid gegeben hast.
+
+--
+BackstagePass - Theatergruppe Widen
+  `
+
+  return { subject, html, text }
+}
+
+/**
+ * Email: Waitlist promotion notification
+ * Sent when a helper is auto-promoted from warteliste to angemeldet.
+ */
+export function waitlistPromotionEmail(
+  recipientName: string,
+  event: EventInfo,
+  abmeldungLink?: string
+): { subject: string; html: string; text: string } {
+  const subject = `Platz frei geworden: ${event.name}`
+
+  const html = `
+    <!DOCTYPE html>
+    <html>
+    <head><style>${baseStyles}</style></head>
+    <body>
+      <div class="container">
+        <div class="header">
+          <h1>BackstagePass</h1>
+        </div>
+        <div class="content">
+          <p>Hallo ${recipientName},</p>
+          <p>Es ist ein Platz frei geworden! Deine Anmeldung wurde von der Warteliste bestätigt:</p>
+
+          <div class="info-box">
+            <h3 style="margin-top: 0;">${event.name}</h3>
+            <p><strong>Datum:</strong> ${event.datum}</p>
+            ${event.ort ? `<p><strong>Ort:</strong> ${event.ort}</p>` : ''}
+            ${event.rolle ? `<p><strong>Rolle:</strong> ${event.rolle}</p>` : ''}
+            ${event.zeitblock ? `<p><strong>Zeit:</strong> ${event.zeitblock}</p>` : ''}
+            <p>
+              <span class="status-badge status-angemeldet">
+                Angemeldet
+              </span>
+            </p>
+          </div>
+
+          <p>Wir freuen uns auf dich!</p>
+
+          ${abmeldungLink ? `
+          <p style="font-size: 13px; color: #666;">
+            Falls du doch nicht teilnehmen kannst, kannst du dich hier abmelden:
+            <a href="${abmeldungLink}" style="color: #dc2626;">Anmeldung stornieren</a>
+          </p>
+          ` : ''}
+        </div>
+        <div class="footer">
+          <p>Diese E-Mail wurde automatisch von BackstagePass gesendet.</p>
+          <p>Theatergruppe Widen</p>
+        </div>
+      </div>
+    </body>
+    </html>
+  `
+
+  const text = `
+Hallo ${recipientName},
+
+Es ist ein Platz frei geworden! Deine Anmeldung wurde von der Warteliste bestätigt:
+
+Event: ${event.name}
+Datum: ${event.datum}
+${event.ort ? `Ort: ${event.ort}` : ''}
+${event.rolle ? `Rolle: ${event.rolle}` : ''}
+${event.zeitblock ? `Zeit: ${event.zeitblock}` : ''}
+Status: Angemeldet
+
+Wir freuen uns auf dich!
+${abmeldungLink ? `\nFalls du doch nicht teilnehmen kannst: ${abmeldungLink}` : ''}
+
+--
+BackstagePass - Theatergruppe Widen
+  `
+
+  return { subject, html, text }
+}

--- a/apps/web/lib/supabase/types.ts
+++ b/apps/web/lib/supabase/types.ts
@@ -1577,6 +1577,7 @@ export type HelferEvent = {
   datum_start: string
   datum_end: string
   ort: string | null
+  abmeldung_frist: string | null         // Per-event cancellation deadline (US-10)
   public_token: string
   max_anmeldungen_pro_helfer: number | null
   created_at: string
@@ -1585,9 +1586,10 @@ export type HelferEvent = {
 
 export type HelferEventInsert = Omit<
   HelferEvent,
-  'id' | 'public_token' | 'max_anmeldungen_pro_helfer' | 'created_at' | 'updated_at'
+  'id' | 'public_token' | 'max_anmeldungen_pro_helfer' | 'abmeldung_frist' | 'created_at' | 'updated_at'
 > & {
   max_anmeldungen_pro_helfer?: number | null
+  abmeldung_frist?: string | null
 }
 export type HelferEventUpdate = Partial<HelferEventInsert>
 

--- a/apps/web/tests/mocks/supabase.ts
+++ b/apps/web/tests/mocks/supabase.ts
@@ -69,6 +69,7 @@ export const mockHelferEvent = {
   datum_start: '2026-03-01T18:00:00Z',
   datum_end: '2026-03-01T22:00:00Z',
   ort: 'Gemeindesaal',
+  abmeldung_frist: null,
   status: 'aktiv' as const,
   public_token: 'abc123',
   created_at: '2026-01-01T00:00:00Z',

--- a/supabase/migrations/20260212141039_helfer_event_abmeldung_frist.sql
+++ b/supabase/migrations/20260212141039_helfer_event_abmeldung_frist.sql
@@ -1,0 +1,63 @@
+-- =============================================================================
+-- US-10: Configurable cancellation deadline + waitlist auto-promotion
+-- =============================================================================
+
+-- Configurable cancellation deadline per helfer_event.
+-- If NULL, the default 6-hour-before-event rule applies.
+ALTER TABLE helfer_events
+  ADD COLUMN IF NOT EXISTS abmeldung_frist TIMESTAMPTZ DEFAULT NULL;
+
+-- -----------------------------------------------------------------------------
+-- Atomic waitlist promotion function (SECURITY DEFINER for anon access).
+-- Called after a cancellation frees a slot on a rollen_instanz.
+-- Returns the promoted anmeldung ID, or NULL if no promotion happened.
+-- Uses FOR UPDATE SKIP LOCKED to prevent race conditions.
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION promote_helfer_waitlist(p_rollen_instanz_id UUID)
+RETURNS UUID AS $$
+DECLARE
+  v_anzahl INTEGER;
+  v_active INTEGER;
+  v_promoted_id UUID;
+BEGIN
+  -- Lock the rollen_instanz row to prevent concurrent promotions
+  SELECT anzahl_benoetigt INTO v_anzahl
+  FROM helfer_rollen_instanzen
+  WHERE id = p_rollen_instanz_id
+  FOR UPDATE;
+
+  IF v_anzahl IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  -- Count active (non-waitlist, non-rejected) registrations
+  SELECT COUNT(*) INTO v_active
+  FROM helfer_anmeldungen
+  WHERE rollen_instanz_id = p_rollen_instanz_id
+    AND status NOT IN ('abgelehnt', 'warteliste');
+
+  -- Still at capacity?
+  IF v_active >= v_anzahl THEN
+    RETURN NULL;
+  END IF;
+
+  -- Promote the oldest waitlisted entry
+  UPDATE helfer_anmeldungen
+  SET status = 'angemeldet'
+  WHERE id = (
+    SELECT id
+    FROM helfer_anmeldungen
+    WHERE rollen_instanz_id = p_rollen_instanz_id
+      AND status = 'warteliste'
+    ORDER BY created_at ASC
+    LIMIT 1
+    FOR UPDATE SKIP LOCKED
+  )
+  RETURNING id INTO v_promoted_id;
+
+  RETURN v_promoted_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION promote_helfer_waitlist TO anon;
+GRANT EXECUTE ON FUNCTION promote_helfer_waitlist TO authenticated;


### PR DESCRIPTION
## Summary
- Add configurable `abmeldung_frist` column to `helfer_events` for per-event cancellation deadlines (falls back to default 6-hour rule when not set)
- Add `promote_helfer_waitlist()` SECURITY DEFINER RPC for atomic, race-safe waitlist auto-promotion when a cancellation frees a slot
- Send cancellation confirmation email to the person who cancelled and waitlist promotion email to the auto-promoted helper
- Add admin UI field for deadline configuration in HelferEventForm

## Test plan
- [x] `npm run typecheck` — pass
- [x] `npm run lint` — no warnings or errors
- [x] `npm run test:run` — 96/96 tests pass
- [ ] Manual: cancel via token link, verify confirmation email + waitlisted entry auto-promoted + promotion email sent
- [ ] Manual: set custom `abmeldung_frist`, verify deadline enforced in both page and action

🤖 Generated with [Claude Code](https://claude.com/claude-code)