### PR TITLE
feat: replace Resend with Nodemailer SMTP (#262)

### DIFF
--- a/apps/web/.env
+++ b/apps/web/.env
@@ -10,3 +10,10 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY="sb_publishable_H1OXl6dX8GvZQNhSxp5xeg_h1pfRLfn"
 # GitHub (für In-App Feedback, nur serverseitig)
 # GITHUB_TOKEN=your-github-personal-access-token
 # GITHUB_REPO=trismus/BackstagePass
+
+# Email (SMTP) - z.B. Gmail mit App-Password
+# SMTP_HOST=smtp.gmail.com
+# SMTP_PORT=587
+# SMTP_USER=your-email@gmail.com
+# SMTP_PASS=your-app-password
+# EMAIL_FROM_ADDRESS="BackstagePass <your-email@gmail.com>"

--- a/apps/web/lib/email/index.ts
+++ b/apps/web/lib/email/index.ts
@@ -1,72 +1,13 @@
 /**
  * Email Service for BackstagePass
  *
- * Uses Resend for transactional emails.
- * Set RESEND_API_KEY in environment variables.
+ * Uses Nodemailer for SMTP-based transactional emails (e.g. Gmail).
+ * Set SMTP_HOST, SMTP_USER, SMTP_PASS in environment variables.
  */
 
-export interface EmailOptions {
-  to: string | string[]
-  subject: string
-  html: string
-  text?: string
-  replyTo?: string
-}
-
-export interface EmailResult {
-  success: boolean
-  error?: string
-  id?: string
-}
-
-/**
- * Send an email using Resend API
- */
-export async function sendEmail(options: EmailOptions): Promise<EmailResult> {
-  const apiKey = process.env.RESEND_API_KEY
-
-  if (!apiKey) {
-    console.warn('RESEND_API_KEY not set - email not sent')
-    return { success: false, error: 'Email service not configured' }
-  }
-
-  const fromEmail = process.env.EMAIL_FROM || 'noreply@backstagepass.app'
-  const fromName = process.env.EMAIL_FROM_NAME || 'BackstagePass'
-
-  try {
-    const response = await fetch('https://api.resend.com/emails', {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        from: `${fromName} <${fromEmail}>`,
-        to: Array.isArray(options.to) ? options.to : [options.to],
-        subject: options.subject,
-        html: options.html,
-        text: options.text,
-        reply_to: options.replyTo,
-      }),
-    })
-
-    if (!response.ok) {
-      const error = await response.text()
-      console.error('Email send error:', error)
-      return { success: false, error: 'Failed to send email' }
-    }
-
-    const data = await response.json()
-    return { success: true, id: data.id }
-  } catch (error) {
-    console.error('Email send exception:', error)
-    return { success: false, error: 'Email service error' }
-  }
-}
-
-/**
- * Check if email service is configured
- */
-export function isEmailConfigured(): boolean {
-  return !!process.env.RESEND_API_KEY
-}
+export {
+  sendEmail,
+  sendEmailWithRetry,
+  isEmailServiceConfigured,
+  getEmailServiceStatus,
+} from './client'

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -22,16 +22,17 @@
         "jspdf-autotable": "^5.0.7",
         "lucide-react": "^0.563.0",
         "next": "^15.1.0",
+        "nodemailer": "^8.0.1",
         "papaparse": "^5.5.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "resend": "^6.9.1",
         "xlsx": "^0.18.5",
         "zod": "^4.3.6"
       },
       "devDependencies": {
         "@playwright/test": "^1.50.0",
         "@types/node": "^22.0.0",
+        "@types/nodemailer": "^7.0.9",
         "@types/papaparse": "^5.5.2",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -767,7 +768,6 @@
       "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-6.1.20.tgz",
       "integrity": "sha512-1cukXLlePFiJ8YKXn/4tMKsy0etxYLCkXk8nUCFi11nRONF2Ba2CD5b21/ovtOO2tL6afTJfwmc1ed3HG7eB1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "preact": "~10.12.1"
       }
@@ -1639,7 +1639,6 @@
       "integrity": "sha512-6LdVIUERWxQMmUSSQi0I53GgCBYgM2RpGngCPY7hSeju+VrKjq3lvs7HpJoPbDiY5QM5EYRtRX5fvrinnMAz3w==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.58.1"
       },
