### PR TITLE
fix: sanitize iLike filter special characters (#274)

### DIFF
--- a/apps/web/lib/actions/externe-helfer.ts
+++ b/apps/web/lib/actions/externe-helfer.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from 'next/cache'
 import { createClient } from '../supabase/server'
 import { requirePermission } from '../supabase/auth-helpers'
+import { sanitizeSearchQuery } from '../utils/search'
 import type {
   ExterneHelferProfil,
   ExterneHelferProfilMitEinsaetze,
@@ -235,7 +236,7 @@ export async function searchExterneHelfer(
 
   const supabase = await createClient()
 
-  const searchTerm = `%${query}%`
+  const searchTerm = `%${sanitizeSearchQuery(query)}%`
 
   const { data, error } = await supabase
     .from('externe_helfer_profile')

--- a/apps/web/lib/actions/manual-assignment.ts
+++ b/apps/web/lib/actions/manual-assignment.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from 'next/cache'
 import { createClient, getUserProfile } from '../supabase/server'
 import { requirePermission } from '../supabase/auth-helpers'
+import { sanitizeSearchQuery } from '../utils/search'
 // Types used for reference but not directly imported
 // Person, Profile, ExterneHelferProfil are used in runtime queries
 
@@ -54,7 +55,7 @@ export async function searchHelfer(
   }
 
   const supabase = await createClient()
-  const searchPattern = `%${query}%`
+  const searchPattern = `%${sanitizeSearchQuery(query)}%`
 
   // Search internal profiles (via personen table)
   const { data: personen } = await supabase

--- a/apps/web/lib/actions/personen.ts
+++ b/apps/web/lib/actions/personen.ts
@@ -11,6 +11,7 @@ import type {
   PersonUpdate,
   UserRole,
 } from '../supabase/types'
+import { sanitizeSearchQuery } from '../utils/search'
 
 const USE_DUMMY_DATA = !process.env.NEXT_PUBLIC_SUPABASE_URL
 
@@ -78,7 +79,7 @@ export async function searchPersonenAction(query: string): Promise<Person[]> {
     .from('personen')
     .select('id, vorname, nachname, strasse, plz, ort, geburtstag, email, telefon, rolle, aktiv, notizen, notfallkontakt_name, notfallkontakt_telefon, notfallkontakt_beziehung, profilbild_url, biografie, mitglied_seit, austrittsdatum, austrittsgrund, skills, telefon_nummern, bevorzugte_kontaktart, social_media, kontakt_notizen, archiviert_am, archiviert_von, created_at, updated_at')
     .or(
-      `vorname.ilike.%${query}%,nachname.ilike.%${query}%,email.ilike.%${query}%`
+      `vorname.ilike.%${sanitizeSearchQuery(query)}%,nachname.ilike.%${sanitizeSearchQuery(query)}%,email.ilike.%${sanitizeSearchQuery(query)}%`
     )
     .order('nachname', { ascending: true })
 
@@ -458,8 +459,9 @@ export async function getPersonenAdvanced(
 
   // Search filter (use ilike for case-insensitive search)
   if (search) {
+    const sanitized = sanitizeSearchQuery(search)
     query = query.or(
-      `vorname.ilike.%${search}%,nachname.ilike.%${search}%,email.ilike.%${search}%`
+      `vorname.ilike.%${sanitized}%,nachname.ilike.%${sanitized}%,email.ilike.%${sanitized}%`
     )
   }
 

--- a/apps/web/lib/utils/search.ts
+++ b/apps/web/lib/utils/search.ts
@@ -1,0 +1,10 @@
+/**
+ * Sanitize a search query for use in iLike filters.
+ * Escapes SQL wildcard characters (% and _) and enforces a max length.
+ */
+export function sanitizeSearchQuery(query: string, maxLength = 100): string {
+  return query
+    .slice(0, maxLength)
+    .replace(/%/g, '\\%')
+    .replace(/_/g, '\\_')
+}


### PR DESCRIPTION
## Summary
- Add `sanitizeSearchQuery()` utility that escapes SQL wildcard characters (`%`, `_`) and enforces a 100-char max length
- Apply sanitization to all 4 vulnerable `.or()` iLike search locations in `personen.ts`, `manual-assignment.ts`, and `externe-helfer.ts`
- Prevents wildcard injection (e.g. searching `%` matching everything) and mitigates DoS via unbounded query length

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run test:run` — 96/96 tests passing
- [ ] Manual: search with `%` or `_` characters returns only literal matches
- [ ] Manual: verify long search queries (>100 chars) are truncated gracefully

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)