### PR TITLE
feat: add Alle Helfer overview page

### DIFF
--- a/apps/web/app/(protected)/alle-helfer/page.tsx
+++ b/apps/web/app/(protected)/alle-helfer/page.tsx
@@ -1,0 +1,55 @@
+import Link from 'next/link'
+import {
+  getAlleHelfer,
+  type AlleHelferFilterParams,
+  type AlleHelferSortField,
+  type SortOrder,
+  type HelferTyp,
+} from '@/lib/actions/alle-helfer'
+import { AlleHelferTable } from '@/components/alle-helfer/AlleHelferTable'
+
+interface PageProps {
+  searchParams: Promise<{
+    search?: string
+    typ?: string
+    sortBy?: string
+    sortOrder?: string
+  }>
+}
+
+export default async function AlleHelferPage({ searchParams }: PageProps) {
+  const params = await searchParams
+
+  const filterParams: AlleHelferFilterParams = {
+    search: params.search || '',
+    typ: (params.typ as HelferTyp | 'alle') || 'alle',
+    sortBy: (params.sortBy as AlleHelferSortField) || 'name',
+    sortOrder: (params.sortOrder as SortOrder) || 'asc',
+  }
+
+  const helfer = await getAlleHelfer(filterParams)
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <div className="mx-auto max-w-7xl px-4 py-8">
+        {/* Header */}
+        <div className="mb-8">
+          <h1 className="text-2xl font-bold text-gray-900">Alle Helfer</h1>
+          <p className="mt-1 text-gray-600">
+            Übersicht aller internen und externen Helfer mit ihren Einsätzen
+          </p>
+        </div>
+
+        {/* Table with Filters */}
+        <AlleHelferTable helfer={helfer} filterParams={filterParams} />
+
+        {/* Back Link */}
+        <div className="mt-8">
+          <Link href="/dashboard" className="text-blue-600 hover:text-blue-800">
+            &larr; Zurück zum Dashboard
+          </Link>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/apps/web/components/alle-helfer/AlleHelferTable.tsx
+++ b/apps/web/components/alle-helfer/AlleHelferTable.tsx
@@ -1,0 +1,222 @@
+'use client'
+
+import { useRouter, useSearchParams } from 'next/navigation'
+import Link from 'next/link'
+import type {
+  HelferUebersicht,
+  AlleHelferFilterParams,
+  AlleHelferSortField,
+  HelferTyp,
+} from '@/lib/actions/alle-helfer'
+
+interface AlleHelferTableProps {
+  helfer: HelferUebersicht[]
+  filterParams: AlleHelferFilterParams
+}
+
+const TYP_OPTIONS: { value: HelferTyp | 'alle'; label: string }[] = [
+  { value: 'alle', label: 'Alle' },
+  { value: 'intern', label: 'Intern' },
+  { value: 'extern', label: 'Extern' },
+]
+
+export function AlleHelferTable({
+  helfer,
+  filterParams = {},
+}: AlleHelferTableProps) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const {
+    search = '',
+    typ = 'alle',
+    sortBy = 'name',
+    sortOrder = 'asc',
+  } = filterParams
+
+  const updateParams = (updates: Partial<AlleHelferFilterParams>) => {
+    const params = new URLSearchParams(searchParams.toString())
+
+    Object.entries(updates).forEach(([key, value]) => {
+      params.delete(key)
+      if (value !== undefined && value !== '' && value !== null) {
+        params.set(key, String(value))
+      }
+    })
+
+    // Remove default values
+    if (params.get('typ') === 'alle') params.delete('typ')
+    if (params.get('sortBy') === 'name') params.delete('sortBy')
+    if (params.get('sortOrder') === 'asc') params.delete('sortOrder')
+    if (params.get('search') === '') params.delete('search')
+
+    const queryString = params.toString()
+    router.push(`/alle-helfer${queryString ? `?${queryString}` : ''}` as never)
+  }
+
+  const toggleSort = (field: AlleHelferSortField) => {
+    if (sortBy === field) {
+      updateParams({ sortOrder: sortOrder === 'asc' ? 'desc' : 'asc' })
+    } else {
+      updateParams({ sortBy: field, sortOrder: 'asc' })
+    }
+  }
+
+  const SortIcon = ({ field }: { field: AlleHelferSortField }) => {
+    if (sortBy !== field) return <span className="ml-1 text-gray-400">&#8597;</span>
+    return (
+      <span className="ml-1">{sortOrder === 'asc' ? '\u2191' : '\u2193'}</span>
+    )
+  }
+
+  const formatDate = (dateStr: string | null) => {
+    if (!dateStr) return '-'
+    return new Date(dateStr).toLocaleDateString('de-CH', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    })
+  }
+
+  return (
+    <div>
+      {/* Filters */}
+      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center">
+        <div className="flex-1">
+          <input
+            type="text"
+            placeholder="Suchen nach Name oder E-Mail..."
+            defaultValue={search}
+            onChange={(e) => {
+              const value = e.target.value
+              const timeout = setTimeout(() => {
+                updateParams({ search: value })
+              }, 300)
+              return () => clearTimeout(timeout)
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                updateParams({ search: e.currentTarget.value })
+              }
+            }}
+            className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-blue-500 focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+
+        <div className="flex rounded-lg border border-gray-300 bg-white">
+          {TYP_OPTIONS.map((option, idx) => (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => updateParams({ typ: option.value })}
+              className={`px-4 py-2 text-sm font-medium transition-colors ${
+                typ === option.value
+                  ? 'bg-blue-600 text-white'
+                  : 'text-gray-600 hover:bg-gray-100'
+              } ${idx === 0 ? 'rounded-l-lg' : ''} ${idx === TYP_OPTIONS.length - 1 ? 'rounded-r-lg' : 'border-l border-gray-300'}`}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto rounded-lg bg-white shadow">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th
+                className="cursor-pointer px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 hover:bg-gray-100"
+                onClick={() => toggleSort('name')}
+              >
+                Name <SortIcon field="name" />
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                Typ
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                E-Mail
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                Telefon
+              </th>
+              <th
+                className="cursor-pointer px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 hover:bg-gray-100"
+                onClick={() => toggleSort('einsaetze')}
+              >
+                Einsätze <SortIcon field="einsaetze" />
+              </th>
+              <th
+                className="cursor-pointer px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 hover:bg-gray-100"
+                onClick={() => toggleSort('letzter_einsatz')}
+              >
+                Letzter Einsatz <SortIcon field="letzter_einsatz" />
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 bg-white">
+            {helfer.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={6}
+                  className="px-6 py-8 text-center text-gray-500"
+                >
+                  Keine Helfer gefunden
+                </td>
+              </tr>
+            ) : (
+              helfer.map((h) => (
+                <tr key={`${h.typ}-${h.id}`} className="hover:bg-gray-50">
+                  <td className="whitespace-nowrap px-6 py-4">
+                    {h.typ === 'intern' ? (
+                      <Link
+                        href={`/mitglieder/${h.id}` as never}
+                        className="font-medium text-blue-600 hover:text-blue-900"
+                      >
+                        {h.vorname} {h.nachname}
+                      </Link>
+                    ) : (
+                      <span className="font-medium text-gray-900">
+                        {h.vorname} {h.nachname}
+                      </span>
+                    )}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4">
+                    <span
+                      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                        h.typ === 'intern'
+                          ? 'bg-green-100 text-green-800'
+                          : 'bg-blue-100 text-blue-800'
+                      }`}
+                    >
+                      {h.typ === 'intern' ? 'Intern' : 'Extern'}
+                    </span>
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-900">
+                    {h.email || '-'}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
+                    {h.telefon || '-'}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-900">
+                    {h.einsaetze_count}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
+                    {formatDate(h.letzter_einsatz)}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Count */}
+      <div className="mt-4 text-sm text-gray-500">
+        {helfer.length} Helfer
+        {typ !== 'alle' && ` (${typ === 'intern' ? 'intern' : 'extern'})`}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/lib/actions/alle-helfer.ts
+++ b/apps/web/lib/actions/alle-helfer.ts
@@ -1,0 +1,169 @@
+'use server'
+
+import { createClient } from '../supabase/server'
+import { requirePermission } from '../supabase/auth-helpers'
+import { sanitizeSearchQuery } from '../utils/search'
+
+export type HelferTyp = 'intern' | 'extern'
+export type AlleHelferSortField = 'name' | 'einsaetze' | 'letzter_einsatz'
+export type SortOrder = 'asc' | 'desc'
+
+export interface HelferUebersicht {
+  id: string
+  typ: HelferTyp
+  vorname: string
+  nachname: string
+  email: string | null
+  telefon: string | null
+  einsaetze_count: number
+  letzter_einsatz: string | null
+}
+
+export interface AlleHelferFilterParams {
+  search?: string
+  typ?: HelferTyp | 'alle'
+  sortBy?: AlleHelferSortField
+  sortOrder?: SortOrder
+}
+
+/**
+ * Get consolidated list of all helpers (internal + external)
+ */
+export async function getAlleHelfer(
+  params: AlleHelferFilterParams = {}
+): Promise<HelferUebersicht[]> {
+  await requirePermission('mitglieder:read')
+
+  const {
+    search = '',
+    typ = 'alle',
+    sortBy = 'name',
+    sortOrder = 'asc',
+  } = params
+
+  const supabase = await createClient()
+  const results: HelferUebersicht[] = []
+
+  // Fetch internal helpers (personen with auffuehrung_zuweisungen)
+  if (typ === 'alle' || typ === 'intern') {
+    const { data: interne, error: interneError } = await supabase
+      .from('auffuehrung_zuweisungen')
+      .select(`
+        person_id,
+        created_at,
+        person:personen!auffuehrung_zuweisungen_person_id_fkey(
+          id, vorname, nachname, email, telefon
+        )
+      `)
+      .not('person_id', 'is', null)
+
+    if (interneError) {
+      console.error('Error fetching internal helpers:', interneError)
+    } else if (interne) {
+      // Group by person_id to get counts and latest assignment
+      const personMap = new Map<
+        string,
+        {
+          person: { id: string; vorname: string; nachname: string; email: string | null; telefon: string | null }
+          count: number
+          letzter_einsatz: string | null
+        }
+      >()
+
+      for (const z of interne) {
+        if (!z.person_id || !z.person) continue
+        const person = z.person as unknown as {
+          id: string; vorname: string; nachname: string; email: string | null; telefon: string | null
+        }
+
+        const existing = personMap.get(z.person_id)
+        if (existing) {
+          existing.count++
+          if (z.created_at > (existing.letzter_einsatz || '')) {
+            existing.letzter_einsatz = z.created_at
+          }
+        } else {
+          personMap.set(z.person_id, {
+            person,
+            count: 1,
+            letzter_einsatz: z.created_at,
+          })
+        }
+      }
+
+      for (const [, entry] of personMap) {
+        results.push({
+          id: entry.person.id,
+          typ: 'intern',
+          vorname: entry.person.vorname,
+          nachname: entry.person.nachname,
+          email: entry.person.email,
+          telefon: entry.person.telefon,
+          einsaetze_count: entry.count,
+          letzter_einsatz: entry.letzter_einsatz,
+        })
+      }
+    }
+  }
+
+  // Fetch external helpers
+  if (typ === 'alle' || typ === 'extern') {
+    const { data: externe, error: externeError } = await supabase
+      .from('externe_helfer_profile')
+      .select(`
+        id, vorname, nachname, email, telefon, letzter_einsatz,
+        anmeldungen:helfer_anmeldungen(id)
+      `)
+
+    if (externeError) {
+      console.error('Error fetching external helpers:', externeError)
+    } else if (externe) {
+      for (const ext of externe) {
+        results.push({
+          id: ext.id,
+          typ: 'extern',
+          vorname: ext.vorname,
+          nachname: ext.nachname,
+          email: ext.email,
+          telefon: ext.telefon,
+          einsaetze_count: (ext.anmeldungen as unknown[] | null)?.length || 0,
+          letzter_einsatz: ext.letzter_einsatz,
+        })
+      }
+    }
+  }
+
+  // Apply search filter
+  const filtered = search
+    ? results.filter((h) => {
+        const sanitized = sanitizeSearchQuery(search).toLowerCase()
+        const name = `${h.vorname} ${h.nachname}`.toLowerCase()
+        const email = (h.email || '').toLowerCase()
+        return name.includes(sanitized) || email.includes(sanitized)
+      })
+    : results
+
+  // Sort
+  filtered.sort((a, b) => {
+    let cmp = 0
+    switch (sortBy) {
+      case 'name':
+        cmp = `${a.nachname} ${a.vorname}`.localeCompare(
+          `${b.nachname} ${b.vorname}`,
+          'de'
+        )
+        break
+      case 'einsaetze':
+        cmp = a.einsaetze_count - b.einsaetze_count
+        break
+      case 'letzter_einsatz':
+        cmp = (a.letzter_einsatz || '').localeCompare(
+          b.letzter_einsatz || ''
+        )
+        break
+    }
+    return sortOrder === 'desc' ? -cmp : cmp
+  })
+
+  return filtered
+}

--- a/apps/web/lib/navigation.ts
+++ b/apps/web/lib/navigation.ts
@@ -97,6 +97,12 @@ const MANAGEMENT_NAVIGATION: NavSection[] = [
         icon: 'partner',
         permission: 'partner:read',
       },
+      {
+        href: '/alle-helfer',
+        label: 'Alle Helfer',
+        icon: 'users',
+        permission: 'mitglieder:read',
+      },
     ],
   },
   {
@@ -364,6 +370,7 @@ export function canAccessRoute(role: UserRole, route: string): boolean {
   const roleRoutes: Record<string, UserRole[]> = {
     '/dashboard': ['ADMIN', 'VORSTAND'],
     '/mitglieder': ['ADMIN', 'VORSTAND'],
+    '/alle-helfer': ['ADMIN', 'VORSTAND'],
     '/partner': ['ADMIN', 'VORSTAND', 'PARTNER'],
     '/helfer': ['ADMIN', 'VORSTAND', 'HELFER'],
     '/partner-portal': ['ADMIN', 'VORSTAND', 'PARTNER'],
@@ -433,6 +440,7 @@ export const BREADCRUMB_LABELS: Record<string, string> = {
   dashboard: 'Dashboard',
   mitglieder: 'Mitglieder',
   partner: 'Partner',
+  'alle-helfer': 'Alle Helfer',
   kalender: 'Kalender',
   veranstaltungen: 'Veranstaltungen',
   auffuehrungen: 'Aufführungen',


### PR DESCRIPTION
## Summary
- Adds `/alle-helfer` route with a consolidated, filterable table showing all internal (personen with auffuehrung_zuweisungen) and external (externe_helfer_profile) helpers
- Supports search by name/email, type filter (Alle/Intern/Extern), and sortable columns (Name, Einsätze, Letzter Einsatz)
- Access restricted to ADMIN and VORSTAND roles via navigation and route access config

## Test plan
- [ ] Navigate to `/alle-helfer` as ADMIN — page loads with all helpers
- [ ] Verify internal helpers show linked names to `/mitglieder/[id]`, external helpers show plain text
- [ ] Test search filter by name and email
- [ ] Test type toggle (Alle / Intern / Extern)
- [ ] Test column sorting (Name, Einsätze, Letzter Einsatz)
- [ ] Verify non-management roles cannot access the route
- [ ] Verify "Alle Helfer" appears in sidebar under "Personen" section

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)