### PR TITLE
chore: add .env*.local to root gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ coverage/
 .claude/settings.local.json
 .claude/agent-memory/
 .claude/agents/
+.env*.local


### PR DESCRIPTION
## Summary
- Adds `.env*.local` to root `.gitignore` to prevent accidentally committing environment files created by Vercel CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)