### PR TITLE
feat: add inline edit for template Zeitblöcke and Schichten

### DIFF
--- a/apps/web/lib/actions/templates.ts
+++ b/apps/web/lib/actions/templates.ts
@@ -9,8 +9,10 @@ import type {
   TemplateMitDetails,
   TemplateZeitblock,
   TemplateZeitblockInsert,
+  TemplateZeitblockUpdate,
   TemplateSchicht,
   TemplateSchichtInsert,
+  TemplateSchichtUpdate,
   TemplateRessourceInsert,
   TemplateInfoBlock,
   TemplateInfoBlockInsert,
@@ -25,7 +27,9 @@ import {
   templateSchema,
   templateUpdateSchema,
   templateZeitblockSchema,
+  templateZeitblockUpdateSchema,
   templateSchichtSchema,
+  templateSchichtUpdateSchema,
   templateRessourceSchema,
   templateInfoBlockSchema,
   templateSachleistungSchema,
@@ -274,6 +278,31 @@ export async function removeTemplateZeitblock(
   return { success: true }
 }
 
+export async function updateTemplateZeitblock(
+  id: string,
+  templateId: string,
+  data: TemplateZeitblockUpdate
+): Promise<{ success: boolean; error?: string }> {
+  const validation = validateInput(templateZeitblockUpdateSchema, data)
+  if (!validation.success) {
+    return { success: false, error: validation.error }
+  }
+
+  const supabase = await createClient()
+  const { error } = await supabase
+    .from('template_zeitbloecke')
+    .update(validation.data as never)
+    .eq('id', id)
+
+  if (error) {
+    console.error('Error updating template zeitblock:', error)
+    return { success: false, error: 'Fehler beim Aktualisieren des Zeitblocks' }
+  }
+
+  revalidatePath(`/templates/${templateId}`)
+  return { success: true }
+}
+
 // =============================================================================
 // Template Schichten
 // =============================================================================
@@ -316,6 +345,31 @@ export async function removeTemplateSchicht(
   if (error) {
     console.error('Error removing template schicht:', error)
     return { success: false, error: error.message }
+  }
+
+  revalidatePath(`/templates/${templateId}`)
+  return { success: true }
+}
+
+export async function updateTemplateSchicht(
+  id: string,
+  templateId: string,
+  data: TemplateSchichtUpdate
+): Promise<{ success: boolean; error?: string }> {
+  const validation = validateInput(templateSchichtUpdateSchema, data)
+  if (!validation.success) {
+    return { success: false, error: validation.error }
+  }
+
+  const supabase = await createClient()
+  const { error } = await supabase
+    .from('template_schichten')
+    .update(validation.data as never)
+    .eq('id', id)
+
+  if (error) {
+    console.error('Error updating template schicht:', error)
+    return { success: false, error: 'Fehler beim Aktualisieren der Schicht' }
   }
 
   revalidatePath(`/templates/${templateId}`)

--- a/apps/web/lib/validations/modul2.ts
+++ b/apps/web/lib/validations/modul2.ts
@@ -189,6 +189,14 @@ export const templateSchichtSchema = z.object({
     .default(1),
 })
 
+export const templateZeitblockUpdateSchema = templateZeitblockSchema
+  .omit({ template_id: true })
+  .partial()
+
+export const templateSchichtUpdateSchema = templateSchichtSchema
+  .omit({ template_id: true })
+  .partial()
+
 export const templateRessourceSchema = z.object({
   template_id: z.string().uuid('Ungültige Template-ID'),
   ressource_id: z.string().uuid('Ungültige Ressource'),


### PR DESCRIPTION
## Summary
- Add `updateTemplateZeitblock()` and `updateTemplateSchicht()` server actions in `lib/actions/templates.ts`
- Add `templateZeitblockUpdateSchema` and `templateSchichtUpdateSchema` validation schemas in `lib/validations/modul2.ts`
- Add "Bearbeiten" button in `TemplateDetailEditor` for inline editing of:
  - **Zeitblöcke**: Name, Offset (Min), Dauer (Min), Typ
  - **Schichten**: Rolle, Zeitblock-Zuordnung, Anzahl benötigt

Closes #304

## Test plan
- [ ] Navigate to Templates > open a template with existing Zeitblöcke/Schichten
- [ ] Click "Bearbeiten" on a Zeitblock → verify inline form with pre-filled Offset/Dauer/Typ
- [ ] Change Offset and Dauer → save → verify values update
- [ ] Click "Bearbeiten" on a Schicht → verify form with Rolle, Zeitblock dropdown, Anzahl
- [ ] Change Anzahl → save → verify value updates
- [ ] Move a Schicht to a different Zeitblock → save → verify zeitblock_name updates
- [ ] Click "Abbrechen" → verify form closes without changes
- [ ] Verify `npm run typecheck`, `npm run lint`, `npm run test:run` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)