### PR TITLE
fix: handle null person in Aufführungen zuweisungen list

### DIFF
--- a/apps/web/components/auffuehrungen/SchichtZuweisungListe.tsx
+++ b/apps/web/components/auffuehrungen/SchichtZuweisungListe.tsx
@@ -175,7 +175,14 @@ export function SchichtZuweisungListe({
                       className="flex items-center justify-between rounded-lg bg-gray-50 px-3 py-2"
                     >
                       <span className="text-sm text-gray-900">
-                        {z.person.vorname} {z.person.nachname}
+                        {z.person
+                          ? `${z.person.vorname} ${z.person.nachname}`
+                          : z.external_helper
+                            ? `${z.external_helper.vorname} ${z.external_helper.nachname}`
+                            : 'Unbekannt'}
+                        {!z.person && (
+                          <span className="ml-1 text-xs text-gray-500">(Extern)</span>
+                        )}
                       </span>
                       <div className="flex items-center gap-2">
                         {canEdit ? (

--- a/apps/web/lib/actions/auffuehrung-schichten.ts
+++ b/apps/web/lib/actions/auffuehrung-schichten.ts
@@ -217,7 +217,8 @@ export async function getZuweisungen(
     .select(
       `
       *,
-      person:personen(id, vorname, nachname, email)
+      person:personen(id, vorname, nachname, email),
+      external_helper:externe_helfer_profile(id, vorname, nachname, email)
     `
     )
     .eq('schicht_id', schichtId)
@@ -256,7 +257,8 @@ export async function getZuweisungenForVeranstaltung(
     .select(
       `
       *,
-      person:personen(id, vorname, nachname, email)
+      person:personen(id, vorname, nachname, email),
+      external_helper:externe_helfer_profile(id, vorname, nachname, email)
     `
     )
     .in('schicht_id', schichtIds)

--- a/apps/web/lib/supabase/types.ts
+++ b/apps/web/lib/supabase/types.ts
@@ -684,9 +684,10 @@ export type AuffuehrungZuweisungInsert = Omit<
 }
 export type AuffuehrungZuweisungUpdate = Partial<AuffuehrungZuweisungInsert>
 
-// Extended type with person details
+// Extended type with person/external helper details
 export type ZuweisungMitPerson = AuffuehrungZuweisung & {
-  person: Pick<Person, 'id' | 'vorname' | 'nachname' | 'email'>
+  person: Pick<Person, 'id' | 'vorname' | 'nachname' | 'email'> | null
+  external_helper: Pick<ExterneHelferProfil, 'id' | 'vorname' | 'nachname' | 'email'> | null
 }
 
 // Extended type with full shift details


### PR DESCRIPTION
## Summary
- Handle nullable `person_id` on `auffuehrung_zuweisungen` by displaying external helper name with "(Extern)" badge when person is null
- Include `external_helper` relation in Supabase queries for `getZuweisungen` and `getZuweisungenForVeranstaltung`
- Update `ZuweisungMitPerson` type to allow null person and add optional `external_helper` field

## Test plan
- [ ] Verify Aufführungen shift list renders correctly for internal helpers (person present)
- [ ] Verify external helpers show name with "(Extern)" label
- [ ] Verify "Unbekannt" fallback when neither person nor external helper is set
- [ ] Verify `npm run typecheck`, `npm run lint`, `npm run test:run` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)