@@ -2014,25 +2013,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@selderee/plugin-htmlparser2": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
-      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "domhandler": "^5.0.3",
-        "selderee": "^0.11.0"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/killymxi"
-      }
-    },
-    "node_modules/@stablelib/base64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
-      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
-      "license": "MIT"
-    },
     "node_modules/@supabase/auth-js": {
       "version": "2.91.1",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.91.1.tgz",
@@ -2115,7 +2095,6 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.91.1.tgz",
       "integrity": "sha512-57Fb4s5nfLn5ed2a1rPtl+LI1Wbtms8MS4qcUa0w6luaStBlFhmSeD2TLBgJWdMIupWRF6iFTH4QTrO2+pG/ZQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.91.1",
         "@supabase/functions-js": "2.91.1",
@@ -2201,6 +2180,16 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/nodemailer": {
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-7.0.9.tgz",
+      "integrity": "sha512-vI8oF1M+8JvQhsId0Pc38BdUP2evenIIys7c7p+9OZXSPOH5c1dyINP1jT8xQ2xPuBUXmIC87s+91IZMDjH8Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/pako": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
@@ -2236,7 +2225,6 @@
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2312,7 +2300,6 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -2942,24 +2929,12 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@zone-eu/mailsplit": {
-      "version": "5.4.8",
-      "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.8.tgz",
-      "integrity": "sha512-eEyACj4JZ7sjzRvy26QhLgKEMWwQbsw1+QZnlLX+/gihcNH07lVPOcnwf5U6UAL7gkc//J3jVd76o/WS+taUiA==",
-      "license": "(MIT OR EUPL-1.1+)",
-      "dependencies": {
-        "libbase64": "1.3.0",
-        "libmime": "5.3.7",
-        "libqp": "2.1.1"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3440,7 +3415,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3896,15 +3870,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/deepmerge": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -3978,47 +3943,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
     "node_modules/dompurify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
@@ -4027,20 +3951,6 @@
       "optional": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
-      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dunder-proto": {
@@ -4078,27 +3988,6 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/encoding-japanese": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/encoding-japanese/-/encoding-japanese-2.2.0.tgz",
-      "integrity": "sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.1",
@@ -4355,7 +4244,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4529,7 +4417,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4857,12 +4744,6 @@
         "iobuffer": "^5.3.2",
         "pako": "^2.1.0"
       }
-    },
-    "node_modules/fast-sha256": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
-      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
-      "license": "Unlicense"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -5333,37 +5214,12 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "license": "MIT",
-      "bin": {
-        "he": "bin/he"
-      }
-    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/html-to-text": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
-      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
-      "license": "MIT",
-      "dependencies": {
-        "@selderee/plugin-htmlparser2": "^0.11.0",
-        "deepmerge": "^4.3.1",
-        "dom-serializer": "^2.0.0",
-        "htmlparser2": "^8.0.2",
-        "selderee": "^0.11.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
     },
     "node_modules/html2canvas": {
       "version": "1.4.1",
@@ -5379,31 +5235,11 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/htmlparser2": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "entities": "^4.4.0"
-      }
-    },
     "node_modules/ical.js": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-1.5.0.tgz",
       "integrity": "sha512-7ZxMkogUkkaCx810yp0ZGKvq1ZpRgJeornPttpoxe6nYZ3NLesZe1wWMXDdwTkj/b5NtXT+Y16Aakph/ao98ZQ==",
