### PR TITLE
feat: add multi-selection and email/CSV export to Alle Helfer page

### DIFF
--- a/apps/web/components/alle-helfer/AlleHelferTable.tsx
+++ b/apps/web/components/alle-helfer/AlleHelferTable.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState, useMemo, useCallback } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import type {
@@ -8,6 +9,7 @@ import type {
   AlleHelferSortField,
   HelferTyp,
 } from '@/lib/actions/alle-helfer'
+import { HelferExportDialog } from './HelferExportDialog'
 
 interface AlleHelferTableProps {
   helfer: HelferUebersicht[]
@@ -20,12 +22,19 @@ const TYP_OPTIONS: { value: HelferTyp | 'alle'; label: string }[] = [
   { value: 'extern', label: 'Extern' },
 ]
 
+function helferKey(h: HelferUebersicht): string {
+  return `${h.typ}-${h.id}`
+}
+
 export function AlleHelferTable({
   helfer,
   filterParams = {},
 }: AlleHelferTableProps) {
   const router = useRouter()
   const searchParams = useSearchParams()
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [copiedEmails, setCopiedEmails] = useState(false)
+  const [showExportDialog, setShowExportDialog] = useState(false)
 
   const {
     search = '',
@@ -50,6 +59,9 @@ export function AlleHelferTable({
     if (params.get('sortOrder') === 'asc') params.delete('sortOrder')
     if (params.get('search') === '') params.delete('search')
 
+    // Reset selection on filter change
+    setSelectedIds(new Set())
+
     const queryString = params.toString()
     router.push(`/alle-helfer${queryString ? `?${queryString}` : ''}` as never)
   }
@@ -59,6 +71,54 @@ export function AlleHelferTable({
       updateParams({ sortOrder: sortOrder === 'asc' ? 'desc' : 'asc' })
     } else {
       updateParams({ sortBy: field, sortOrder: 'asc' })
+    }
+  }
+
+  const allKeys = useMemo(() => new Set(helfer.map(helferKey)), [helfer])
+
+  const allSelected = helfer.length > 0 && allKeys.size === selectedIds.size &&
+    [...allKeys].every((k) => selectedIds.has(k))
+
+  const toggleSelectAll = useCallback(() => {
+    if (allSelected) {
+      setSelectedIds(new Set())
+    } else {
+      setSelectedIds(new Set(allKeys))
+    }
+  }, [allSelected, allKeys])
+
+  const toggleSelect = useCallback((key: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) {
+        next.delete(key)
+      } else {
+        next.add(key)
+      }
+      return next
+    })
+  }, [])
+
+  const selectedHelfer = useMemo(
+    () => helfer.filter((h) => selectedIds.has(helferKey(h))),
+    [helfer, selectedIds]
+  )
+
+  const handleCopyEmails = async () => {
+    const emails = selectedHelfer
+      .filter((h) => h.email)
+      .map((h) => h.email!)
+      .filter((e, i, a) => a.indexOf(e) === i)
+      .join('; ')
+
+    if (!emails) return
+
+    try {
+      await navigator.clipboard.writeText(emails)
+      setCopiedEmails(true)
+      setTimeout(() => setCopiedEmails(false), 2000)
+    } catch (err) {
+      console.error('Failed to copy emails:', err)
     }
   }
 
@@ -77,6 +137,8 @@ export function AlleHelferTable({
       year: 'numeric',
     })
   }
+
+  const selectedEmailCount = selectedHelfer.filter((h) => h.email).length
 
   return (
     <div>
@@ -121,11 +183,73 @@ export function AlleHelferTable({
         </div>
       </div>
 
+      {/* Action Bar */}
+      {selectedIds.size > 0 && (
+        <div className="mb-4 flex flex-wrap items-center gap-3 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3">
+          <span className="text-sm font-medium text-blue-800">
+            {selectedIds.size} ausgewählt
+          </span>
+
+          <div className="h-4 w-px bg-blue-200" />
+
+          <button
+            type="button"
+            onClick={handleCopyEmails}
+            disabled={selectedEmailCount === 0}
+            className="inline-flex items-center gap-1.5 rounded-md bg-white px-3 py-1.5 text-sm font-medium text-gray-700 shadow-sm ring-1 ring-gray-300 hover:bg-gray-50 disabled:opacity-50"
+          >
+            {copiedEmails ? (
+              <>
+                <svg className="h-4 w-4 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                </svg>
+                Kopiert!
+              </>
+            ) : (
+              <>
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                </svg>
+                E-Mails kopieren
+              </>
+            )}
+          </button>
+
+          <button
+            type="button"
+            onClick={() => setShowExportDialog(true)}
+            className="inline-flex items-center gap-1.5 rounded-md bg-white px-3 py-1.5 text-sm font-medium text-gray-700 shadow-sm ring-1 ring-gray-300 hover:bg-gray-50"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            </svg>
+            Export
+          </button>
+
+          <button
+            type="button"
+            onClick={() => setSelectedIds(new Set())}
+            className="ml-auto text-sm text-blue-600 hover:text-blue-800"
+          >
+            Auswahl aufheben
+          </button>
+        </div>
+      )}
+
       {/* Table */}
       <div className="overflow-x-auto rounded-lg bg-white shadow">
         <table className="min-w-full divide-y divide-gray-200">
           <thead className="bg-gray-50">
             <tr>
+              <th className="w-10 px-3 py-3">
+                <input
+                  type="checkbox"
+                  checked={allSelected}
+                  onChange={toggleSelectAll}
+                  className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  aria-label="Alle auswählen"
+                />
+              </th>
               <th
                 className="cursor-pointer px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 hover:bg-gray-100"
                 onClick={() => toggleSort('name')}
@@ -159,54 +283,66 @@ export function AlleHelferTable({
             {helfer.length === 0 ? (
               <tr>
                 <td
-                  colSpan={6}
+                  colSpan={7}
                   className="px-6 py-8 text-center text-gray-500"
                 >
                   Keine Helfer gefunden
                 </td>
               </tr>
             ) : (
-              helfer.map((h) => (
-                <tr key={`${h.typ}-${h.id}`} className="hover:bg-gray-50">
-                  <td className="whitespace-nowrap px-6 py-4">
-                    {h.typ === 'intern' ? (
-                      <Link
-                        href={`/mitglieder/${h.id}` as never}
-                        className="font-medium text-blue-600 hover:text-blue-900"
+              helfer.map((h) => {
+                const key = helferKey(h)
+                return (
+                  <tr key={key} className="hover:bg-gray-50">
+                    <td className="w-10 px-3 py-4">
+                      <input
+                        type="checkbox"
+                        checked={selectedIds.has(key)}
+                        onChange={() => toggleSelect(key)}
+                        className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                        aria-label={`${h.vorname} ${h.nachname} auswählen`}
+                      />
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4">
+                      {h.typ === 'intern' ? (
+                        <Link
+                          href={`/mitglieder/${h.id}` as never}
+                          className="font-medium text-blue-600 hover:text-blue-900"
+                        >
+                          {h.vorname} {h.nachname}
+                        </Link>
+                      ) : (
+                        <span className="font-medium text-gray-900">
+                          {h.vorname} {h.nachname}
+                        </span>
+                      )}
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4">
+                      <span
+                        className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                          h.typ === 'intern'
+                            ? 'bg-green-100 text-green-800'
+                            : 'bg-blue-100 text-blue-800'
+                        }`}
                       >
-                        {h.vorname} {h.nachname}
-                      </Link>
-                    ) : (
-                      <span className="font-medium text-gray-900">
-                        {h.vorname} {h.nachname}
+                        {h.typ === 'intern' ? 'Intern' : 'Extern'}
                       </span>
-                    )}
-                  </td>
-                  <td className="whitespace-nowrap px-6 py-4">
-                    <span
-                      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
-                        h.typ === 'intern'
-                          ? 'bg-green-100 text-green-800'
-                          : 'bg-blue-100 text-blue-800'
-                      }`}
-                    >
-                      {h.typ === 'intern' ? 'Intern' : 'Extern'}
-                    </span>
-                  </td>
-                  <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-900">
-                    {h.email || '-'}
-                  </td>
-                  <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
-                    {h.telefon || '-'}
-                  </td>
-                  <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-900">
-                    {h.einsaetze_count}
-                  </td>
-                  <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
-                    {formatDate(h.letzter_einsatz)}
-                  </td>
-                </tr>
-              ))
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-900">
+                      {h.email || '-'}
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
+                      {h.telefon || '-'}
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-900">
+                      {h.einsaetze_count}
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
+                      {formatDate(h.letzter_einsatz)}
+                    </td>
+                  </tr>
+                )
+              })
             )}
           </tbody>
         </table>
@@ -217,6 +353,14 @@ export function AlleHelferTable({
         {helfer.length} Helfer
         {typ !== 'alle' && ` (${typ === 'intern' ? 'intern' : 'extern'})`}
       </div>
+
+      {/* Export Dialog */}
+      {showExportDialog && (
+        <HelferExportDialog
+          helfer={selectedHelfer}
+          onClose={() => setShowExportDialog(false)}
+        />
+      )}
     </div>
   )
 }

--- a/apps/web/components/alle-helfer/HelferExportDialog.tsx
+++ b/apps/web/components/alle-helfer/HelferExportDialog.tsx
@@ -1,0 +1,208 @@
+'use client'
+
+import { useState } from 'react'
+import type { HelferUebersicht } from '@/lib/actions/alle-helfer'
+
+interface HelferExportColumn {
+  key: string
+  label: string
+  enabled: boolean
+  getValue: (h: HelferUebersicht) => string
+}
+
+interface HelferExportDialogProps {
+  helfer: HelferUebersicht[]
+  onClose: () => void
+}
+
+const createColumns = (): HelferExportColumn[] => [
+  {
+    key: 'name',
+    label: 'Name',
+    enabled: true,
+    getValue: (h) => `${h.vorname} ${h.nachname}`,
+  },
+  {
+    key: 'typ',
+    label: 'Typ',
+    enabled: true,
+    getValue: (h) => (h.typ === 'intern' ? 'Intern' : 'Extern'),
+  },
+  {
+    key: 'email',
+    label: 'E-Mail',
+    enabled: true,
+    getValue: (h) => h.email || '',
+  },
+  {
+    key: 'telefon',
+    label: 'Telefon',
+    enabled: true,
+    getValue: (h) => h.telefon || '',
+  },
+  {
+    key: 'einsaetze',
+    label: 'Einsätze',
+    enabled: true,
+    getValue: (h) => String(h.einsaetze_count),
+  },
+  {
+    key: 'letzter_einsatz',
+    label: 'Letzter Einsatz',
+    enabled: false,
+    getValue: (h) =>
+      h.letzter_einsatz
+        ? new Date(h.letzter_einsatz).toLocaleDateString('de-CH', {
+            day: '2-digit',
+            month: '2-digit',
+            year: 'numeric',
+          })
+        : '',
+  },
+]
+
+function downloadFile(content: string, filename: string, mimeType: string) {
+  const blob = new Blob(['\ufeff' + content], { type: mimeType })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+}
+
+function escapeCSV(value: string): string {
+  if (value.includes(';') || value.includes('"') || value.includes('\n')) {
+    return `"${value.replace(/"/g, '""')}"`
+  }
+  return value
+}
+
+export function HelferExportDialog({
+  helfer,
+  onClose,
+}: HelferExportDialogProps) {
+  const [columns, setColumns] = useState<HelferExportColumn[]>(createColumns)
+
+  const toggleColumn = (key: string) => {
+    setColumns((cols) =>
+      cols.map((c) => (c.key === key ? { ...c, enabled: !c.enabled } : c))
+    )
+  }
+
+  const handleExportCSV = () => {
+    const enabledCols = columns.filter((c) => c.enabled)
+    const header = enabledCols.map((c) => escapeCSV(c.label)).join(';')
+    const rows = helfer.map((h) =>
+      enabledCols.map((c) => escapeCSV(c.getValue(h))).join(';')
+    )
+    const csv = [header, ...rows].join('\n')
+    const date = new Date().toISOString().slice(0, 10)
+    downloadFile(csv, `helfer-export-${date}.csv`, 'text/csv;charset=utf-8')
+    onClose()
+  }
+
+  const handleExportEmails = () => {
+    const emails = helfer
+      .filter((h) => h.email)
+      .map((h) => h.email!)
+      .filter((e, i, a) => a.indexOf(e) === i)
+      .join('; ')
+    const date = new Date().toISOString().slice(0, 10)
+    downloadFile(
+      emails,
+      `helfer-emails-${date}.txt`,
+      'text/plain;charset=utf-8'
+    )
+    onClose()
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-gray-900">
+            Helfer exportieren
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600"
+          >
+            <svg
+              className="h-6 w-6"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <div className="mb-4 rounded-lg bg-blue-50 p-3 text-sm text-blue-700">
+          <strong>{helfer.length}</strong> Helfer werden exportiert.
+        </div>
+
+        {/* Column Selection */}
+        <div className="mb-6">
+          <h3 className="mb-2 text-sm font-medium text-gray-700">
+            Spalten auswählen
+          </h3>
+          <div className="grid grid-cols-2 gap-2">
+            {columns.map((col) => (
+              <label
+                key={col.key}
+                className="flex items-center gap-2 rounded border border-gray-200 p-2 hover:bg-gray-50"
+              >
+                <input
+                  type="checkbox"
+                  checked={col.enabled}
+                  onChange={() => toggleColumn(col.key)}
+                  className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                />
+                <span className="text-sm text-gray-700">{col.label}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+
+        {/* Export Buttons */}
+        <div className="flex flex-col gap-3">
+          <button
+            type="button"
+            onClick={handleExportCSV}
+            disabled={columns.every((c) => !c.enabled)}
+            className="w-full rounded-lg bg-blue-600 px-4 py-2 font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
+          >
+            Als CSV exportieren
+          </button>
+
+          <button
+            type="button"
+            onClick={handleExportEmails}
+            disabled={!helfer.some((h) => h.email)}
+            className="w-full rounded-lg border border-gray-300 bg-white px-4 py-2 font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:opacity-50"
+          >
+            Nur E-Mail-Liste exportieren
+          </button>
+
+          <button
+            type="button"
+            onClick={onClose}
+            className="w-full px-4 py-2 text-sm text-gray-500 hover:text-gray-700"
+          >
+            Abbrechen
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- **Checkbox-based multi-selection** on the Alle Helfer table with "select all" in header
- **Action bar** appears on selection with counter, "E-Mails kopieren" (clipboard), "Export" (dialog), and "Auswahl aufheben"
- **HelferExportDialog** with column selection, CSV export (BOM + semicolon-delimited), and email-only .txt export
- Selection resets automatically on filter/sort changes

## Test plan
- [ ] Select individual helpers via checkboxes, verify action bar appears with correct count
- [ ] Use "Alle auswählen" checkbox in header, verify all rows selected
- [ ] Click "E-Mails kopieren" — verify semicolon-separated emails copied to clipboard with "Kopiert!" feedback
- [ ] Click "Export" — verify dialog opens with column checkboxes and correct selected helper count
- [ ] Export CSV — verify file downloads with BOM, correct columns, semicolon delimiter
- [ ] Export email list — verify .txt file with deduplicated semicolon-separated emails
- [ ] Change filter/search — verify selection is reset
- [ ] Verify `npm run typecheck`, `npm run lint`, `npm run test:run` all pass

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)