### PR TITLE
feat: add error boundaries and loading states for protected routes

### DIFF
--- a/apps/web/app/(protected)/auffuehrungen/error.tsx
+++ b/apps/web/app/(protected)/auffuehrungen/error.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import Link from 'next/link'
+
+export default function AuffuehrungenError({
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <div className="flex min-h-[50vh] items-center justify-center p-4">
+      <div className="w-full max-w-md rounded-lg border border-error-200 bg-error-50 p-8 text-center">
+        <h2 className="mb-2 text-xl font-semibold text-error-700">
+          Fehler beim Laden der Aufführungen
+        </h2>
+        <p className="mb-6 text-sm text-error-700">
+          Die Aufführungen konnten nicht geladen werden. Bitte versuche es erneut.
+        </p>
+        <div className="flex items-center justify-center gap-3">
+          <button
+            onClick={reset}
+            className="rounded-lg bg-error-600 px-4 py-2 text-sm font-medium text-white hover:bg-error-700"
+          >
+            Erneut versuchen
+          </button>
+          <Link
+            href={'/dashboard' as never}
+            className="rounded-lg border border-neutral-300 bg-white px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+          >
+            Zum Dashboard
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/(protected)/auffuehrungen/loading.tsx
+++ b/apps/web/app/(protected)/auffuehrungen/loading.tsx
@@ -1,0 +1,31 @@
+export default function AuffuehrungenLoading() {
+  return (
+    <div className="animate-pulse space-y-6 p-6">
+      {/* Header skeleton */}
+      <div className="flex items-center justify-between">
+        <div className="h-8 w-48 rounded bg-neutral-200" />
+        <div className="h-9 w-32 rounded bg-neutral-200" />
+      </div>
+
+      {/* Table skeleton */}
+      <div className="overflow-hidden rounded-lg border border-neutral-200 bg-white">
+        {/* Table header */}
+        <div className="flex gap-4 border-b border-neutral-200 bg-neutral-50 px-4 py-3">
+          <div className="h-4 w-1/4 rounded bg-neutral-200" />
+          <div className="h-4 w-1/6 rounded bg-neutral-200" />
+          <div className="h-4 w-1/6 rounded bg-neutral-200" />
+          <div className="h-4 w-1/6 rounded bg-neutral-200" />
+        </div>
+        {/* Table rows */}
+        {[1, 2, 3, 4, 5].map((i) => (
+          <div key={i} className="flex gap-4 border-b border-neutral-100 px-4 py-3">
+            <div className="h-4 w-1/4 rounded bg-neutral-200" />
+            <div className="h-4 w-1/6 rounded bg-neutral-200" />
+            <div className="h-4 w-1/6 rounded bg-neutral-200" />
+            <div className="h-4 w-1/6 rounded bg-neutral-200" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/(protected)/dashboard/error.tsx
+++ b/apps/web/app/(protected)/dashboard/error.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import Link from 'next/link'
+
+export default function DashboardError({
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <div className="flex min-h-[50vh] items-center justify-center p-4">
+      <div className="w-full max-w-md rounded-lg border border-error-200 bg-error-50 p-8 text-center">
+        <h2 className="mb-2 text-xl font-semibold text-error-700">
+          Fehler beim Laden des Dashboards
+        </h2>
+        <p className="mb-6 text-sm text-error-700">
+          Das Dashboard konnte nicht geladen werden. Bitte versuche es erneut.
+        </p>
+        <div className="flex items-center justify-center gap-3">
+          <button
+            onClick={reset}
+            className="rounded-lg bg-error-600 px-4 py-2 text-sm font-medium text-white hover:bg-error-700"
+          >
+            Erneut versuchen
+          </button>
+          <Link
+            href={'/dashboard' as never}
+            className="rounded-lg border border-neutral-300 bg-white px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+          >
+            Zum Dashboard
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/(protected)/dashboard/loading.tsx
+++ b/apps/web/app/(protected)/dashboard/loading.tsx
@@ -1,0 +1,32 @@
+export default function DashboardLoading() {
+  return (
+    <div className="animate-pulse space-y-6 p-6">
+      {/* Header skeleton */}
+      <div className="h-8 w-40 rounded bg-neutral-200" />
+
+      {/* Stat cards grid */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {[1, 2, 3, 4].map((i) => (
+          <div key={i} className="rounded-lg border border-neutral-200 bg-white p-4">
+            <div className="mb-2 h-3 w-20 rounded bg-neutral-200" />
+            <div className="h-7 w-16 rounded bg-neutral-200" />
+          </div>
+        ))}
+      </div>
+
+      {/* Module placeholders */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        {[1, 2].map((i) => (
+          <div key={i} className="rounded-lg border border-neutral-200 bg-white p-6">
+            <div className="mb-4 h-5 w-32 rounded bg-neutral-200" />
+            <div className="space-y-3">
+              <div className="h-4 w-full rounded bg-neutral-200" />
+              <div className="h-4 w-3/4 rounded bg-neutral-200" />
+              <div className="h-4 w-1/2 rounded bg-neutral-200" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/(protected)/error.tsx
+++ b/apps/web/app/(protected)/error.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import Link from 'next/link'
+
+export default function ProtectedError({
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <div className="flex min-h-[50vh] items-center justify-center p-4">
+      <div className="w-full max-w-md rounded-lg border border-error-200 bg-error-50 p-8 text-center">
+        <h2 className="mb-2 text-xl font-semibold text-error-700">
+          Fehler beim Laden
+        </h2>
+        <p className="mb-6 text-sm text-error-700">
+          Die Seite konnte nicht geladen werden. Bitte versuche es erneut.
+        </p>
+        <div className="flex items-center justify-center gap-3">
+          <button
+            onClick={reset}
+            className="rounded-lg bg-error-600 px-4 py-2 text-sm font-medium text-white hover:bg-error-700"
+          >
+            Erneut versuchen
+          </button>
+          <Link
+            href={'/dashboard' as never}
+            className="rounded-lg border border-neutral-300 bg-white px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+          >
+            Zum Dashboard
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/(protected)/loading.tsx
+++ b/apps/web/app/(protected)/loading.tsx
@@ -1,0 +1,19 @@
+export default function ProtectedLoading() {
+  return (
+    <div className="animate-pulse space-y-6 p-6">
+      {/* Header skeleton */}
+      <div className="h-8 w-48 rounded bg-neutral-200" />
+
+      {/* Card skeletons */}
+      <div className="space-y-4">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="rounded-lg border border-neutral-200 bg-white p-4">
+            <div className="mb-3 h-4 w-1/3 rounded bg-neutral-200" />
+            <div className="mb-2 h-4 w-2/3 rounded bg-neutral-200" />
+            <div className="h-4 w-1/2 rounded bg-neutral-200" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/(protected)/mitglieder/error.tsx
+++ b/apps/web/app/(protected)/mitglieder/error.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import Link from 'next/link'
+
+export default function MitgliederError({
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <div className="flex min-h-[50vh] items-center justify-center p-4">
+      <div className="w-full max-w-md rounded-lg border border-error-200 bg-error-50 p-8 text-center">
+        <h2 className="mb-2 text-xl font-semibold text-error-700">
+          Fehler beim Laden der Mitglieder
+        </h2>
+        <p className="mb-6 text-sm text-error-700">
+          Die Mitgliederliste konnte nicht geladen werden. Bitte versuche es erneut.
+        </p>
+        <div className="flex items-center justify-center gap-3">
+          <button
+            onClick={reset}
+            className="rounded-lg bg-error-600 px-4 py-2 text-sm font-medium text-white hover:bg-error-700"
+          >
+            Erneut versuchen
+          </button>
+          <Link
+            href={'/dashboard' as never}
+            className="rounded-lg border border-neutral-300 bg-white px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+          >
+            Zum Dashboard
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/(protected)/mitglieder/loading.tsx
+++ b/apps/web/app/(protected)/mitglieder/loading.tsx
@@ -1,0 +1,31 @@
+export default function MitgliederLoading() {
+  return (
+    <div className="animate-pulse space-y-6 p-6">
+      {/* Header skeleton */}
+      <div className="flex items-center justify-between">
+        <div className="h-8 w-36 rounded bg-neutral-200" />
+        <div className="h-9 w-32 rounded bg-neutral-200" />
+      </div>
+
+      {/* Table skeleton */}
+      <div className="overflow-hidden rounded-lg border border-neutral-200 bg-white">
+        {/* Table header */}
+        <div className="flex gap-4 border-b border-neutral-200 bg-neutral-50 px-4 py-3">
+          <div className="h-4 w-1/4 rounded bg-neutral-200" />
+          <div className="h-4 w-1/6 rounded bg-neutral-200" />
+          <div className="h-4 w-1/6 rounded bg-neutral-200" />
+          <div className="h-4 w-1/6 rounded bg-neutral-200" />
+        </div>
+        {/* Table rows */}
+        {[1, 2, 3, 4, 5].map((i) => (
+          <div key={i} className="flex gap-4 border-b border-neutral-100 px-4 py-3">
+            <div className="h-4 w-1/4 rounded bg-neutral-200" />
+            <div className="h-4 w-1/6 rounded bg-neutral-200" />
+            <div className="h-4 w-1/6 rounded bg-neutral-200" />
+            <div className="h-4 w-1/6 rounded bg-neutral-200" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/(protected)/veranstaltungen/error.tsx
+++ b/apps/web/app/(protected)/veranstaltungen/error.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import Link from 'next/link'
+
+export default function VeranstaltungenError({
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <div className="flex min-h-[50vh] items-center justify-center p-4">
+      <div className="w-full max-w-md rounded-lg border border-error-200 bg-error-50 p-8 text-center">
+        <h2 className="mb-2 text-xl font-semibold text-error-700">
+          Fehler beim Laden der Veranstaltungen
+        </h2>
+        <p className="mb-6 text-sm text-error-700">
+          Die Veranstaltungen konnten nicht geladen werden. Bitte versuche es erneut.
+        </p>
+        <div className="flex items-center justify-center gap-3">
+          <button
+            onClick={reset}
+            className="rounded-lg bg-error-600 px-4 py-2 text-sm font-medium text-white hover:bg-error-700"
+          >
+            Erneut versuchen
+          </button>
+          <Link
+            href={'/dashboard' as never}
+            className="rounded-lg border border-neutral-300 bg-white px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+          >
+            Zum Dashboard
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/(protected)/veranstaltungen/loading.tsx
+++ b/apps/web/app/(protected)/veranstaltungen/loading.tsx
@@ -1,0 +1,31 @@
+export default function VeranstaltungenLoading() {
+  return (
+    <div className="animate-pulse space-y-6 p-6">
+      {/* Header skeleton */}
+      <div className="flex items-center justify-between">
+        <div className="h-8 w-48 rounded bg-neutral-200" />
+        <div className="h-9 w-32 rounded bg-neutral-200" />
+      </div>
+
+      {/* Table skeleton */}
+      <div className="overflow-hidden rounded-lg border border-neutral-200 bg-white">
+        {/* Table header */}
+        <div className="flex gap-4 border-b border-neutral-200 bg-neutral-50 px-4 py-3">
+          <div className="h-4 w-1/4 rounded bg-neutral-200" />
+          <div className="h-4 w-1/6 rounded bg-neutral-200" />
+          <div className="h-4 w-1/6 rounded bg-neutral-200" />
+          <div className="h-4 w-1/6 rounded bg-neutral-200" />
+        </div>
+        {/* Table rows */}
+        {[1, 2, 3, 4, 5].map((i) => (
+          <div key={i} className="flex gap-4 border-b border-neutral-100 px-4 py-3">
+            <div className="h-4 w-1/4 rounded bg-neutral-200" />
+            <div className="h-4 w-1/6 rounded bg-neutral-200" />
+            <div className="h-4 w-1/6 rounded bg-neutral-200" />
+            <div className="h-4 w-1/6 rounded bg-neutral-200" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/global-error.tsx
+++ b/apps/web/app/global-error.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+export default function GlobalError({
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <html lang="de">
+      <body className="flex min-h-screen items-center justify-center bg-neutral-50 p-4">
+        <div className="w-full max-w-md rounded-lg border border-red-200 bg-red-50 p-8 text-center">
+          <h1 className="mb-2 text-xl font-semibold text-red-700">
+            Etwas ist schiefgelaufen
+          </h1>
+          <p className="mb-6 text-sm text-red-600">
+            Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es erneut.
+          </p>
+          <button
+            onClick={reset}
+            className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700"
+          >
+            Erneut versuchen
+          </button>
+        </div>
+      </body>
+    </html>
+  )
+}


### PR DESCRIPTION
## Summary
- Add `global-error.tsx` as root-level fallback with standalone HTML (no layout dependencies)
- Add catch-all `error.tsx` and `loading.tsx` at the `(protected)` layout level
- Add segment-specific `error.tsx` and `loading.tsx` for dashboard, veranstaltungen, auffuehrungen, and mitglieder routes
- Error pages use the project's `error-*` color palette, German UI text, reset button + dashboard link
- Loading skeletons use `animate-pulse` + `bg-neutral-200` matching the existing `SkeletonRow` pattern

Closes #275

## Test plan
- [ ] Verify `npm run typecheck`, `npm run lint`, and `npm run test:run` pass
- [ ] Simulate a server component error and confirm the segment-specific error boundary renders
- [ ] Confirm the catch-all `(protected)/error.tsx` catches errors from routes without their own error boundary
- [ ] Verify loading skeletons appear during slow data fetches (e.g. throttle network in DevTools)
- [ ] Test "Erneut versuchen" button triggers `reset()` and re-renders the route
- [ ] Test "Zum Dashboard" link navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)