-      "license": "MPL-2.0",
-      "peer": true
+      "license": "MPL-2.0"
     },
     "node_modules/iceberg-js": {
       "version": "0.8.1",
@@ -5412,22 +5248,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -6021,7 +5841,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -6085,7 +5904,6 @@
       "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.1.0.tgz",
       "integrity": "sha512-xd1d/XRkwqnsq6FP3zH1Q+Ejqn2ULIJeDZ+FTKpaabVpZREjsJKRJwuokTNgdqOU+fl55KgbvgZ1pRTSWCP2kQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "fast-png": "^6.2.0",
@@ -6153,15 +5971,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/leac": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
-      "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://ko-fi.com/killymxi"
-      }
-    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -6175,42 +5984,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/libbase64": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-1.3.0.tgz",
-      "integrity": "sha512-GgOXd0Eo6phYgh0DJtjQ2tO8dc0IVINtZJeARPeiIJqge+HdsWSuaDTe8ztQ7j/cONByDZ3zeB325AHiv5O0dg==",
-      "license": "MIT"
-    },
-    "node_modules/libmime": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.3.7.tgz",
-      "integrity": "sha512-FlDb3Wtha8P01kTL3P9M+ZDNDWPKPmKHWaU/cG/lg5pfuAwdflVpZE+wm9m7pKmC5ww6s+zTxBKS1p6yl3KpSw==",
-      "license": "MIT",
-      "dependencies": {
-        "encoding-japanese": "2.2.0",
-        "iconv-lite": "0.6.3",
-        "libbase64": "1.3.0",
-        "libqp": "2.1.1"
-      }
-    },
-    "node_modules/libmime/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/libqp": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/libqp/-/libqp-2.1.1.tgz",
-      "integrity": "sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow==",
-      "license": "MIT"
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -6231,15 +6004,6 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-      "license": "MIT",
-      "dependencies": {
-        "uc.micro": "^2.0.0"
-      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -6320,24 +6084,6 @@
         "@babel/parser": "^7.25.4",
         "@babel/types": "^7.25.4",
         "source-map-js": "^1.2.0"
-      }
-    },
-    "node_modules/mailparser": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-3.9.1.tgz",
-      "integrity": "sha512-6vHZcco3fWsDMkf4Vz9iAfxvwrKNGbHx0dV1RKVphQ/zaNY34Buc7D37LSa09jeSeybWzYcTPjhiZFxzVRJedA==",
-      "license": "MIT",
-      "dependencies": {
-        "@zone-eu/mailsplit": "5.4.8",
-        "encoding-japanese": "2.2.0",
-        "he": "1.2.0",
-        "html-to-text": "9.0.5",
-        "iconv-lite": "0.7.0",
-        "libmime": "5.3.7",
-        "linkify-it": "5.0.0",
-        "nodemailer": "7.0.11",
-        "punycode.js": "2.3.1",
-        "tlds": "1.261.0"
       }
     },
     "node_modules/make-dir": {
@@ -6571,9 +6317,9 @@
       "license": "MIT"
     },
     "node_modules/nodemailer": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.11.tgz",
-      "integrity": "sha512-gnXhNRE0FNhD7wPSCGhdNh46Hs6nm+uTyg+Kq0cZukNQiYdnCsoQjodNP9BQVG9XrcK/v6/MgpAPBUFyzh9pvw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.1.tgz",
+      "integrity": "sha512-5kcldIXmaEjZcHR6F28IKGSgpmZHaF1IXLWFTG+Xh3S+Cce4MiakLtWY+PlBU69fLbRa8HlaGIrC/QolUpHkhg==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
@@ -6822,19 +6568,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/parseley": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
-      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
-      "license": "MIT",
-      "dependencies": {
-        "leac": "^0.6.0",
-        "peberminta": "^0.9.0"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/killymxi"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6894,15 +6627,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14.16"
-      }
-    },
-    "node_modules/peberminta": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
-      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/performance-now": {
@@ -6987,7 +6711,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7028,7 +6751,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7198,7 +6920,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7318,15 +7039,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/punycode.js": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -7363,7 +7075,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7373,7 +7084,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7460,27 +7170,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/resend": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/resend/-/resend-6.9.1.tgz",
-      "integrity": "sha512-jFY3qPP2cith1npRXvS7PVdnhbR1CcuzHg65ty5Elv55GKiXhe+nItXuzzoOlKeYJez1iJAo2+8f6ae8sCj0iA==",
-      "license": "MIT",
-      "dependencies": {
-        "mailparser": "3.9.1",
-        "svix": "1.84.1"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@react-email/render": "*"
-      },
-      "peerDependenciesMeta": {
-        "@react-email/render": {
-          "optional": true
-        }
       }
     },
     "node_modules/resolve": {
@@ -7669,29 +7358,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
-    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
-    },
-    "node_modules/selderee": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
-      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
-      "license": "MIT",
-      "dependencies": {
-        "parseley": "^0.12.0"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/killymxi"
-      }
     },
     "node_modules/semver": {
       "version": "7.7.3",
@@ -7962,16 +7633,6 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.14"
-      }
-    },
-    "node_modules/standardwebhooks": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
-      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
-      "license": "MIT",
-      "dependencies": {
-        "@stablelib/base64": "^1.0.0",
-        "fast-sha256": "^1.3.0"
       }
     },
     "node_modules/std-env": {
@@ -8337,16 +7998,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/svix": {
-      "version": "1.84.1",
-      "resolved": "https://registry.npmjs.org/svix/-/svix-1.84.1.tgz",
-      "integrity": "sha512-K8DPPSZaW/XqXiz1kEyzSHYgmGLnhB43nQCMeKjWGCUpLIpAMMM8kx3rVVOSm6Bo6EHyK1RQLPT4R06skM/MlQ==",
-      "license": "MIT",
-      "dependencies": {
-        "standardwebhooks": "1.0.0",
-        "uuid": "^10.0.0"
-      }
-    },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
@@ -8544,7 +8195,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8580,15 +8230,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tlds": {
-      "version": "1.261.0",
-      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.261.0.tgz",
-      "integrity": "sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==",
-      "license": "MIT",
-      "bin": {
-        "tlds": "bin.js"
       }
     },
     "node_modules/to-regex-range": {
@@ -8740,7 +8381,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8748,12 +8388,6 @@
       "engines": {
         "node": ">=14.17"
       }
-    },
-    "node_modules/uc.micro": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "license": "MIT"
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
@@ -8873,26 +8507,12 @@
         "base64-arraybuffer": "^1.0.2"
       }
     },
