### PR TITLE
fix: force dynamic rendering for /mitmachen page

### DIFF
--- a/apps/web/app/(public)/mitmachen/page.tsx
+++ b/apps/web/app/(public)/mitmachen/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from 'next'
 import { getPublicShiftOverview } from '@/lib/actions/public-overview'
 import { PublicOverviewView } from '@/components/public-overview'
 
+export const dynamic = 'force-dynamic'
+
 export const metadata: Metadata = {
   title: 'Mitmachen | Theatergruppe Widen',
   description:


### PR DESCRIPTION
## Summary
- `/mitmachen` page was statically cached at build time because it uses `createAdminClient()` (no cookies)
- Added `export const dynamic = 'force-dynamic'` to ensure fresh data on every request

## Test plan
- [ ] Visit `/mitmachen` → should show published events with available shifts

🤖 Generated with [Claude Code](https://claude.com/claude-code)