### PR TITLE
feat: grid layout for mitmachen shift cards

### DIFF
--- a/apps/web/app/(public)/mitmachen/page.tsx
+++ b/apps/web/app/(public)/mitmachen/page.tsx
@@ -21,7 +21,7 @@ export default async function MitmachenPage() {
 
   return (
     <main className="min-h-screen bg-gray-50">
-      <div className="mx-auto max-w-4xl px-4 py-8">
+      <div className="mx-auto max-w-6xl px-4 py-8">
         {/* Header */}
         <div className="mb-8 text-center">
           <div className="mb-4 inline-flex items-center gap-2 rounded-full bg-primary-100 px-4 py-1 text-sm font-medium text-primary-700">

--- a/apps/web/components/public-overview/EventGroup.tsx
+++ b/apps/web/components/public-overview/EventGroup.tsx
@@ -105,7 +105,7 @@ export function EventGroup({
                   {zeitblock.endzeit.slice(0, 5)} Uhr
                 </span>
               </div>
-              <div className="space-y-1.5">
+              <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
                 {availableSchichten.map((schicht) => (
                   <SelectableSchichtCard
                     key={schicht.id}
@@ -123,18 +123,18 @@ export function EventGroup({
                       onToggle={onToggleSchicht}
                     />
                   ))}
-                {fullSchichten.length > 0 && (
-                  <button
-                    type="button"
-                    onClick={() => toggleShowFull(zeitblock.id)}
-                    className="mt-1 text-xs text-gray-400 hover:text-gray-600"
-                  >
-                    {showingFull
-                      ? 'Belegte Rollen ausblenden'
-                      : `${fullSchichten.length} belegte ${fullSchichten.length === 1 ? 'Rolle' : 'Rollen'} anzeigen`}
-                  </button>
-                )}
               </div>
+              {fullSchichten.length > 0 && (
+                <button
+                  type="button"
+                  onClick={() => toggleShowFull(zeitblock.id)}
+                  className="mt-2 text-xs text-gray-400 hover:text-gray-600"
+                >
+                  {showingFull
+                    ? 'Belegte Rollen ausblenden'
+                    : `${fullSchichten.length} belegte ${fullSchichten.length === 1 ? 'Rolle' : 'Rollen'} anzeigen`}
+                </button>
+              )}
             </div>
           )
         })}

--- a/apps/web/components/public-overview/PublicOverviewView.tsx
+++ b/apps/web/components/public-overview/PublicOverviewView.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState, useMemo } from 'react'
-import { Tabs } from '@/components/ui/Tabs'
 import { EventGroup } from './EventGroup'
 import { OverviewRegistrationForm } from './OverviewRegistrationForm'
 import { OverviewSuccessScreen } from './OverviewSuccessScreen'
@@ -35,16 +34,6 @@ export function PublicOverviewView({ data }: PublicOverviewViewProps) {
     }
     return map
   }, [data])
