### PR TITLE
fix: make person_id nullable for external helper registrations

### DIFF
--- a/supabase/migrations/20260228200000_fix_zuweisungen_person_nullable.sql
+++ b/supabase/migrations/20260228200000_fix_zuweisungen_person_nullable.sql
@@ -1,0 +1,6 @@
+-- Migration: Make person_id nullable on auffuehrung_zuweisungen
+-- Created: 2026-02-15
+-- Description: External helpers register with external_helper_id, not person_id.
+--   The NOT NULL constraint on person_id prevented external registrations.
+
+ALTER TABLE auffuehrung_zuweisungen ALTER COLUMN person_id DROP NOT NULL;


### PR DESCRIPTION
## Summary
- `person_id` on `auffuehrung_zuweisungen` was `NOT NULL`, preventing external helper registrations
- External helpers use `external_helper_id` instead of `person_id`
- Migration already applied to production DB

## Test plan
- [x] External registration via `/helfer/anmeldung/[token]` works
- [x] External registration via `/mitmachen` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)