### PR TITLE
feat: send confirmation email after external helper registration

### DIFF
--- a/apps/web/lib/actions/email-sender.ts
+++ b/apps/web/lib/actions/email-sender.ts
@@ -71,7 +71,7 @@ async function updateEmailLogStatus(
 /**
  * Get veranstaltung coordinator info
  */
-async function getKoordinatorInfo(koordinatorId: string | null): Promise<{
+export async function getKoordinatorInfo(koordinatorId: string | null): Promise<{
   name: string
   email: string
   telefon: string


### PR DESCRIPTION
## Summary
- Both public registration flows (`/mitmachen` multi-shift and `/helfer/anmeldung/[token]` single-shift) now send a fire-and-forget confirmation email after successful registration
- Reuses the existing `multiRegistrationConfirmationEmail` template with shift details, dashboard link, cancellation links, and coordinator info
- Exported `getKoordinatorInfo` from `email-sender.ts` for reuse across registration flows

## Test plan
- [ ] Register as external helper via `/mitmachen` → verify confirmation email received with all shifts listed
- [ ] Register as external helper via `/helfer/anmeldung/[token]` → verify confirmation email received with single shift
- [ ] Verify email contains correct dashboard link, cancellation links, and coordinator info
- [ ] Verify registration still succeeds if email sending fails (fire-and-forget)
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm run test:run` passes (96/96)

🤖 Generated with [Claude Code](https://claude.com/claude-code)