### PR TITLE
feat: flatten shift grid for side-by-side layout

### DIFF
--- a/apps/web/components/public-overview/SelectableSchichtCard.tsx
+++ b/apps/web/components/public-overview/SelectableSchichtCard.tsx
@@ -6,12 +6,14 @@ interface SelectableSchichtCardProps {
   schicht: PublicSchichtData
   isSelected: boolean
   onToggle: (schichtId: string) => void
+  zeitblockLabel?: string
 }
 
 export function SelectableSchichtCard({
   schicht,
   isSelected,
   onToggle,
+  zeitblockLabel,
 }: SelectableSchichtCardProps) {
   const isFull = schicht.freie_plaetze <= 0
   const slotsText = isFull
@@ -22,6 +24,9 @@ export function SelectableSchichtCard({
     return (
       <div className="flex flex-col items-center justify-center rounded-md border border-gray-100 bg-gray-50 px-2 py-2 text-center text-gray-400">
         <span className="text-xs leading-tight">{schicht.rolle}</span>
+        {zeitblockLabel && (
+          <span className="mt-0.5 text-[10px]">{zeitblockLabel}</span>
+        )}
         <span className="mt-0.5 text-[10px]">{slotsText}</span>
       </div>
     )
@@ -65,6 +70,9 @@ export function SelectableSchichtCard({
       <span className="text-xs font-medium leading-tight text-gray-900">
         {schicht.rolle}
       </span>
+      {zeitblockLabel && (
+        <span className="mt-0.5 text-[10px] text-gray-400">{zeitblockLabel}</span>
+      )}
       <span className="mt-0.5 text-[10px] text-gray-500">{slotsText}</span>
     </button>
   )


### PR DESCRIPTION
## Summary
- **Flaches Grid**: Alle Schichten eines Events in einem einzigen Grid statt pro Zeitblock getrennt
- **Zeitblock-Info auf Card**: Jede Box zeigt die Zeitblock-Uhrzeit (z.B. "17:00–22:00")
- **Kein vertikales Stacking mehr**: Alle Rollen fliessen nebeneinander (3/4/5 Spalten)

## Test plan
- [ ] Alle Schichten eines Events nebeneinander im Grid
- [ ] Zeitblock-Uhrzeit auf jeder Card sichtbar
- [ ] Auswahl funktioniert, Sticky Footer korrekt
- [ ] Belegte Rollen Toggle funktioniert (jetzt ein Toggle pro Event)
- [ ] Mobile: 3 Spalten, Desktop: 5 Spalten

🤖 Generated with [Claude Code](https://claude.com/claude-code)