### PR TITLE
fix: add cache revalidation for /auffuehrungen routes

### DIFF
--- a/apps/web/lib/actions/veranstaltungen.ts
+++ b/apps/web/lib/actions/veranstaltungen.ts
@@ -97,6 +97,7 @@ export async function createVeranstaltung(
   }
 
   revalidatePath('/veranstaltungen')
+  revalidatePath('/auffuehrungen')
   return { success: true, id: result?.id }
 }
 
@@ -120,7 +121,9 @@ export async function updateVeranstaltung(
   }
 
   revalidatePath('/veranstaltungen')
+  revalidatePath('/auffuehrungen')
   revalidatePath(`/veranstaltungen/${id}`)
+  revalidatePath(`/auffuehrungen/${id}`)
   return { success: true }
 }
 
@@ -140,6 +143,7 @@ export async function deleteVeranstaltung(
   }
 
   revalidatePath('/veranstaltungen')
+  revalidatePath('/auffuehrungen')
   return { success: true }
 }
 


### PR DESCRIPTION
## Summary
- `createVeranstaltung()`, `updateVeranstaltung()`, and `deleteVeranstaltung()` only called `revalidatePath('/veranstaltungen')` but not `/auffuehrungen`
- After creating an Aufführung, the user was redirected to `/auffuehrungen` which showed stale cached data — making it look like nothing was saved
- Added `revalidatePath('/auffuehrungen')` (and `/auffuehrungen/${id}` for update) to all three functions

## Test plan
- [ ] Create a new Aufführung → appears immediately in `/auffuehrungen` list
- [ ] Edit an Aufführung → changes visible on list and detail page
- [ ] Delete an Aufführung → removed from list immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)