### PR TITLE
feat: personal volunteer dashboard (US-9)

### DIFF
--- a/apps/web/app/(public)/helfer/meine-einsaetze/[token]/page.tsx
+++ b/apps/web/app/(public)/helfer/meine-einsaetze/[token]/page.tsx
@@ -1,0 +1,29 @@
+import { notFound } from 'next/navigation'
+import type { Metadata } from 'next'
+import { getHelferDashboardData } from '@/lib/actions/helfer-dashboard'
+import { HelferDashboardView } from '@/components/helfer-dashboard/HelferDashboardView'
+
+export const metadata: Metadata = {
+  title: 'Meine Einsätze',
+  description: 'Übersicht deiner Helfer-Einsätze',
+  robots: { index: false },
+}
+
+export default async function HelferDashboardPage({
+  params,
+}: {
+  params: Promise<{ token: string }>
+}) {
+  const { token } = await params
+  const data = await getHelferDashboardData(token)
+
+  if (!data) {
+    notFound()
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8">
+      <HelferDashboardView data={data} />
+    </div>
+  )
+}

--- a/apps/web/components/helfer-dashboard/HelferDashboardView.tsx
+++ b/apps/web/components/helfer-dashboard/HelferDashboardView.tsx
@@ -1,0 +1,154 @@
+'use client'
+
+import { useState } from 'react'
+import { Card, CardContent } from '@/components/ui'
+import { ShiftCard } from './ShiftCard'
+import type {
+  HelferDashboardData,
+  HelferDashboardAnmeldung,
+} from '@/lib/supabase/types'
+
+interface HelferDashboardViewProps {
+  data: HelferDashboardData
+}
+
+function canCancelAnmeldung(anmeldung: HelferDashboardAnmeldung): boolean {
+  if (!anmeldung.abmeldung_token) return false
+
+  const now = new Date()
+
+  if (anmeldung.event_abmeldung_frist) {
+    return now <= new Date(anmeldung.event_abmeldung_frist)
+  }
+
+  // Fallback: 6 hours before event start
+  const eventStart = new Date(anmeldung.event_datum_start)
+  const hoursUntilEvent =
+    (eventStart.getTime() - now.getTime()) / (1000 * 60 * 60)
+  return hoursUntilEvent >= 6
+}
+
+export function HelferDashboardView({ data }: HelferDashboardViewProps) {
+  const [showPast, setShowPast] = useState(false)
+
+  const now = new Date()
+  const upcoming = data.anmeldungen.filter(
+    (a) => new Date(a.event_datum_start) >= now
+  )
+  const past = data.anmeldungen.filter(
+    (a) => new Date(a.event_datum_start) < now
+  )
+
+  return (
+    <div className="space-y-8">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-bold text-neutral-900">Meine Einsätze</h1>
+        <p className="mt-1 text-neutral-600">
+          Übersicht deiner Helfer-Anmeldungen
+        </p>
+      </div>
+
+      {/* Helper Info */}
+      <Card>
+        <CardContent className="p-4">
+          <p className="text-sm text-neutral-600">Angemeldet als</p>
+          <p className="font-semibold text-neutral-900">
+            {data.helper.vorname} {data.helper.nachname}
+          </p>
+          <p className="text-sm text-neutral-500">{data.helper.email}</p>
+        </CardContent>
+      </Card>
+
+      {/* Upcoming Shifts */}
+      <section>
+        <h2 className="mb-4 text-lg font-semibold text-neutral-900">
+          Kommende Einsätze
+          {upcoming.length > 0 && (
+            <span className="ml-2 text-sm font-normal text-neutral-500">
+              ({upcoming.length})
+            </span>
+          )}
+        </h2>
+        {upcoming.length === 0 ? (
+          <Card>
+            <CardContent className="p-6 text-center">
+              <p className="text-neutral-500">
+                Du hast keine kommenden Einsätze.
+              </p>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="space-y-3">
+            {upcoming.map((anmeldung) => (
+              <ShiftCard
+                key={anmeldung.id}
+                anmeldung={anmeldung}
+                canCancel={canCancelAnmeldung(anmeldung)}
+                isPast={false}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Past Shifts */}
+      {past.length > 0 && (
+        <section>
+          <button
+            type="button"
+            onClick={() => setShowPast(!showPast)}
+            className="mb-4 flex items-center gap-2 text-lg font-semibold text-neutral-900"
+          >
+            <svg
+              className={`h-5 w-5 text-neutral-500 transition-transform duration-200 ${
+                showPast ? 'rotate-180' : ''
+              }`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 9l-7 7-7-7"
+              />
+            </svg>
+            Vergangene Einsätze
+            <span className="text-sm font-normal text-neutral-500">
+              ({past.length})
+            </span>
+          </button>
+          {showPast && (
+            <div className="space-y-3">
+              {past.map((anmeldung) => (
+                <ShiftCard
+                  key={anmeldung.id}
+                  anmeldung={anmeldung}
+                  canCancel={false}
+                  isPast={true}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      )}
+
+      {/* Empty state when no registrations at all */}
+      {data.anmeldungen.length === 0 && (
+        <Card>
+          <CardContent className="p-8 text-center">
+            <p className="text-lg font-medium text-neutral-700">
+              Noch keine Einsätze vorhanden
+            </p>
+            <p className="mt-1 text-sm text-neutral-500">
+              Sobald du dich für einen Helfer-Einsatz anmeldest, siehst du hier
+              deine Übersicht.
+            </p>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}

--- a/apps/web/components/helfer-dashboard/ShiftCard.tsx
+++ b/apps/web/components/helfer-dashboard/ShiftCard.tsx
@@ -1,0 +1,89 @@
+import Link from 'next/link'
+import { Card, CardContent } from '@/components/ui'
+import { StatusBadge } from '@/components/helferliste/StatusBadge'
+import type { HelferDashboardAnmeldung } from '@/lib/supabase/types'
+
+interface ShiftCardProps {
+  anmeldung: HelferDashboardAnmeldung
+  canCancel: boolean
+  isPast: boolean
+}
+
+function formatDate(dateStr: string) {
+  return new Date(dateStr).toLocaleDateString('de-CH', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  })
+}
+
+function formatTime(dateStr: string) {
+  return new Date(dateStr).toLocaleTimeString('de-CH', {
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+export function ShiftCard({ anmeldung, canCancel, isPast }: ShiftCardProps) {
+  return (
+    <Card>
+      <CardContent className="p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <h3 className="font-semibold text-neutral-900">
+              {anmeldung.event_name}
+            </h3>
+            <p className="text-sm text-neutral-600">
+              {formatDate(anmeldung.event_datum_start)}
+            </p>
+            {anmeldung.event_ort && (
+              <p className="text-sm text-neutral-500">{anmeldung.event_ort}</p>
+            )}
+          </div>
+          <StatusBadge status={anmeldung.status} />
+        </div>
+
+        <div className="mt-3 border-t border-neutral-100 pt-3">
+          <p className="text-sm">
+            <span className="text-neutral-600">Rolle: </span>
+            <span className="font-medium">{anmeldung.rolle_name}</span>
+          </p>
+          {anmeldung.zeitblock_start && (
+            <p className="text-sm">
+              <span className="text-neutral-600">Zeit: </span>
+              <span className="font-medium">
+                {formatTime(anmeldung.zeitblock_start)}
+                {anmeldung.zeitblock_end &&
+                  ` - ${formatTime(anmeldung.zeitblock_end)}`}
+                {' Uhr'}
+              </span>
+            </p>
+          )}
+        </div>
+
+        {!isPast && (
+          <div className="mt-3 flex flex-wrap gap-2 border-t border-neutral-100 pt-3">
+            <Link
+              href={`/helfer/anmeldung/${anmeldung.event_public_token}` as never}
+              className="text-sm font-medium text-primary-600 hover:text-primary-700"
+            >
+              Weitere Schichten
+            </Link>
+            {canCancel && anmeldung.abmeldung_token && (
+              <>
+                <span className="text-neutral-300">|</span>
+                <Link
+                  href={`/helfer/helferliste/abmeldung/${anmeldung.abmeldung_token}` as never}
+                  className="text-sm font-medium text-error-600 hover:text-error-700"
+                >
+                  Abmelden
+                </Link>
+              </>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/web/lib/actions/helfer-dashboard.ts
+++ b/apps/web/lib/actions/helfer-dashboard.ts
@@ -1,0 +1,35 @@
+'use server'
+
+import { createAdminClient } from '@/lib/supabase/admin'
+import type { HelferDashboardData } from '@/lib/supabase/types'
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export async function getHelferDashboardData(
+  dashboardToken: string
+): Promise<HelferDashboardData | null> {
+  if (!UUID_REGEX.test(dashboardToken)) {
+    return null
+  }
+
+  const supabase = createAdminClient()
+
+  const { data, error } = await supabase.rpc('get_helfer_dashboard_data', {
+    p_dashboard_token: dashboardToken,
+  })
+
+  if (error || !data) {
+    return null
+  }
+
+  const result = data as unknown as
+    | HelferDashboardData
+    | { error: string }
+
+  if ('error' in result) {
+    return null
+  }
+
+  return result
+}

--- a/apps/web/lib/supabase/middleware.ts
+++ b/apps/web/lib/supabase/middleware.ts
@@ -30,6 +30,20 @@ const protectedPrefixes = [
   '/profile',
 ]
 
+// Public sub-paths under /helfer that use token-based access (no auth required)
+const publicHelferPrefixes = [
+  '/helfer/meine-einsaetze/',
+  '/helfer/helferliste/',
+  '/helfer/abmeldung/',
+  '/helfer/anmeldung/',
+  '/helfer/warteliste/',
+  '/helfer/feedback/',
+]
+
+// UUID v4 pattern for matching /helfer/[token] (public event page)
+const uuidPattern =
+  /^\/helfer\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
 // Routes only accessible when NOT authenticated
 const authRoutes = ['/login', '/signup', '/forgot-password']
 
@@ -81,8 +95,13 @@ export async function updateSession(request: NextRequest) {
   // Check if current path is a public route
   const isPublicRoute = publicRoutes.some((route) => pathname.startsWith(route))
 
+  // Check if this is a public helfer route (token-based, no auth needed)
+  const isPublicHelferRoute =
+    publicHelferPrefixes.some((prefix) => pathname.startsWith(prefix)) ||
+    uuidPattern.test(pathname)
+
   // Redirect to login if accessing protected route without authentication
-  if (isProtectedRoute && !user) {
+  if (isProtectedRoute && !user && !isPublicHelferRoute) {
     const loginUrl = new URL('/login', request.url)
     loginUrl.searchParams.set('redirect', pathname)
     return NextResponse.redirect(loginUrl)

--- a/apps/web/lib/supabase/types.ts
+++ b/apps/web/lib/supabase/types.ts
@@ -1715,6 +1715,33 @@ export type CheckHelferTimeConflictsResult = {
 }
 
 // =============================================================================
+// Helfer Dashboard (US-9)
+// =============================================================================
+
+export type HelferDashboardAnmeldung = {
+  id: string
+  status: HelferAnmeldungStatus
+  abmeldung_token: string | null
+  created_at: string
+  rolle_name: string
+  zeitblock_start: string | null
+  zeitblock_end: string | null
+  rollen_instanz_id: string
+  event_id: string
+  event_name: string
+  event_datum_start: string
+  event_datum_end: string
+  event_ort: string | null
+  event_public_token: string
+  event_abmeldung_frist: string | null
+}
+
+export type HelferDashboardData = {
+  helper: { vorname: string; nachname: string; email: string }
+  anmeldungen: HelferDashboardAnmeldung[]
+}
+
+// =============================================================================
 // Produktionen (Issue #156)
 // =============================================================================
 

--- a/supabase/migrations/20260228100000_helfer_dashboard_data.sql
+++ b/supabase/migrations/20260228100000_helfer_dashboard_data.sql
@@ -1,0 +1,65 @@
+-- =============================================================================
+-- Migration: Helfer Dashboard Data RPC
+-- Created: 2026-02-28
+-- Issue: US-9 / #251
+-- Description: RPC function for the personal volunteer dashboard.
+--   Validates dashboard_token, returns helper info + registration details.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION get_helfer_dashboard_data(p_dashboard_token UUID)
+RETURNS JSONB AS $$
+DECLARE
+  v_helper RECORD;
+  v_anmeldungen JSONB;
+BEGIN
+  -- Validate token and get helper info
+  SELECT id, vorname, nachname, email
+  INTO v_helper
+  FROM externe_helfer_profile
+  WHERE dashboard_token = p_dashboard_token;
+
+  IF v_helper IS NULL THEN
+    RETURN jsonb_build_object('error', 'invalid');
+  END IF;
+
+  -- Get all non-rejected registrations with event and role details
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object(
+      'id', ha.id,
+      'status', ha.status,
+      'abmeldung_token', ha.abmeldung_token,
+      'created_at', ha.created_at,
+      'rolle_name', COALESCE(hrt.name, hri.custom_name, 'Unbekannte Rolle'),
+      'zeitblock_start', hri.zeitblock_start,
+      'zeitblock_end', hri.zeitblock_end,
+      'rollen_instanz_id', hri.id,
+      'event_id', he.id,
+      'event_name', he.name,
+      'event_datum_start', he.datum_start,
+      'event_datum_end', he.datum_end,
+      'event_ort', he.ort,
+      'event_public_token', he.public_token,
+      'event_abmeldung_frist', he.abmeldung_frist
+    ) ORDER BY he.datum_start ASC, hri.zeitblock_start ASC NULLS LAST
+  ), '[]'::jsonb)
+  INTO v_anmeldungen
+  FROM helfer_anmeldungen ha
+  JOIN helfer_rollen_instanzen hri ON hri.id = ha.rollen_instanz_id
+  JOIN helfer_events he ON he.id = hri.helfer_event_id
+  LEFT JOIN helfer_rollen_templates hrt ON hrt.id = hri.template_id
+  WHERE ha.external_helper_id = v_helper.id
+    AND ha.status != 'abgelehnt';
+
+  RETURN jsonb_build_object(
+    'helper', jsonb_build_object(
+      'vorname', v_helper.vorname,
+      'nachname', v_helper.nachname,
+      'email', v_helper.email
+    ),
+    'anmeldungen', v_anmeldungen
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION get_helfer_dashboard_data TO anon;
+GRANT EXECUTE ON FUNCTION get_helfer_dashboard_data TO authenticated;


### PR DESCRIPTION
## Summary
- Add `/helfer/meine-einsaetze/[token]` page where external volunteers view their shift overview via dashboard token from confirmation emails
- Create `get_helfer_dashboard_data` RPC function (SECURITY DEFINER) that validates the dashboard token and returns helper info + all non-rejected registrations with event/role details
- Fix middleware bug: `/helfer` was in `protectedPrefixes`, blocking all public `/helfer/*` token-based routes for unauthenticated users — now exempts specific public sub-paths
- Upcoming shifts show cancel link (reuses US-10 flow) and "more shifts" link; past shifts in collapsible section

## Test plan
- [ ] Open `/helfer/meine-einsaetze/{valid-dashboard-token}` in incognito — should show dashboard, not redirect to login
- [ ] Verify invalid/random UUID returns 404
- [ ] Verify upcoming shifts display with correct date (de-CH), role, time block, status badge
- [ ] Verify cancel link hidden when past deadline (configurable `abmeldung_frist` or 6h fallback)
- [ ] Verify past shifts section is collapsible and shows no cancel button
- [ ] Verify existing public helfer routes (`/helfer/[token]`, `/helfer/anmeldung/...`, `/helfer/helferliste/abmeldung/...`) still work unauthenticated
- [ ] Run `npm run typecheck && npm run lint && npm run test:run` — all pass

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)