-    "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/vite": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9009,7 +8629,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9023,7 +8642,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -34,16 +34,17 @@
     "jspdf-autotable": "^5.0.7",
     "lucide-react": "^0.563.0",
     "next": "^15.1.0",
+    "nodemailer": "^8.0.1",
     "papaparse": "^5.5.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "resend": "^6.9.1",
     "xlsx": "^0.18.5",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.0",
     "@types/node": "^22.0.0",
+    "@types/nodemailer": "^7.0.9",
     "@types/papaparse": "^5.5.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/apps/web/tests/setup.ts
+++ b/apps/web/tests/setup.ts
@@ -7,7 +7,9 @@ import { vi } from 'vitest'
 // Mock environment variables
 process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co'
 process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'test-anon-key'
-process.env.RESEND_API_KEY = 'test-resend-key'
+process.env.SMTP_HOST = 'smtp.test.local'
+process.env.SMTP_USER = 'test@test.local'
+process.env.SMTP_PASS = 'test-password'
 process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000'
 
 // Mock next/cache


### PR DESCRIPTION
## Summary
- Replace `resend` package with `nodemailer` + `@types/nodemailer` for SMTP-based email sending (e.g. Gmail with App-Password)
- Rewrite `lib/email/client.ts` to use Nodemailer transporter instead of Resend SDK — same exported interface (`sendEmail`, `sendEmailWithRetry`, `isEmailServiceConfigured`, `getEmailServiceStatus`)
- Clean up `lib/email/index.ts` to re-export from client (was a duplicate Resend REST implementation, unused)
- Add SMTP env variables to `.env` template (`SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`)
- Update test setup to use SMTP env vars instead of `RESEND_API_KEY`

## Why
Resend requires a paid plan for custom domains and has no free API key configured. Gmail SMTP is free and sufficient for TGW's volume (~50-100 helpers per event).

## What stays the same
All existing email consumers are **untouched** — `email-sender.ts`, `helferliste-notifications.ts`, `thank-you-emails.ts`, `probe-reminders.ts`, templates, logging, cron jobs. They all call `sendEmail()`/`sendEmailWithRetry()` which now routes through Nodemailer instead of Resend.

## Gmail Setup (for deployment)
1. Create or use a Gmail account (e.g. `backstagepass@tgw.ch` or a `@gmail.com`)
2. Enable 2FA on the Google account
3. Generate an [App Password](https://myaccount.google.com/apppasswords)
4. Set env vars:
   ```
   SMTP_HOST=smtp.gmail.com
   SMTP_PORT=587
   SMTP_USER=your-email@gmail.com
   SMTP_PASS=your-app-password
   EMAIL_FROM_ADDRESS="BackstagePass <your-email@gmail.com>"
   ```

## Test plan
- [x] `npm run typecheck` — pass
- [x] `npm run lint` — pass
- [x] `npm run test:run` — 96/96 tests pass
- [ ] Manual: configure Gmail SMTP in `.env.local` and trigger a test email

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)