### PR TITLE
feat: add public shift overview page /mitmachen

### DIFF
--- a/apps/web/app/(public)/mitmachen/page.tsx
+++ b/apps/web/app/(public)/mitmachen/page.tsx
@@ -1,0 +1,92 @@
+import type { Metadata } from 'next'
+import { getPublicShiftOverview } from '@/lib/actions/public-overview'
+import { PublicOverviewView } from '@/components/public-overview'
+
+export const metadata: Metadata = {
+  title: 'Mitmachen | Theatergruppe Widen',
+  description:
+    'Unterstütze die Theatergruppe Widen als Helfer! Wähle aus verschiedenen Schichten und melde dich direkt an.',
+  openGraph: {
+    title: 'Mitmachen bei der Theatergruppe Widen',
+    description:
+      'Wir suchen Helferinnen und Helfer für unsere Veranstaltungen. Melde dich jetzt an!',
+    type: 'website',
+  },
+}
+
+export default async function MitmachenPage() {
+  const data = await getPublicShiftOverview()
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <div className="mx-auto max-w-4xl px-4 py-8">
+        {/* Header */}
+        <div className="mb-8 text-center">
+          <div className="mb-4 inline-flex items-center gap-2 rounded-full bg-primary-100 px-4 py-1 text-sm font-medium text-primary-700">
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+              />
+            </svg>
+            Helfer gesucht
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900 sm:text-3xl">
+            Mitmachen bei der Theatergruppe Widen
+          </h1>
+          <p className="mt-2 text-gray-600">
+            Unterstütze uns bei unseren Veranstaltungen — jede helfende Hand
+            zählt!
+          </p>
+        </div>
+
+        {/* Content */}
+        {data.events.length === 0 ? (
+          <div className="rounded-xl border border-gray-200 bg-white p-8 text-center shadow-sm">
+            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-gray-100">
+              <svg
+                className="h-6 w-6 text-gray-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                />
+              </svg>
+            </div>
+            <h2 className="text-lg font-medium text-gray-900">
+              Aktuell keine offenen Schichten
+            </h2>
+            <p className="mt-2 text-gray-500">
+              Derzeit suchen wir keine Helfer. Schau bald wieder vorbei — neue
+              Veranstaltungen werden hier veröffentlicht.
+            </p>
+          </div>
+        ) : (
+          <PublicOverviewView data={data} />
+        )}
+
+        {/* Footer */}
+        <div className="mt-12 text-center text-sm text-gray-500">
+          <p>Theatergruppe Widen</p>
+          <p className="mt-1">
+            <a href="/datenschutz" className="text-primary-600 hover:underline">
+              Datenschutzerklärung
+            </a>
+          </p>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/apps/web/components/public-overview/EventGroup.tsx
+++ b/apps/web/components/public-overview/EventGroup.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { SelectableSchichtCard } from './SelectableSchichtCard'
+import type { PublicOverviewEventData } from '@/lib/actions/public-overview'
+
+interface EventGroupProps {
+  event: PublicOverviewEventData
+  selectedSchichtIds: Set<string>
+  onToggleSchicht: (schichtId: string) => void
+}
+
+export function EventGroup({
+  event,
+  selectedSchichtIds,
+  onToggleSchicht,
+}: EventGroupProps) {
+  const { veranstaltung, zeitbloecke } = event
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleDateString('de-CH', {
+      weekday: 'short',
+      day: '2-digit',
+      month: 'long',
+      year: 'numeric',
+    })
+  }
+
+  const formatTime = (timeStr: string | null) => {
+    if (!timeStr) return null
+    return timeStr.slice(0, 5)
+  }
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white shadow-sm">
+      {/* Event Header */}
+      <div className="border-b border-gray-100 px-5 py-4">
+        <h3 className="text-lg font-semibold text-gray-900">
+          {veranstaltung.titel}
+        </h3>
+        <div className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-500">
+          <span>{formatDate(veranstaltung.datum)}</span>
+          {veranstaltung.startzeit && (
+            <span>
+              {formatTime(veranstaltung.startzeit)}
+              {veranstaltung.endzeit &&
+                ` - ${formatTime(veranstaltung.endzeit)}`}{' '}
+              Uhr
+            </span>
+          )}
+          {veranstaltung.ort && <span>{veranstaltung.ort}</span>}
+        </div>
+      </div>
+
+      {/* Zeitbloecke with Schichten */}
+      <div className="divide-y divide-gray-100">
+        {zeitbloecke.map((zeitblock) => (
+          <div key={zeitblock.id} className="px-5 py-4">
+            <div className="mb-3 flex items-center justify-between">
+              <h4 className="text-sm font-semibold text-gray-700">
+                {zeitblock.name}
+              </h4>
+              <span className="text-xs text-gray-400">
+                {zeitblock.startzeit.slice(0, 5)} -{' '}
+                {zeitblock.endzeit.slice(0, 5)} Uhr
+              </span>
+            </div>
+            <div className="space-y-2">
+              {zeitblock.schichten.map((schicht) => (
+                <SelectableSchichtCard
+                  key={schicht.id}
+                  schicht={schicht}
+                  isSelected={selectedSchichtIds.has(schicht.id)}
+                  onToggle={onToggleSchicht}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/public-overview/OverviewRegistrationForm.tsx
+++ b/apps/web/components/public-overview/OverviewRegistrationForm.tsx
@@ -1,0 +1,332 @@
+'use client'
+
+import { useState } from 'react'
+import { registerForMultipleShifts } from '@/lib/actions/public-overview'
+import type { MultiRegistrationResult } from '@/lib/actions/public-overview'
+import type { PublicOverviewData } from '@/lib/actions/public-overview'
+import {
+  externeHelferRegistrierungFormSchema,
+  type ExterneHelferRegistrierungFormWithPrivacy,
+} from '@/lib/validations/externe-helfer'
+
+interface OverviewRegistrationFormProps {
+  selectedSchichtIds: string[]
+  data: PublicOverviewData
+  onBack: () => void
+  onSuccess: (results: MultiRegistrationResult) => void
+}
+
+export function OverviewRegistrationForm({
+  selectedSchichtIds,
+  data,
+  onBack,
+  onSuccess,
+}: OverviewRegistrationFormProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
+
+  const [formData, setFormData] =
+    useState<ExterneHelferRegistrierungFormWithPrivacy>({
+      email: '',
+      vorname: '',
+      nachname: '',
+      telefon: '',
+      datenschutz: false,
+    })
+
+  // Build summary of selected shifts grouped by event
+  const selectedSummary = data.events
+    .map((event) => {
+      const shifts = event.zeitbloecke.flatMap((zb) =>
+        zb.schichten
+          .filter((s) => selectedSchichtIds.includes(s.id))
+          .map((s) => ({
+            id: s.id,
+            rolle: s.rolle,
+            zeitblock: zb.name,
+            zeit: `${zb.startzeit.slice(0, 5)} - ${zb.endzeit.slice(0, 5)}`,
+          }))
+      )
+      if (!shifts.length) return null
+      return { event, shifts }
+    })
+    .filter(Boolean) as Array<{
+    event: PublicOverviewData['events'][number]
+    shifts: Array<{
+      id: string
+      rolle: string
+      zeitblock: string
+      zeit: string
+    }>
+  }>
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setFieldErrors({})
+
+    const parseResult = externeHelferRegistrierungFormSchema.safeParse(formData)
+    if (!parseResult.success) {
+      const errors: Record<string, string> = {}
+      for (const issue of parseResult.error.issues) {
+        const field = issue.path[0] as string
+        if (!errors[field]) {
+          errors[field] = issue.message
+        }
+      }
+      setFieldErrors(errors)
+      return
+    }
+
+    setIsSubmitting(true)
+
+    const result = await registerForMultipleShifts(selectedSchichtIds, {
+      email: formData.email,
+      vorname: formData.vorname,
+      nachname: formData.nachname,
+      telefon: formData.telefon || undefined,
+    })
+
+    if (!result.success && result.error) {
+      setError(result.error)
+      setIsSubmitting(false)
+      return
+    }
+
+    onSuccess(result)
+  }
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleDateString('de-CH', {
+      weekday: 'short',
+      day: '2-digit',
+      month: 'long',
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Summary of selected shifts */}
+      <div className="rounded-xl border border-gray-200 bg-white shadow-sm">
+        <div className="border-b border-gray-100 px-5 py-4">
+          <div className="flex items-center justify-between">
+            <h2 className="font-semibold text-gray-900">
+              Ausgewählte Schichten ({selectedSchichtIds.length})
+            </h2>
+            <button
+              type="button"
+              onClick={onBack}
+              className="text-sm text-primary-600 hover:text-primary-700"
+            >
+              Ändern
+            </button>
+          </div>
+        </div>
+        <div className="divide-y divide-gray-100">
+          {selectedSummary.map(({ event, shifts }) => (
+            <div key={event.veranstaltung.id} className="px-5 py-3">
+              <p className="text-sm font-medium text-gray-900">
+                {event.veranstaltung.titel}{' '}
+                <span className="font-normal text-gray-500">
+                  ({formatDate(event.veranstaltung.datum)})
+                </span>
+              </p>
+              <ul className="mt-1 space-y-0.5">
+                {shifts.map((s) => (
+                  <li key={s.id} className="text-sm text-gray-600">
+                    {s.rolle}{' '}
+                    <span className="text-gray-400">
+                      &middot; {s.zeitblock} ({s.zeit})
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Registration Form */}
+      <div className="rounded-xl border border-gray-200 bg-white shadow-sm">
+        <div className="border-b border-gray-100 px-5 py-4">
+          <h2 className="font-semibold text-gray-900">Deine Kontaktdaten</h2>
+          <p className="mt-1 text-sm text-gray-500">
+            Bitte fülle das Formular einmal aus — die Anmeldung gilt für alle
+            ausgewählten Schichten.
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="p-5">
+          {error && (
+            <div className="mb-4 rounded-lg border border-error-200 bg-error-50 px-4 py-3 text-sm text-error-700">
+              {error}
+            </div>
+          )}
+
+          <div className="space-y-4">
+            {/* Vorname */}
+            <div>
+              <label
+                htmlFor="overview-vorname"
+                className="block text-sm font-medium text-gray-700"
+              >
+                Vorname *
+              </label>
+              <input
+                type="text"
+                id="overview-vorname"
+                value={formData.vorname}
+                onChange={(e) =>
+                  setFormData({ ...formData, vorname: e.target.value })
+                }
+                className={`mt-1 block w-full rounded-lg border px-4 py-2 focus:ring-2 focus:ring-primary-500 ${
+                  fieldErrors.vorname
+                    ? 'border-error-300 focus:border-error-500'
+                    : 'border-gray-300 focus:border-primary-500'
+                }`}
+                placeholder="Max"
+              />
+              {fieldErrors.vorname && (
+                <p className="mt-1 text-sm text-error-600">
+                  {fieldErrors.vorname}
+                </p>
+              )}
+            </div>
+
+            {/* Nachname */}
+            <div>
+              <label
+                htmlFor="overview-nachname"
+                className="block text-sm font-medium text-gray-700"
+              >
+                Nachname *
+              </label>
+              <input
+                type="text"
+                id="overview-nachname"
+                value={formData.nachname}
+                onChange={(e) =>
+                  setFormData({ ...formData, nachname: e.target.value })
+                }
+                className={`mt-1 block w-full rounded-lg border px-4 py-2 focus:ring-2 focus:ring-primary-500 ${
+                  fieldErrors.nachname
+                    ? 'border-error-300 focus:border-error-500'
+                    : 'border-gray-300 focus:border-primary-500'
+                }`}
+                placeholder="Muster"
+              />
+              {fieldErrors.nachname && (
+                <p className="mt-1 text-sm text-error-600">
+                  {fieldErrors.nachname}
+                </p>
+              )}
+            </div>
+
+            {/* Email */}
+            <div>
+              <label
+                htmlFor="overview-email"
+                className="block text-sm font-medium text-gray-700"
+              >
+                E-Mail *
+              </label>
+              <input
+                type="email"
+                id="overview-email"
+                value={formData.email}
+                onChange={(e) =>
+                  setFormData({ ...formData, email: e.target.value })
+                }
+                className={`mt-1 block w-full rounded-lg border px-4 py-2 focus:ring-2 focus:ring-primary-500 ${
+                  fieldErrors.email
+                    ? 'border-error-300 focus:border-error-500'
+                    : 'border-gray-300 focus:border-primary-500'
+                }`}
+                placeholder="max.muster@beispiel.ch"
+              />
+              {fieldErrors.email && (
+                <p className="mt-1 text-sm text-error-600">
+                  {fieldErrors.email}
+                </p>
+              )}
+            </div>
+
+            {/* Telefon */}
+            <div>
+              <label
+                htmlFor="overview-telefon"
+                className="block text-sm font-medium text-gray-700"
+              >
+                Telefon <span className="text-gray-400">(optional)</span>
+              </label>
+              <input
+                type="tel"
+                id="overview-telefon"
+                value={formData.telefon}
+                onChange={(e) =>
+                  setFormData({ ...formData, telefon: e.target.value })
+                }
+                className="mt-1 block w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-primary-500 focus:ring-2 focus:ring-primary-500"
+                placeholder="+41 79 123 45 67"
+              />
+            </div>
+
+            {/* Datenschutz */}
+            <div className="flex items-start gap-3">
+              <input
+                type="checkbox"
+                id="overview-datenschutz"
+                checked={formData.datenschutz}
+                onChange={(e) =>
+                  setFormData({ ...formData, datenschutz: e.target.checked })
+                }
+                className="mt-1 h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+              />
+              <label
+                htmlFor="overview-datenschutz"
+                className="text-sm text-gray-600"
+              >
+                Ich akzeptiere die{' '}
+                <a
+                  href="/datenschutz"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary-600 hover:underline"
+                >
+                  Datenschutzerklärung
+                </a>{' '}
+                und stimme der Verarbeitung meiner Daten zu. *
+              </label>
+            </div>
+            {fieldErrors.datenschutz && (
+              <p className="text-sm text-error-600">
+                {fieldErrors.datenschutz}
+              </p>
+            )}
+          </div>
+
+          {/* Actions */}
+          <div className="mt-6 flex gap-3">
+            <button
+              type="button"
+              onClick={onBack}
+              className="flex-1 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+            >
+              Zurück
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="flex-1 rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-700 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isSubmitting
+                ? 'Wird angemeldet...'
+                : `Verbindlich anmelden (${selectedSchichtIds.length})`}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/public-overview/OverviewSuccessScreen.tsx
+++ b/apps/web/components/public-overview/OverviewSuccessScreen.tsx
@@ -1,0 +1,185 @@
+'use client'
+
+import type { MultiRegistrationResult } from '@/lib/actions/public-overview'
+
+interface OverviewSuccessScreenProps {
+  results: MultiRegistrationResult
+  schichtNames: Map<string, string>
+  dashboardToken?: string
+  onBrowseMore: () => void
+}
+
+export function OverviewSuccessScreen({
+  results,
+  schichtNames,
+  dashboardToken,
+  onBrowseMore,
+}: OverviewSuccessScreenProps) {
+  const successResults = results.results.filter((r) => r.success)
+  const failedResults = results.results.filter((r) => !r.success)
+  const waitlistResults = results.results.filter((r) => r.waitlist)
+
+  return (
+    <div className="space-y-6">
+      {/* Success Header */}
+      <div className="rounded-xl border border-success-200 bg-white p-8 text-center shadow-sm">
+        <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-success-100">
+          <svg
+            className="h-8 w-8 text-success-600"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M5 13l4 4L19 7"
+            />
+          </svg>
+        </div>
+
+        <h2 className="text-xl font-semibold text-gray-900">
+          {successResults.length === results.results.length
+            ? 'Alle Anmeldungen erfolgreich!'
+            : 'Anmeldung teilweise erfolgreich'}
+        </h2>
+
+        <p className="mt-2 text-gray-600">
+          {successResults.length} von {results.results.length}{' '}
+          {results.results.length === 1 ? 'Schicht' : 'Schichten'} erfolgreich
+          gebucht.
+        </p>
+      </div>
+
+      {/* Successful Registrations */}
+      {successResults.length > 0 && (
+        <div className="rounded-xl border border-gray-200 bg-white shadow-sm">
+          <div className="border-b border-gray-100 px-5 py-3">
+            <h3 className="font-medium text-success-700">
+              Erfolgreich angemeldet
+            </h3>
+          </div>
+          <ul className="divide-y divide-gray-100">
+            {successResults.map((r) => (
+              <li key={r.schichtId} className="flex items-center gap-3 px-5 py-3">
+                <svg
+                  className="h-5 w-5 shrink-0 text-success-500"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M5 13l4 4L19 7"
+                  />
+                </svg>
+                <span className="text-gray-900">
+                  {schichtNames.get(r.schichtId) || r.schichtId}
+                </span>
+                {r.waitlist && (
+                  <span className="rounded-full bg-warning-100 px-2 py-0.5 text-xs font-medium text-warning-700">
+                    Warteliste
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Waitlist Notice */}
+      {waitlistResults.length > 0 && (
+        <div className="rounded-lg border border-warning-200 bg-warning-50 px-4 py-3 text-sm text-warning-700">
+          {waitlistResults.length === 1
+            ? 'Eine Schicht wurde auf die Warteliste gesetzt. Du wirst benachrichtigt, falls ein Platz frei wird.'
+            : `${waitlistResults.length} Schichten wurden auf die Warteliste gesetzt. Du wirst benachrichtigt, falls Plätze frei werden.`}
+        </div>
+      )}
+
+      {/* Failed Registrations */}
+      {failedResults.length > 0 && (
+        <div className="rounded-xl border border-error-200 bg-white shadow-sm">
+          <div className="border-b border-error-100 px-5 py-3">
+            <h3 className="font-medium text-error-700">
+              Nicht angemeldet
+            </h3>
+          </div>
+          <ul className="divide-y divide-gray-100">
+            {failedResults.map((r) => (
+              <li key={r.schichtId} className="px-5 py-3">
+                <div className="flex items-center gap-3">
+                  <svg
+                    className="h-5 w-5 shrink-0 text-error-500"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M6 18L18 6M6 6l12 12"
+                    />
+                  </svg>
+                  <span className="text-gray-900">
+                    {schichtNames.get(r.schichtId) || r.schichtId}
+                  </span>
+                </div>
+                {r.error && (
+                  <p className="mt-1 pl-8 text-sm text-error-600">{r.error}</p>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="flex flex-col gap-3 sm:flex-row">
+        {dashboardToken && (
+          <a
+            href={`/helfer/meine-einsaetze/${dashboardToken}` as never}
+            className="inline-flex items-center justify-center gap-2 rounded-lg bg-primary-600 px-6 py-3 font-medium text-white transition-colors hover:bg-primary-700"
+          >
+            <svg
+              className="h-5 w-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+              />
+            </svg>
+            Zu meinen Einsätzen
+          </a>
+        )}
+        <button
+          onClick={onBrowseMore}
+          className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-300 px-6 py-3 font-medium text-gray-700 transition-colors hover:bg-gray-50"
+        >
+          <svg
+            className="h-5 w-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+            />
+          </svg>
+          Weitere Schichten buchen
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/public-overview/PublicOverviewView.tsx
+++ b/apps/web/components/public-overview/PublicOverviewView.tsx
@@ -1,0 +1,162 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+import { EventGroup } from './EventGroup'
+import { OverviewRegistrationForm } from './OverviewRegistrationForm'
+import { OverviewSuccessScreen } from './OverviewSuccessScreen'
+import type {
+  PublicOverviewData,
+  MultiRegistrationResult,
+} from '@/lib/actions/public-overview'
+
+interface PublicOverviewViewProps {
+  data: PublicOverviewData
+}
+
+type OverviewState =
+  | { type: 'browsing' }
+  | { type: 'form'; selectedSchichtIds: string[] }
+  | { type: 'success'; results: MultiRegistrationResult }
+
+export function PublicOverviewView({ data }: PublicOverviewViewProps) {
+  const [state, setState] = useState<OverviewState>({ type: 'browsing' })
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+
+  // Build a map of schichtId -> display name for the success screen
+  const schichtNames = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const event of data.events) {
+      for (const zb of event.zeitbloecke) {
+        for (const s of zb.schichten) {
+          map.set(s.id, `${s.rolle} (${event.veranstaltung.titel})`)
+        }
+      }
+    }
+    return map
+  }, [data])
+
+  const handleToggleSchicht = (schichtId: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(schichtId)) {
+        next.delete(schichtId)
+      } else {
+        next.add(schichtId)
+      }
+      return next
+    })
+  }
+
+  const handleProceedToForm = () => {
+    setState({
+      type: 'form',
+      selectedSchichtIds: Array.from(selectedIds),
+    })
+  }
+
+  const handleSuccess = (results: MultiRegistrationResult) => {
+    setState({ type: 'success', results })
+    setSelectedIds(new Set())
+  }
+
+  const handleBackToBrowsing = () => {
+    setState({ type: 'browsing' })
+  }
+
+  const handleBrowseMore = () => {
+    setState({ type: 'browsing' })
+    setSelectedIds(new Set())
+  }
+
+  // Success screen
+  if (state.type === 'success') {
+    return (
+      <OverviewSuccessScreen
+        results={state.results}
+        schichtNames={schichtNames}
+        dashboardToken={state.results.dashboardToken}
+        onBrowseMore={handleBrowseMore}
+      />
+    )
+  }
+
+  // Form screen
+  if (state.type === 'form') {
+    return (
+      <OverviewRegistrationForm
+        selectedSchichtIds={state.selectedSchichtIds}
+        data={data}
+        onBack={handleBackToBrowsing}
+        onSuccess={handleSuccess}
+      />
+    )
+  }
+
+  // Browsing screen
+  return (
+    <>
+      {/* Info Box */}
+      <div className="mb-6 rounded-xl border border-primary-200 bg-primary-50 p-5">
+        <div className="flex items-start gap-4">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary-100">
+            <svg
+              className="h-5 w-5 text-primary-600"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+          </div>
+          <div>
+            <h3 className="font-medium text-primary-900">
+              Wähle deine Schichten aus
+            </h3>
+            <p className="mt-1 text-sm text-primary-700">
+              Du kannst mehrere Schichten aus verschiedenen Veranstaltungen
+              auswählen und dich mit einem einzigen Formular für alle anmelden.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Event Cards */}
+      <div className="space-y-6">
+        {data.events.map((event) => (
+          <EventGroup
+            key={event.veranstaltung.id}
+            event={event}
+            selectedSchichtIds={selectedIds}
+            onToggleSchicht={handleToggleSchicht}
+          />
+        ))}
+      </div>
+
+      {/* Sticky Footer Bar */}
+      {selectedIds.size > 0 && (
+        <div className="fixed inset-x-0 bottom-0 z-40 border-t border-gray-200 bg-white/95 px-4 py-3 shadow-lg backdrop-blur-sm">
+          <div className="mx-auto flex max-w-4xl items-center justify-between">
+            <p className="text-sm font-medium text-gray-700">
+              {selectedIds.size}{' '}
+              {selectedIds.size === 1 ? 'Schicht' : 'Schichten'} ausgewählt
+            </p>
+            <button
+              onClick={handleProceedToForm}
+              className="rounded-lg bg-primary-600 px-6 py-2.5 text-sm font-medium text-white transition-colors hover:bg-primary-700"
+            >
+              Weiter zur Anmeldung
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Bottom spacer when footer is visible */}
+      {selectedIds.size > 0 && <div className="h-20" />}
+    </>
+  )
+}

--- a/apps/web/components/public-overview/SelectableSchichtCard.tsx
+++ b/apps/web/components/public-overview/SelectableSchichtCard.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import type { PublicSchichtData } from '@/lib/actions/external-registration'
+
+interface SelectableSchichtCardProps {
+  schicht: PublicSchichtData
+  isSelected: boolean
+  onToggle: (schichtId: string) => void
+}
+
+export function SelectableSchichtCard({
+  schicht,
+  isSelected,
+  onToggle,
+}: SelectableSchichtCardProps) {
+  const isFull = schicht.freie_plaetze <= 0
+  const slotsText = isFull
+    ? 'Alle Plätze belegt'
+    : `${schicht.freie_plaetze} von ${schicht.anzahl_benoetigt} ${schicht.freie_plaetze === 1 ? 'Platz' : 'Plätze'} frei`
+
+  return (
+    <button
+      type="button"
+      disabled={isFull}
+      onClick={() => onToggle(schicht.id)}
+      className={`w-full rounded-lg border p-4 text-left transition-all ${
+        isFull
+          ? 'cursor-not-allowed border-gray-200 bg-gray-50 opacity-60'
+          : isSelected
+            ? 'border-primary-500 bg-primary-50 ring-1 ring-primary-500'
+            : 'border-gray-200 bg-white hover:border-primary-300 hover:shadow-sm'
+      }`}
+    >
+      <div className="flex items-center gap-3">
+        {/* Checkbox */}
+        <div
+          className={`flex h-5 w-5 shrink-0 items-center justify-center rounded border transition-colors ${
+            isFull
+              ? 'border-gray-300 bg-gray-100'
+              : isSelected
+                ? 'border-primary-600 bg-primary-600'
+                : 'border-gray-300 bg-white'
+          }`}
+        >
+          {isSelected && (
+            <svg
+              className="h-3.5 w-3.5 text-white"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={3}
+                d="M5 13l4 4L19 7"
+              />
+            </svg>
+          )}
+        </div>
+
+        <div className="flex-1">
+          <h4 className="font-medium text-gray-900">{schicht.rolle}</h4>
+          <p
+            className={`text-sm ${isFull ? 'text-gray-400' : 'text-gray-600'}`}
+          >
+            {slotsText}
+          </p>
+        </div>
+
+        {isFull && (
+          <span className="rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-500">
+            Belegt
+          </span>
+        )}
+      </div>
+
+      {/* Slot indicator */}
+      <div className="mt-3 pl-8">
+        <div className="flex gap-1">
+          {Array.from({ length: schicht.anzahl_benoetigt }).map((_, i) => (
+            <div
+              key={i}
+              className={`h-2 flex-1 rounded-full ${
+                i < schicht.anzahl_belegt ? 'bg-primary-500' : 'bg-gray-200'
+              }`}
+            />
+          ))}
+        </div>
+      </div>
+    </button>
+  )
+}

--- a/apps/web/components/public-overview/index.ts
+++ b/apps/web/components/public-overview/index.ts
@@ -1,0 +1,5 @@
+export { PublicOverviewView } from './PublicOverviewView'
+export { EventGroup } from './EventGroup'
+export { SelectableSchichtCard } from './SelectableSchichtCard'
+export { OverviewRegistrationForm } from './OverviewRegistrationForm'
+export { OverviewSuccessScreen } from './OverviewSuccessScreen'

--- a/apps/web/lib/actions/public-overview.ts
+++ b/apps/web/lib/actions/public-overview.ts
@@ -1,0 +1,373 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { createAdminClient } from '../supabase/admin'
+import { externeHelferRegistrierungSchema } from '../validations/externe-helfer'
+import type {
+  PublicVeranstaltungData,
+  PublicSchichtData,
+  PublicZeitblockData,
+} from './external-registration'
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type PublicOverviewEventData = {
+  veranstaltung: PublicVeranstaltungData & { public_helfer_token: string }
+  zeitbloecke: PublicZeitblockData[]
+}
+
+export type PublicOverviewData = {
+  events: PublicOverviewEventData[]
+}
+
+export type MultiRegistrationResult = {
+  success: boolean
+  results: Array<{
+    schichtId: string
+    success: boolean
+    error?: string
+    waitlist?: boolean
+  }>
+  dashboardToken?: string
+  error?: string
+}
+
+// =============================================================================
+// Data Fetching
+// =============================================================================
+
+/**
+ * Get all published events with available public shifts.
+ * No authentication required - this is for the public /mitmachen page.
+ */
+export async function getPublicShiftOverview(): Promise<PublicOverviewData> {
+  const supabase = createAdminClient()
+
+  // Get today's date (start of day) for filtering
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const todayStr = today.toISOString().split('T')[0]
+
+  // Fetch all published veranstaltungen with future dates
+  const { data: veranstaltungen, error: veranstaltungenError } = await supabase
+    .from('veranstaltungen')
+    .select('id, titel, datum, startzeit, endzeit, ort, helfer_status, public_helfer_token')
+    .eq('helfer_status', 'veroeffentlicht')
+    .gte('datum', todayStr)
+    .order('datum', { ascending: true })
+
+  if (veranstaltungenError || !veranstaltungen?.length) {
+    return { events: [] }
+  }
+
+  const veranstaltungIds = veranstaltungen.map((v) => v.id)
+
+  // Fetch zeitbloecke and schichten in parallel
+  const [zeitblockResult, schichtenResult] = await Promise.all([
+    supabase
+      .from('zeitbloecke')
+      .select('id, name, startzeit, endzeit, typ, sortierung, veranstaltung_id')
+      .in('veranstaltung_id', veranstaltungIds)
+      .order('sortierung', { ascending: true }),
+    supabase
+      .from('auffuehrung_schichten')
+      .select(`
+        id,
+        rolle,
+        anzahl_benoetigt,
+        zeitblock_id,
+        veranstaltung_id,
+        zuweisungen:auffuehrung_zuweisungen(id, status)
+      `)
+      .in('veranstaltung_id', veranstaltungIds)
+      .eq('sichtbarkeit', 'public'),
+  ])
+
+  if (zeitblockResult.error || schichtenResult.error) {
+    return { events: [] }
+  }
+
+  const zeitbloecke = zeitblockResult.data || []
+  const schichten = schichtenResult.data || []
+
+  // Build events
+  const events: PublicOverviewEventData[] = []
+
+  for (const v of veranstaltungen) {
+    if (!v.public_helfer_token) continue
+
+    const eventZeitbloecke = zeitbloecke.filter(
+      (zb) => zb.veranstaltung_id === v.id
+    )
+    const eventSchichten = schichten.filter(
+      (s) => s.veranstaltung_id === v.id
+    )
+
+    // Group schichten by zeitblock
+    const zeitblockMap = new Map<string | null, PublicSchichtData[]>()
+
+    for (const schicht of eventSchichten) {
+      const zuweisungen =
+        (schicht.zuweisungen as unknown as { id: string; status: string }[]) ||
+        []
+      const anzahl_belegt = zuweisungen.filter(
+        (z) => z.status !== 'abgesagt'
+      ).length
+      const freie_plaetze = Math.max(
+        0,
+        schicht.anzahl_benoetigt - anzahl_belegt
+      )
+
+      const zeitblock = eventZeitbloecke.find(
+        (zb) => zb.id === schicht.zeitblock_id
+      )
+
+      const schichtData: PublicSchichtData = {
+        id: schicht.id,
+        rolle: schicht.rolle,
+        anzahl_benoetigt: schicht.anzahl_benoetigt,
+        zeitblock: zeitblock
+          ? {
+              id: zeitblock.id,
+              name: zeitblock.name,
+              startzeit: zeitblock.startzeit,
+              endzeit: zeitblock.endzeit,
+            }
+          : null,
+        anzahl_belegt,
+        freie_plaetze,
+      }
+
+      const key = schicht.zeitblock_id
+      if (!zeitblockMap.has(key)) {
+        zeitblockMap.set(key, [])
+      }
+      zeitblockMap.get(key)!.push(schichtData)
+    }
+
+    // Build zeitblock data with grouped schichten
+    const transformedZeitbloecke: PublicZeitblockData[] = eventZeitbloecke
+      .filter((zb) => zeitblockMap.has(zb.id))
+      .map((zb) => ({
+        id: zb.id,
+        name: zb.name,
+        startzeit: zb.startzeit,
+        endzeit: zb.endzeit,
+        typ: zb.typ,
+        sortierung: zb.sortierung,
+        schichten: zeitblockMap.get(zb.id) || [],
+      }))
+
+    // Add schichten without zeitblock
+    const orphanSchichten = zeitblockMap.get(null)
+    if (orphanSchichten?.length) {
+      transformedZeitbloecke.push({
+        id: 'ohne-zeitblock',
+        name: 'Allgemein',
+        startzeit: v.startzeit || '00:00',
+        endzeit: v.endzeit || '23:59',
+        typ: 'standard',
+        sortierung: 9999,
+        schichten: orphanSchichten,
+      })
+    }
+
+    // Only include events that have at least one shift with free spots
+    const hasFreeSpots = transformedZeitbloecke.some((zb) =>
+      zb.schichten.some((s) => s.freie_plaetze > 0)
+    )
+
+    if (transformedZeitbloecke.length > 0 && hasFreeSpots) {
+      events.push({
+        veranstaltung: {
+          id: v.id,
+          titel: v.titel,
+          datum: v.datum,
+          startzeit: v.startzeit,
+          endzeit: v.endzeit,
+          ort: v.ort,
+          helfer_status: v.helfer_status!,
+          public_helfer_token: v.public_helfer_token,
+        },
+        zeitbloecke: transformedZeitbloecke,
+      })
+    }
+  }
+
+  return { events }
+}
+
+// =============================================================================
+// Multi-Shift Registration
+// =============================================================================
+
+/**
+ * Register an external helper for multiple shifts across events.
+ * No authentication required - uses admin client.
+ */
+export async function registerForMultipleShifts(
+  schichtIds: string[],
+  helperData: {
+    email: string
+    vorname: string
+    nachname: string
+    telefon?: string
+  }
+): Promise<MultiRegistrationResult> {
+  if (!schichtIds.length) {
+    return { success: false, results: [], error: 'Keine Schichten ausgewählt' }
+  }
+
+  // Validate helper data
+  const parseResult = externeHelferRegistrierungSchema.safeParse(helperData)
+  if (!parseResult.success) {
+    const firstIssue = parseResult.error.issues[0]
+    return { success: false, results: [], error: firstIssue.message }
+  }
+  const validData = parseResult.data
+
+  const supabase = createAdminClient()
+
+  // Find or create external helper profile (once)
+  const { data: helperId, error: helperError } = await supabase.rpc(
+    'find_or_create_external_helper',
+    {
+      p_email: validData.email,
+      p_vorname: validData.vorname,
+      p_nachname: validData.nachname,
+      p_telefon: validData.telefon || null,
+    }
+  )
+
+  if (helperError || !helperId) {
+    console.error('Error creating helper profile:', helperError)
+    return {
+      success: false,
+      results: [],
+      error: 'Fehler bei der Registrierung',
+    }
+  }
+
+  // Process each shift sequentially
+  const results: MultiRegistrationResult['results'] = []
+
+  for (const schichtId of schichtIds) {
+    const result = await registerSingleShift(supabase, schichtId, helperId)
+    results.push({ schichtId, ...result })
+  }
+
+  // Get dashboard token
+  const { data: dashboardToken } = await supabase.rpc(
+    'get_externe_helfer_dashboard_token',
+    { p_helper_id: helperId }
+  )
+
+  const anySuccess = results.some((r) => r.success)
+
+  if (anySuccess) {
+    revalidatePath('/mitmachen')
+  }
+
+  return {
+    success: anySuccess,
+    results,
+    dashboardToken: dashboardToken || undefined,
+  }
+}
+
+// =============================================================================
+// Helper: Single Shift Registration
+// =============================================================================
+
+async function registerSingleShift(
+  supabase: ReturnType<typeof createAdminClient>,
+  schichtId: string,
+  helperId: string
+): Promise<{ success: boolean; error?: string; waitlist?: boolean }> {
+  // Verify schicht exists and is public
+  const { data: schicht, error: schichtError } = await supabase
+    .from('auffuehrung_schichten')
+    .select('id, veranstaltung_id, anzahl_benoetigt, sichtbarkeit')
+    .eq('id', schichtId)
+    .single()
+
+  if (schichtError || !schicht) {
+    return { success: false, error: 'Schicht nicht gefunden' }
+  }
+
+  if (schicht.sichtbarkeit !== 'public') {
+    return { success: false, error: 'Diese Schicht ist nicht öffentlich verfügbar' }
+  }
+
+  // Verify veranstaltung is still published and in the future
+  const { data: veranstaltung, error: veranstaltungError } = await supabase
+    .from('veranstaltungen')
+    .select('id, helfer_status, datum, helfer_buchung_deadline')
+    .eq('id', schicht.veranstaltung_id)
+    .single()
+
+  if (veranstaltungError || !veranstaltung) {
+    return { success: false, error: 'Veranstaltung nicht gefunden' }
+  }
+
+  if (veranstaltung.helfer_status !== 'veroeffentlicht') {
+    return { success: false, error: 'Anmeldung nicht mehr möglich' }
+  }
+
+  const eventDate = new Date(veranstaltung.datum)
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  if (eventDate < today) {
+    return { success: false, error: 'Veranstaltung hat bereits stattgefunden' }
+  }
+
+  if (veranstaltung.helfer_buchung_deadline) {
+    const deadline = new Date(veranstaltung.helfer_buchung_deadline)
+    if (deadline < new Date()) {
+      return { success: false, error: 'Anmeldefrist abgelaufen' }
+    }
+  }
+
+  // Check duplicate
+  const { data: existingZuweisung } = await supabase
+    .from('auffuehrung_zuweisungen')
+    .select('id')
+    .eq('schicht_id', schichtId)
+    .eq('external_helper_id', helperId)
+    .neq('status', 'abgesagt')
+    .single()
+
+  if (existingZuweisung) {
+    return { success: false, error: 'Bereits für diese Schicht angemeldet' }
+  }
+
+  // Check capacity
+  const { count: currentCount } = await supabase
+    .from('auffuehrung_zuweisungen')
+    .select('id', { count: 'exact', head: true })
+    .eq('schicht_id', schichtId)
+    .neq('status', 'abgesagt')
+
+  const isWaitlist = (currentCount ?? 0) >= schicht.anzahl_benoetigt
+
+  // Create zuweisung
+  const { error: insertError } = await supabase
+    .from('auffuehrung_zuweisungen')
+    .insert({
+      schicht_id: schichtId,
+      external_helper_id: helperId,
+      status: 'zugesagt',
+    } as never)
+
+  if (insertError) {
+    console.error('Error creating zuweisung:', insertError)
+    if (insertError.code === '23505') {
+      return { success: false, error: 'Bereits für diese Schicht angemeldet' }
+    }
+    return { success: false, error: 'Fehler bei der Anmeldung' }
+  }
+
+  return { success: true, waitlist: isWaitlist }
+}


### PR DESCRIPTION
## Summary
- Add a central public page at `/mitmachen` showing all available shifts across published events — no login or token required
- Helpers can select multiple shifts (even across different events) and register with a single form submission
- Includes browsing view with selectable shift cards, registration form, and success screen with dashboard link

Closes #268

## New Files
| File | Description |
|------|-------------|
| `lib/actions/public-overview.ts` | Server action: `getPublicShiftOverview()` + `registerForMultipleShifts()` |
| `app/(public)/mitmachen/page.tsx` | Public page with SEO metadata and empty state |
| `components/public-overview/PublicOverviewView.tsx` | Main client component with browsing/form/success state machine |
| `components/public-overview/EventGroup.tsx` | Event card with zeitbloecke and selectable shifts |
| `components/public-overview/SelectableSchichtCard.tsx` | Checkbox-style shift card with slot indicator |
| `components/public-overview/OverviewRegistrationForm.tsx` | Multi-shift registration form with shift summary |
| `components/public-overview/OverviewSuccessScreen.tsx` | Results display with dashboard link |

## Reuses
- `externeHelferRegistrierungSchema` for validation
- `find_or_create_external_helper()` and `get_externe_helfer_dashboard_token()` RPCs
- `PublicSchichtData` / `PublicZeitblockData` types from `external-registration.ts`
- `createAdminClient()` for public data access (bypass RLS)

## Test plan
- [ ] Open `/mitmachen` in incognito — shows all published events with free shifts
- [ ] Select shifts from multiple events → "Weiter zur Anmeldung" appears in sticky footer
- [ ] Fill form and submit → all shifts registered, success screen shows results
- [ ] Success screen links to `/helfer/meine-einsaetze/[token]` dashboard
- [ ] Empty state shown when no published events exist
- [ ] Already-registered shifts show error per-shift (partial success)
- [ ] Full shifts show as disabled with "Belegt" badge
- [ ] `npm run typecheck` ✅ `npm run lint` ✅ `npm run test:run` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)