### PR TITLE
fix: add router.refresh() to VeranstaltungForm navigation

### DIFF
--- a/apps/web/components/veranstaltungen/VeranstaltungForm.tsx
+++ b/apps/web/components/veranstaltungen/VeranstaltungForm.tsx
@@ -90,6 +90,7 @@ export function VeranstaltungForm({
         : await updateVeranstaltung(veranstaltung!.id, data)
 
     if (result.success) {
+      router.refresh()
       router.push(returnUrl as never)
     } else {
       setError(result.error || 'Ein Fehler ist aufgetreten')
@@ -105,6 +106,7 @@ export function VeranstaltungForm({
     const result = await deleteVeranstaltung(veranstaltung.id)
 
     if (result.success) {
+      router.refresh()
       router.push(returnUrl as never)
     } else {
       setError(result.error || 'Ein Fehler ist aufgetreten')


### PR DESCRIPTION
## Summary
- After creating/updating/deleting a Veranstaltung, `router.push()` alone uses the client-side Router Cache, which can show stale data
- Adding `router.refresh()` before `router.push()` forces the router to invalidate its cache and fetch fresh data from the server
- This fixes the issue where a newly created Aufführung wouldn't appear in the list after redirect

## Test plan
- [ ] Create a new Aufführung → appears immediately in list after redirect
- [ ] Edit an Aufführung → changes visible after redirect
- [ ] Delete an Aufführung → removed from list after redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)