### PR TITLE
feat: add inline edit for Zeitblöcke and Schichten

### DIFF
--- a/apps/web/components/auffuehrungen/ZeitblockEditor.tsx
+++ b/apps/web/components/auffuehrungen/ZeitblockEditor.tsx
@@ -2,7 +2,11 @@
 
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { createZeitblock, deleteZeitblock } from '@/lib/actions/zeitbloecke'
+import {
+  createZeitblock,
+  updateZeitblock,
+  deleteZeitblock,
+} from '@/lib/actions/zeitbloecke'
 import type { Zeitblock, ZeitblockTyp } from '@/lib/supabase/types'
 import { ZeitblockTypBadge } from './ZeitblockTypBadge'
 
@@ -35,6 +39,52 @@ export function ZeitblockEditor({
   const [startzeit, setStartzeit] = useState('')
   const [endzeit, setEndzeit] = useState('')
   const [typ, setTyp] = useState<ZeitblockTyp>('standard')
+
+  // Edit state
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editName, setEditName] = useState('')
+  const [editStartzeit, setEditStartzeit] = useState('')
+  const [editEndzeit, setEditEndzeit] = useState('')
+  const [editTyp, setEditTyp] = useState<ZeitblockTyp>('standard')
+  const [editLoading, setEditLoading] = useState(false)
+  const [editError, setEditError] = useState<string | null>(null)
+
+  function startEditing(zb: Zeitblock) {
+    setEditingId(zb.id)
+    setEditName(zb.name)
+    setEditStartzeit(zb.startzeit.slice(0, 5))
+    setEditEndzeit(zb.endzeit.slice(0, 5))
+    setEditTyp(zb.typ)
+    setEditError(null)
+  }
+
+  function cancelEditing() {
+    setEditingId(null)
+    setEditError(null)
+  }
+
+  async function handleEditSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!editingId) return
+
+    setEditLoading(true)
+    setEditError(null)
+
+    const result = await updateZeitblock(editingId, {
+      name: editName,
+      startzeit: editStartzeit,
+      endzeit: editEndzeit,
+      typ: editTyp,
+    })
+
+    if (result.success) {
+      setEditingId(null)
+      router.refresh()
+    } else {
+      setEditError(result.error || 'Ein Fehler ist aufgetreten')
+    }
+    setEditLoading(false)
+  }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -160,27 +210,114 @@ export function ZeitblockEditor({
       )}
 
       <div className="divide-y divide-gray-200">
-        {zeitbloecke.map((zb) => (
-          <div key={zb.id} className="flex items-center justify-between p-4">
-            <div>
-              <div className="flex items-center gap-2">
-                <span className="font-medium text-gray-900">{zb.name}</span>
-                <ZeitblockTypBadge typ={zb.typ} />
+        {zeitbloecke.map((zb) =>
+          editingId === zb.id ? (
+            <form
+              key={zb.id}
+              onSubmit={handleEditSubmit}
+              className="bg-blue-50 p-4"
+            >
+              {editError && (
+                <div className="mb-3 rounded border border-red-200 bg-red-50 p-2 text-sm text-red-700">
+                  {editError}
+                </div>
+              )}
+              <div className="grid grid-cols-2 gap-3">
+                <div className="col-span-2">
+                  <input
+                    type="text"
+                    placeholder="Name *"
+                    required
+                    value={editName}
+                    onChange={(e) => setEditName(e.target.value)}
+                    className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-xs text-gray-500">
+                    Startzeit
+                  </label>
+                  <input
+                    type="time"
+                    required
+                    value={editStartzeit}
+                    onChange={(e) => setEditStartzeit(e.target.value)}
+                    className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-xs text-gray-500">
+                    Endzeit
+                  </label>
+                  <input
+                    type="time"
+                    required
+                    value={editEndzeit}
+                    onChange={(e) => setEditEndzeit(e.target.value)}
+                    className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+                  />
+                </div>
+                <div className="col-span-2">
+                  <select
+                    value={editTyp}
+                    onChange={(e) => setEditTyp(e.target.value as ZeitblockTyp)}
+                    className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+                  >
+                    {zeitblockTypen.map((t) => (
+                      <option key={t.value} value={t.value}>
+                        {t.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
               </div>
-              <span className="text-sm text-gray-500">
-                {formatTime(zb.startzeit)} - {formatTime(zb.endzeit)}
-              </span>
+              <div className="mt-3 flex gap-2">
+                <button
+                  type="submit"
+                  disabled={editLoading}
+                  className="rounded-lg bg-blue-600 px-3 py-1.5 text-sm text-white disabled:bg-blue-400"
+                >
+                  {editLoading ? 'Speichern...' : 'Speichern'}
+                </button>
+                <button
+                  type="button"
+                  onClick={cancelEditing}
+                  className="px-3 py-1.5 text-sm text-gray-600"
+                >
+                  Abbrechen
+                </button>
+              </div>
+            </form>
+          ) : (
+            <div key={zb.id} className="flex items-center justify-between p-4">
+              <div>
+                <div className="flex items-center gap-2">
+                  <span className="font-medium text-gray-900">{zb.name}</span>
+                  <ZeitblockTypBadge typ={zb.typ} />
+                </div>
+                <span className="text-sm text-gray-500">
+                  {formatTime(zb.startzeit)} - {formatTime(zb.endzeit)}
+                </span>
+              </div>
+              {canEdit && (
+                <div className="flex items-center gap-3">
+                  <button
+                    onClick={() => startEditing(zb)}
+                    className="text-sm text-blue-600 hover:text-blue-800"
+                  >
+                    Bearbeiten
+                  </button>
+                  <button
+                    onClick={() => handleDelete(zb.id, zb.name)}
+                    className="text-sm text-red-600 hover:text-red-800"
+                  >
+                    Löschen
+                  </button>
+                </div>
+              )}
             </div>
-            {canEdit && (
-              <button
-                onClick={() => handleDelete(zb.id, zb.name)}
-                className="text-sm text-red-600 hover:text-red-800"
-              >
-                Löschen
-              </button>
-            )}
-          </div>
-        ))}
+          )
+        )}
         {zeitbloecke.length === 0 && (
           <div className="p-8 text-center text-gray-500">
             Noch keine Zeitblöcke definiert


### PR DESCRIPTION
## Summary
- Add "Bearbeiten" button to `ZeitblockEditor` — clicking swaps the row into an inline form to edit Name, Startzeit, Endzeit, and Typ
- Add "Bearbeiten" button to `SchichtEditor` — inline form for Rolle, Zeitblock, and Anzahl benötigt
- Uses existing `updateZeitblock()` and `updateSchicht()` server actions (no backend changes needed)

Closes #302

## Test plan
- [ ] Navigate to an Aufführung with generated Schichten from a template
- [ ] Click "Bearbeiten" on a Zeitblock → verify inline form shows with pre-filled values
- [ ] Change start/end times → click "Speichern" → verify times update correctly
- [ ] Click "Bearbeiten" on a Schicht → verify form with Rolle, Zeitblock dropdown, Anzahl
- [ ] Change Anzahl benötigt → save → verify value updates
- [ ] Move a Schicht to a different Zeitblock → save → verify it appears under the new group
- [ ] Click "Abbrechen" → verify form closes without changes
- [ ] Verify `npm run typecheck`, `npm run lint`, `npm run test:run` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)