-
-  // Build tabs from events
-  const tabs = useMemo(
-    () =>
-      data.events.map((event) => ({
-        id: event.veranstaltung.id,
-        label: event.veranstaltung.titel,
-      })),
-    [data]
-  )
 
   const handleToggleSchicht = (schichtId: string) => {
     setSelectedIds((prev) => {
@@ -136,40 +125,22 @@ export function PublicOverviewView({ data }: PublicOverviewViewProps) {
         </div>
       </div>
 
-      {/* Event Tabs */}
-      {tabs.length > 1 ? (
-        <Tabs tabs={tabs} defaultTab={tabs[0]?.id} fullWidth>
-          {(activeTab) => {
-            const event = data.events.find(
-              (e) => e.veranstaltung.id === activeTab
-            )
-            if (!event) return null
-            return (
-              <EventGroup
-                event={event}
-                selectedSchichtIds={selectedIds}
-                onToggleSchicht={handleToggleSchicht}
-              />
-            )
-          }}
-        </Tabs>
-      ) : (
-        <div className="space-y-6">
-          {data.events.map((event) => (
-            <EventGroup
-              key={event.veranstaltung.id}
-              event={event}
-              selectedSchichtIds={selectedIds}
-              onToggleSchicht={handleToggleSchicht}
-            />
-          ))}
-        </div>
-      )}
+      {/* All Events */}
+      <div className="space-y-6">
+        {data.events.map((event) => (
+          <EventGroup
+            key={event.veranstaltung.id}
+            event={event}
+            selectedSchichtIds={selectedIds}
+            onToggleSchicht={handleToggleSchicht}
+          />
+        ))}
+      </div>
 
       {/* Sticky Footer Bar */}
       {selectedIds.size > 0 && (
         <div className="fixed inset-x-0 bottom-0 z-40 border-t border-gray-200 bg-white/95 px-4 py-3 shadow-lg backdrop-blur-sm">
-          <div className="mx-auto flex max-w-4xl items-center justify-between">
+          <div className="mx-auto flex max-w-6xl items-center justify-between">
             <p className="text-sm font-medium text-gray-700">
               {selectedIds.size}{' '}
               {selectedIds.size === 1 ? 'Schicht' : 'Schichten'} ausgewählt

--- a/apps/web/components/public-overview/SelectableSchichtCard.tsx
+++ b/apps/web/components/public-overview/SelectableSchichtCard.tsx
@@ -20,24 +20,9 @@ export function SelectableSchichtCard({
 
   if (isFull) {
     return (
-      <div className="flex items-center gap-3 rounded-lg border border-gray-100 bg-gray-50 px-3 py-2 text-gray-400">
-        <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded border border-gray-200 bg-gray-100">
-          <svg
-            className="h-3 w-3 text-gray-300"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M18 12H6"
-            />
-          </svg>
-        </div>
-        <span className="flex-1 text-sm">{schicht.rolle}</span>
-        <span className="text-xs">{slotsText}</span>
+      <div className="flex flex-col items-center justify-center rounded-lg border border-gray-100 bg-gray-50 px-3 py-3 text-center text-gray-400">
+        <span className="text-sm leading-tight">{schicht.rolle}</span>
+        <span className="mt-1 text-xs">{slotsText}</span>
       </div>
     )
   }
@@ -46,15 +31,15 @@ export function SelectableSchichtCard({
     <button
       type="button"
       onClick={() => onToggle(schicht.id)}
-      className={`flex w-full items-center gap-3 rounded-lg border px-3 py-2.5 text-left transition-all ${
+      className={`relative flex flex-col items-center justify-center rounded-lg border px-3 py-3 text-center transition-all ${
         isSelected
           ? 'border-primary-500 bg-primary-50 ring-1 ring-primary-500'
           : 'border-gray-200 bg-white hover:border-primary-300 hover:shadow-sm'
       }`}
     >
-      {/* Checkbox */}
+      {/* Selection indicator */}
       <div
-        className={`flex h-5 w-5 shrink-0 items-center justify-center rounded border transition-colors ${
+        className={`absolute right-2 top-2 flex h-4 w-4 items-center justify-center rounded-sm border transition-colors ${
           isSelected
             ? 'border-primary-600 bg-primary-600'
             : 'border-gray-300 bg-white'
@@ -62,7 +47,7 @@ export function SelectableSchichtCard({
       >
         {isSelected && (
           <svg
-            className="h-3.5 w-3.5 text-white"
+            className="h-3 w-3 text-white"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -77,11 +62,10 @@ export function SelectableSchichtCard({
         )}
       </div>
 
-      <span className="flex-1 text-sm font-medium text-gray-900">
+      <span className="text-sm font-medium leading-tight text-gray-900">
         {schicht.rolle}
       </span>
-
-      <span className="text-xs text-gray-500">{slotsText}</span>
+      <span className="mt-1 text-xs text-gray-500">{slotsText}</span>
     </button>
   )
 }


### PR DESCRIPTION
## Summary
- **Tabs entfernt** — alle Events wieder auf einer Seite sichtbar
- **Grid-Layout für Schichten** — responsive 2/3/4 Spalten statt vertikaler Liste
- **Breiterer Container** — `max-w-4xl` → `max-w-6xl` für mehr Platz
- **Kompakte Box-Cards** — zentrierter Rollenname, Checkbox oben rechts, Platz-Info darunter

## Test plan
- [ ] Alle Events auf einer Seite sichtbar (kein Tab-Wechsel nötig)
- [ ] Schicht-Boxen im Grid: 2 Spalten Mobile, 3 Tablet, 4 Desktop
- [ ] Auswahl funktioniert über Events hinweg, Sticky Footer zeigt korrekte Anzahl
- [ ] Belegte Schichten ausgeblendet, Toggle pro Zeitblock funktioniert
- [ ] Weiter zur Anmeldung / Registrierung funktioniert weiterhin

🤖 Generated with [Claude Code](https://claude.com/claude-code)