### PR TITLE
fix: add Zod validation to server action mutations (#273)

### DIFF
--- a/apps/web/lib/actions/helfereinsaetze.ts
+++ b/apps/web/lib/actions/helfereinsaetze.ts
@@ -9,6 +9,12 @@ import type {
   Helferrolle,
   HelferrolleInsert,
 } from '../supabase/types'
+import {
+  helfereinsatzSchema,
+  helfereinsatzUpdateSchema,
+  helferrolleSchema,
+} from '../validations/helfereinsaetze'
+import { validateInput } from '../validations/modul2'
 
 /**
  * Get all helfereinsaetze with partner info
@@ -102,6 +108,21 @@ export async function createHelfereinsatz(
   data: HelfereinsatzInsert,
   rollen?: HelferrolleInsert[]
 ): Promise<{ success: boolean; error?: string; id?: string }> {
+  // Validate input
+  const validation = validateInput(helfereinsatzSchema, data)
+  if (!validation.success) {
+    return { success: false, error: validation.error }
+  }
+
+  if (rollen) {
+    for (const rolle of rollen) {
+      const rolleValidation = validateInput(helferrolleSchema, rolle)
+      if (!rolleValidation.success) {
+        return { success: false, error: rolleValidation.error }
+      }
+    }
+  }
+
   const supabase = await createClient()
 
   // Insert helfereinsatz
@@ -145,6 +166,12 @@ export async function updateHelfereinsatz(
   id: string,
   data: HelfereinsatzUpdate
 ): Promise<{ success: boolean; error?: string }> {
+  // Validate input
+  const validation = validateInput(helfereinsatzUpdateSchema, data)
+  if (!validation.success) {
+    return { success: false, error: validation.error }
+  }
+
   const supabase = await createClient()
   const { error } = await supabase
     .from('helfereinsaetze')

--- a/apps/web/lib/actions/veranstaltungen.ts
+++ b/apps/web/lib/actions/veranstaltungen.ts
@@ -7,6 +7,11 @@ import type {
   VeranstaltungInsert,
   VeranstaltungUpdate,
 } from '../supabase/types'
+import {
+  veranstaltungSchema,
+  veranstaltungUpdateSchema,
+} from '../validations/veranstaltungen'
+import { validateInput } from '../validations/modul2'
 
 /**
  * Get all veranstaltungen
@@ -84,6 +89,12 @@ export async function getVeranstaltung(
 export async function createVeranstaltung(
   data: VeranstaltungInsert
 ): Promise<{ success: boolean; error?: string; id?: string }> {
+  // Validate input
+  const validation = validateInput(veranstaltungSchema, data)
+  if (!validation.success) {
+    return { success: false, error: validation.error }
+  }
+
   const supabase = await createClient()
   const { data: result, error } = await supabase
     .from('veranstaltungen')
@@ -109,6 +120,12 @@ export async function updateVeranstaltung(
   id: string,
   data: VeranstaltungUpdate
 ): Promise<{ success: boolean; error?: string }> {
+  // Validate input
+  const validation = validateInput(veranstaltungUpdateSchema, data)
+  if (!validation.success) {
+    return { success: false, error: validation.error }
+  }
+
   const supabase = await createClient()
   const { error } = await supabase
     .from('veranstaltungen')

--- a/apps/web/lib/validations/helfereinsaetze.ts
+++ b/apps/web/lib/validations/helfereinsaetze.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod'
+
+export const helfereinsatzSchema = z.object({
+  titel: z.string().min(1, 'Titel ist erforderlich').max(200, 'Titel zu lang'),
+  datum: z.string().min(1, 'Datum ist erforderlich'),
+  status: z.enum(['offen', 'bestaetigt', 'abgeschlossen', 'abgesagt']),
+  partner_id: z.string().uuid('Ungültige Partner-ID').nullable().optional(),
+  beschreibung: z
+    .string()
+    .max(2000, 'Beschreibung zu lang')
+    .nullable()
+    .optional(),
+  startzeit: z.string().nullable().optional(),
+  endzeit: z.string().nullable().optional(),
+  ort: z.string().max(200, 'Ort zu lang').nullable().optional(),
+  stundenlohn_verein: z
+    .number()
+    .min(0, 'Stundenlohn muss positiv sein')
+    .nullable()
+    .optional(),
+})
+
+export const helfereinsatzUpdateSchema = helfereinsatzSchema.partial()
+
+export const helferrolleSchema = z.object({
+  helfereinsatz_id: z.string().uuid('Ungültige Helfereinsatz-ID'),
+  rolle: z
+    .string()
+    .min(1, 'Rolle ist erforderlich')
+    .max(100, 'Rolle zu lang'),
+  anzahl_benoetigt: z
+    .number()
+    .int()
+    .min(1, 'Mindestens 1 Person benötigt'),
+})

--- a/apps/web/lib/validations/veranstaltungen.ts
+++ b/apps/web/lib/validations/veranstaltungen.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod'
+
+export const veranstaltungSchema = z.object({
+  titel: z.string().min(1, 'Titel ist erforderlich').max(200, 'Titel zu lang'),
+  datum: z.string().min(1, 'Datum ist erforderlich'),
+  typ: z.enum(['vereinsevent', 'probe', 'auffuehrung', 'sonstiges', 'meeting']),
+  status: z.enum(['geplant', 'bestaetigt', 'abgesagt', 'abgeschlossen']),
+  warteliste_aktiv: z.boolean(),
+  beschreibung: z
+    .string()
+    .max(2000, 'Beschreibung zu lang')
+    .nullable()
+    .optional(),
+  startzeit: z.string().nullable().optional(),
+  endzeit: z.string().nullable().optional(),
+  ort: z.string().max(200, 'Ort zu lang').nullable().optional(),
+  max_teilnehmer: z
+    .number()
+    .int()
+    .min(1, 'Mindestens 1 Teilnehmer')
+    .nullable()
+    .optional(),
+  organisator_id: z
+    .string()
+    .uuid('Ungültige Organisator-ID')
+    .nullable()
+    .optional(),
+  helfer_template_id: z
+    .string()
+    .uuid('Ungültige Template-ID')
+    .nullable()
+    .optional(),
+  helfer_status: z
+    .enum(['entwurf', 'veroeffentlicht', 'abgeschlossen'])
+    .nullable()
+    .optional(),
+  public_helfer_token: z.string().nullable().optional(),
+  max_schichten_pro_helfer: z
+    .number()
+    .int()
+    .min(1, 'Mindestens 1 Schicht')
+    .nullable()
+    .optional(),
+  helfer_buchung_deadline: z.string().nullable().optional(),
+  helfer_buchung_limit_aktiv: z.boolean().optional(),
+  koordinator_id: z
+    .string()
+    .uuid('Ungültige Koordinator-ID')
+    .nullable()
+    .optional(),
+})
+
+export const veranstaltungUpdateSchema = veranstaltungSchema.partial()


### PR DESCRIPTION
## Summary
- Created Zod schemas for `helfereinsaetze` (`helfereinsatzSchema`, `helfereinsatzUpdateSchema`, `helferrolleSchema`) and `veranstaltungen` (`veranstaltungSchema`, `veranstaltungUpdateSchema`)
- Added `validateInput()` calls to `createHelfereinsatz`, `updateHelfereinsatz`, `createVeranstaltung`, and `updateVeranstaltung` server actions
- Uses the existing `validateInput` helper from `lib/validations/modul2.ts` for consistent error handling

Closes #273

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run test:run` — all 96 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)