### PR TITLE
feat: Template-Zeitmodell von Offset auf Startzeit/Endzeit umstellen

### DIFF
--- a/apps/web/components/admin/templates/InfoBloeckeEditor.tsx
+++ b/apps/web/components/admin/templates/InfoBloeckeEditor.tsx
@@ -10,15 +10,6 @@ interface InfoBloeckeEditorProps {
   infoBloecke: TemplateInfoBlock[]
 }
 
-function formatOffset(minutes: number): string {
-  const hours = Math.floor(Math.abs(minutes) / 60)
-  const mins = Math.abs(minutes) % 60
-  const sign = minutes < 0 ? '-' : '+'
-  if (hours === 0) return `${sign}${mins}min`
-  if (mins === 0) return `${sign}${hours}h`
-  return `${sign}${hours}h ${mins}min`
-}
-
 export function InfoBloeckeEditor({ templateId, infoBloecke }: InfoBloeckeEditorProps) {
   const [isAdding, setIsAdding] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -29,8 +20,8 @@ export function InfoBloeckeEditor({ templateId, infoBloecke }: InfoBloeckeEditor
   const [formData, setFormData] = useState({
     titel: '',
     beschreibung: '',
-    offset_minuten: -60,
-    dauer_minuten: 30,
+    startzeit: '18:00',
+    endzeit: '18:30',
     sortierung: infoBloecke.length,
   })
 
@@ -38,8 +29,8 @@ export function InfoBloeckeEditor({ templateId, infoBloecke }: InfoBloeckeEditor
     setFormData({
       titel: '',
       beschreibung: '',
-      offset_minuten: -60,
-      dauer_minuten: 30,
+      startzeit: '18:00',
+      endzeit: '18:30',
       sortierung: infoBloecke.length,
     })
     setError(null)
@@ -55,8 +46,8 @@ export function InfoBloeckeEditor({ templateId, infoBloecke }: InfoBloeckeEditor
         template_id: templateId,
         titel: formData.titel.trim(),
         beschreibung: formData.beschreibung.trim() || null,
-        offset_minuten: formData.offset_minuten,
-        dauer_minuten: formData.dauer_minuten,
+        startzeit: formData.startzeit,
+        endzeit: formData.endzeit,
         sortierung: formData.sortierung,
       })
 
@@ -150,21 +141,20 @@ export function InfoBloeckeEditor({ templateId, infoBloecke }: InfoBloeckeEditor
                 </div>
 
                 <Input
-                  label="Offset (Minuten)"
-                  name="offset_minuten"
-                  type="number"
-                  value={formData.offset_minuten}
-                  onChange={(e) => setFormData((prev) => ({ ...prev, offset_minuten: parseInt(e.target.value) || 0 }))}
-                  helperText="Negativ = vor Beginn"
+                  label="Startzeit"
+                  name="startzeit"
+                  type="time"
+                  value={formData.startzeit}
+                  onChange={(e) => setFormData((prev) => ({ ...prev, startzeit: e.target.value }))}
+                  required
                 />
 
                 <Input
-                  label="Dauer (Minuten)"
-                  name="dauer_minuten"
-                  type="number"
-                  min={1}
-                  value={formData.dauer_minuten}
-                  onChange={(e) => setFormData((prev) => ({ ...prev, dauer_minuten: parseInt(e.target.value) || 30 }))}
+                  label="Endzeit"
+                  name="endzeit"
+                  type="time"
+                  value={formData.endzeit}
+                  onChange={(e) => setFormData((prev) => ({ ...prev, endzeit: e.target.value }))}
                   required
                 />
               </div>
@@ -209,10 +199,10 @@ export function InfoBloeckeEditor({ templateId, infoBloecke }: InfoBloeckeEditor
                       Beschreibung
                     </th>
                     <th className="pb-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500">
-                      Offset
+                      Startzeit
                     </th>
                     <th className="pb-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500">
-                      Dauer
+                      Endzeit
                     </th>
                     <th className="pb-3 text-right text-xs font-medium uppercase tracking-wider text-neutral-500">
                       Aktionen
@@ -234,10 +224,10 @@ export function InfoBloeckeEditor({ templateId, infoBloecke }: InfoBloeckeEditor
                           {ib.beschreibung ?? '-'}
                         </td>
                         <td className="py-3 text-sm text-neutral-600">
-                          {formatOffset(ib.offset_minuten)}
+                          {ib.startzeit}
                         </td>
                         <td className="py-3 text-sm text-neutral-600">
-                          {ib.dauer_minuten} min
+                          {ib.endzeit}
                         </td>
                         <td className="py-3 text-right">
                           <Button

--- a/apps/web/components/admin/templates/ZeitbloeckeEditor.tsx
+++ b/apps/web/components/admin/templates/ZeitbloeckeEditor.tsx
@@ -19,15 +19,6 @@ interface ZeitbloeckeEditorProps {
   zeitbloecke: TemplateZeitblock[]
 }
 
-function formatOffset(minutes: number): string {
-  const hours = Math.floor(Math.abs(minutes) / 60)
-  const mins = Math.abs(minutes) % 60
-  const sign = minutes < 0 ? '-' : '+'
-  if (hours === 0) return `${sign}${mins}min`
-  if (mins === 0) return `${sign}${hours}h`
-  return `${sign}${hours}h ${mins}min`
-}
-
 export function ZeitbloeckeEditor({ templateId, zeitbloecke }: ZeitbloeckeEditorProps) {
   const [isAdding, setIsAdding] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -37,8 +28,8 @@ export function ZeitbloeckeEditor({ templateId, zeitbloecke }: ZeitbloeckeEditor
 
   const [formData, setFormData] = useState({
     name: '',
-    offset_minuten: 0,
-    dauer_minuten: 60,
+    startzeit: '19:00',
+    endzeit: '20:00',
     typ: 'standard' as ZeitblockTyp,
     sortierung: zeitbloecke.length,
   })
@@ -46,8 +37,8 @@ export function ZeitbloeckeEditor({ templateId, zeitbloecke }: ZeitbloeckeEditor
   const resetForm = () => {
     setFormData({
       name: '',
-      offset_minuten: 0,
-      dauer_minuten: 60,
+      startzeit: '19:00',
+      endzeit: '20:00',
       typ: 'standard',
       sortierung: zeitbloecke.length,
     })
@@ -63,8 +54,8 @@ export function ZeitbloeckeEditor({ templateId, zeitbloecke }: ZeitbloeckeEditor
       const result = await addTemplateZeitblock({
         template_id: templateId,
         name: formData.name.trim(),
-        offset_minuten: formData.offset_minuten,
-        dauer_minuten: formData.dauer_minuten,
+        startzeit: formData.startzeit,
+        endzeit: formData.endzeit,
         typ: formData.typ,
         sortierung: formData.sortierung,
       })
@@ -109,7 +100,7 @@ export function ZeitbloeckeEditor({ templateId, zeitbloecke }: ZeitbloeckeEditor
             <div>
               <CardTitle>Zeitbloecke</CardTitle>
               <CardDescription>
-                Zeitraeume relativ zum Vorstellungsbeginn (Offset 0 = Beginn)
+                Zeitraeume mit festen Start- und Endzeiten
               </CardDescription>
             </div>
             {!isAdding && (
@@ -159,21 +150,20 @@ export function ZeitbloeckeEditor({ templateId, zeitbloecke }: ZeitbloeckeEditor
                 </div>
 
                 <Input
-                  label="Offset (Minuten)"
-                  name="offset_minuten"
-                  type="number"
-                  value={formData.offset_minuten}
-                  onChange={(e) => setFormData((prev) => ({ ...prev, offset_minuten: parseInt(e.target.value) || 0 }))}
-                  helperText="Negativ = vor Beginn"
+                  label="Startzeit"
+                  name="startzeit"
+                  type="time"
+                  value={formData.startzeit}
+                  onChange={(e) => setFormData((prev) => ({ ...prev, startzeit: e.target.value }))}
+                  required
                 />
 
                 <Input
-                  label="Dauer (Minuten)"
-                  name="dauer_minuten"
-                  type="number"
-                  min={1}
-                  value={formData.dauer_minuten}
-                  onChange={(e) => setFormData((prev) => ({ ...prev, dauer_minuten: parseInt(e.target.value) || 60 }))}
+                  label="Endzeit"
+                  name="endzeit"
+                  type="time"
+                  value={formData.endzeit}
+                  onChange={(e) => setFormData((prev) => ({ ...prev, endzeit: e.target.value }))}
                   required
                 />
               </div>
@@ -218,10 +208,10 @@ export function ZeitbloeckeEditor({ templateId, zeitbloecke }: ZeitbloeckeEditor
                       Typ
                     </th>
                     <th className="pb-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500">
-                      Offset
+                      Startzeit
                     </th>
                     <th className="pb-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500">
-                      Dauer
+                      Endzeit
                     </th>
                     <th className="pb-3 text-right text-xs font-medium uppercase tracking-wider text-neutral-500">
                       Aktionen
@@ -245,10 +235,10 @@ export function ZeitbloeckeEditor({ templateId, zeitbloecke }: ZeitbloeckeEditor
                           </span>
                         </td>
                         <td className="py-3 text-sm text-neutral-600">
-                          {formatOffset(zb.offset_minuten)}
+                          {zb.startzeit}
                         </td>
                         <td className="py-3 text-sm text-neutral-600">
-                          {zb.dauer_minuten} min
+                          {zb.endzeit}
                         </td>
                         <td className="py-3 text-right">
                           <Button

--- a/apps/web/components/auffuehrungen/TemplateSelector.tsx
+++ b/apps/web/components/auffuehrungen/TemplateSelector.tsx
@@ -10,10 +10,10 @@ import { Button, ConfirmDialog } from '@/components/ui'
 interface TemplateSelectorProps {
   veranstaltungId: string
   templates: AuffuehrungTemplate[]
-  startzeit: string
+  startzeit?: string
 }
 
-export function TemplateSelector({ veranstaltungId, templates, startzeit }: TemplateSelectorProps) {
+export function TemplateSelector({ veranstaltungId, templates }: TemplateSelectorProps) {
   const router = useRouter()
   const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(null)
   const [templateDetails, setTemplateDetails] = useState<TemplateMitDetails | null>(null)
@@ -63,26 +63,6 @@ export function TemplateSelector({ veranstaltungId, templates, startzeit }: Temp
     } finally {
       setIsGenerating(false)
     }
-  }
-
-  // Helper to format time
-  const formatOffset = (minutes: number): string => {
-    const hours = Math.floor(Math.abs(minutes) / 60)
-    const mins = Math.abs(minutes) % 60
-    const sign = minutes < 0 ? '-' : '+'
-    if (hours === 0) return `${sign}${mins}min`
-    if (mins === 0) return `${sign}${hours}h`
-    return `${sign}${hours}h ${mins}min`
-  }
-
-  // Calculate preview times based on startzeit
-  const calculateTime = (offsetMinutes: number): string => {
-    const [startH, startM] = startzeit.split(':').map(Number)
-    const totalMinutes = startH * 60 + startM + offsetMinutes
-    const normalizedMinutes = ((totalMinutes % 1440) + 1440) % 1440
-    const hours = Math.floor(normalizedMinutes / 60)
-    const minutes = normalizedMinutes % 60
-    return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`
   }
 
   return (
@@ -180,7 +160,7 @@ export function TemplateSelector({ veranstaltungId, templates, startzeit }: Temp
           {templateDetails.zeitbloecke.length > 0 && (
             <div className="mt-4">
               <h5 className="mb-2 text-sm font-medium text-neutral-700">
-                Zeitbloecke (Vorschau mit Start {startzeit} Uhr)
+                Zeitbloecke
               </h5>
               <div className="space-y-1">
                 {templateDetails.zeitbloecke
@@ -193,10 +173,7 @@ export function TemplateSelector({ veranstaltungId, templates, startzeit }: Temp
                     >
                       <span className="font-medium text-neutral-900">{zb.name}</span>
                       <span className="text-neutral-500">
-                        {calculateTime(zb.offset_minuten)} - {calculateTime(zb.offset_minuten + zb.dauer_minuten)}
-                        <span className="ml-2 text-neutral-400">
-                          ({formatOffset(zb.offset_minuten)})
-                        </span>
+                        {zb.startzeit} - {zb.endzeit}
                       </span>
                     </div>
                   ))}

--- a/apps/web/components/templates/TemplateDetailEditor.tsx
+++ b/apps/web/components/templates/TemplateDetailEditor.tsx
@@ -48,16 +48,16 @@ export function TemplateDetailEditor({
   // Zeitblock Form State
   const [showZeitblockForm, setShowZeitblockForm] = useState(false)
   const [zbName, setZbName] = useState('')
-  const [zbOffset, setZbOffset] = useState('0')
-  const [zbDauer, setZbDauer] = useState('30')
+  const [zbStartzeit, setZbStartzeit] = useState('19:00')
+  const [zbEndzeit, setZbEndzeit] = useState('20:00')
   const [zbTyp, setZbTyp] = useState<ZeitblockTyp>('standard')
   const [zbLoading, setZbLoading] = useState(false)
 
   // Zeitblock Edit State
   const [editZbId, setEditZbId] = useState<string | null>(null)
   const [editZbName, setEditZbName] = useState('')
-  const [editZbOffset, setEditZbOffset] = useState('')
-  const [editZbDauer, setEditZbDauer] = useState('')
+  const [editZbStartzeit, setEditZbStartzeit] = useState('')
+  const [editZbEndzeit, setEditZbEndzeit] = useState('')
   const [editZbTyp, setEditZbTyp] = useState<ZeitblockTyp>('standard')
   const [editZbLoading, setEditZbLoading] = useState(false)
   const [editZbError, setEditZbError] = useState<string | null>(null)
@@ -87,8 +87,8 @@ export function TemplateDetailEditor({
   const [showInfoBlockForm, setShowInfoBlockForm] = useState(false)
   const [ibTitel, setIbTitel] = useState('')
   const [ibBeschreibung, setIbBeschreibung] = useState('')
-  const [ibOffset, setIbOffset] = useState('0')
-  const [ibDauer, setIbDauer] = useState('30')
+  const [ibStartzeit, setIbStartzeit] = useState('18:00')
+  const [ibEndzeit, setIbEndzeit] = useState('18:30')
   const [ibLoading, setIbLoading] = useState(false)
 
   // Sachleistung Form State
@@ -111,14 +111,14 @@ export function TemplateDetailEditor({
     await addTemplateZeitblock({
       template_id: template.id,
       name: zbName,
-      offset_minuten: parseInt(zbOffset, 10),
-      dauer_minuten: parseInt(zbDauer, 10),
+      startzeit: zbStartzeit,
+      endzeit: zbEndzeit,
       typ: zbTyp,
       sortierung: template.zeitbloecke.length,
     })
     setZbName('')
-    setZbOffset('0')
-    setZbDauer('30')
+    setZbStartzeit('19:00')
+    setZbEndzeit('20:00')
     setZbTyp('standard')
     setShowZeitblockForm(false)
     setZbLoading(false)
@@ -134,8 +134,8 @@ export function TemplateDetailEditor({
   function startEditZeitblock(zb: TemplateZeitblock) {
     setEditZbId(zb.id)
     setEditZbName(zb.name)
-    setEditZbOffset(String(zb.offset_minuten))
-    setEditZbDauer(String(zb.dauer_minuten))
+    setEditZbStartzeit(zb.startzeit)
+    setEditZbEndzeit(zb.endzeit)
     setEditZbTyp(zb.typ)
     setEditZbError(null)
   }
@@ -149,8 +149,8 @@ export function TemplateDetailEditor({
 
     const result = await updateTemplateZeitblock(editZbId, template.id, {
       name: editZbName,
-      offset_minuten: parseInt(editZbOffset, 10),
-      dauer_minuten: parseInt(editZbDauer, 10),
+      startzeit: editZbStartzeit,
+      endzeit: editZbEndzeit,
       typ: editZbTyp,
     })
 
@@ -248,14 +248,14 @@ export function TemplateDetailEditor({
       template_id: template.id,
       titel: ibTitel,
       beschreibung: ibBeschreibung || null,
-      offset_minuten: parseInt(ibOffset, 10),
-      dauer_minuten: parseInt(ibDauer, 10),
+      startzeit: ibStartzeit,
+      endzeit: ibEndzeit,
       sortierung: template.info_bloecke?.length || 0,
     })
     setIbTitel('')
     setIbBeschreibung('')
-    setIbOffset('0')
-    setIbDauer('30')
+    setIbStartzeit('18:00')
+    setIbEndzeit('18:30')
     setShowInfoBlockForm(false)
     setIbLoading(false)
     router.refresh()
@@ -325,25 +325,26 @@ export function TemplateDetailEditor({
             <div className="grid grid-cols-3 gap-3">
               <div>
                 <label className="mb-1 block text-xs text-gray-500">
-                  Offset (Min)
+                  Startzeit
                 </label>
                 <input
-                  type="number"
-                  value={zbOffset}
-                  onChange={(e) => setZbOffset(e.target.value)}
+                  type="time"
+                  value={zbStartzeit}
+                  onChange={(e) => setZbStartzeit(e.target.value)}
                   className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+                  required
                 />
               </div>
               <div>
                 <label className="mb-1 block text-xs text-gray-500">
-                  Dauer (Min)
+                  Endzeit
                 </label>
                 <input
-                  type="number"
-                  min="1"
-                  value={zbDauer}
-                  onChange={(e) => setZbDauer(e.target.value)}
+                  type="time"
+                  value={zbEndzeit}
+                  onChange={(e) => setZbEndzeit(e.target.value)}
                   className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+                  required
                 />
               </div>
               <div>
@@ -404,25 +405,26 @@ export function TemplateDetailEditor({
                 <div className="grid grid-cols-3 gap-3">
                   <div>
                     <label className="mb-1 block text-xs text-gray-500">
-                      Offset (Min)
+                      Startzeit
                     </label>
                     <input
-                      type="number"
-                      value={editZbOffset}
-                      onChange={(e) => setEditZbOffset(e.target.value)}
+                      type="time"
+                      value={editZbStartzeit}
+                      onChange={(e) => setEditZbStartzeit(e.target.value)}
                       className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+                      required
                     />
                   </div>
                   <div>
                     <label className="mb-1 block text-xs text-gray-500">
-                      Dauer (Min)
+                      Endzeit
                     </label>
                     <input
-                      type="number"
-                      min="1"
-                      value={editZbDauer}
-                      onChange={(e) => setEditZbDauer(e.target.value)}
+                      type="time"
+                      value={editZbEndzeit}
+                      onChange={(e) => setEditZbEndzeit(e.target.value)}
                       className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+                      required
                     />
                   </div>
                   <div>
@@ -472,8 +474,7 @@ export function TemplateDetailEditor({
                     <ZeitblockTypBadge typ={zb.typ} />
                   </div>
                   <span className="text-sm text-gray-500">
-                    Offset: {zb.offset_minuten} Min, Dauer: {zb.dauer_minuten}{' '}
-                    Min
+                    {zb.startzeit} - {zb.endzeit}
                   </span>
                 </div>
                 <div className="flex items-center gap-3">
@@ -812,25 +813,26 @@ export function TemplateDetailEditor({
             <div className="grid grid-cols-2 gap-3">
               <div>
                 <label className="mb-1 block text-xs text-gray-500">
-                  Offset (Min)
+                  Startzeit
                 </label>
                 <input
-                  type="number"
-                  value={ibOffset}
-                  onChange={(e) => setIbOffset(e.target.value)}
+                  type="time"
+                  value={ibStartzeit}
+                  onChange={(e) => setIbStartzeit(e.target.value)}
                   className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+                  required
                 />
               </div>
               <div>
                 <label className="mb-1 block text-xs text-gray-500">
-                  Dauer (Min)
+                  Endzeit
                 </label>
                 <input
-                  type="number"
-                  min="1"
-                  value={ibDauer}
-                  onChange={(e) => setIbDauer(e.target.value)}
+                  type="time"
+                  value={ibEndzeit}
+                  onChange={(e) => setIbEndzeit(e.target.value)}
                   className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+                  required
                 />
               </div>
             </div>
@@ -859,7 +861,7 @@ export function TemplateDetailEditor({
               <div>
                 <span className="font-medium text-gray-900">{ib.titel}</span>
                 <div className="text-sm text-gray-500">
-                  Offset: {ib.offset_minuten} Min, Dauer: {ib.dauer_minuten} Min
+                  {ib.startzeit} - {ib.endzeit}
                 </div>
                 {ib.beschreibung && (
                   <div className="text-sm text-gray-400">{ib.beschreibung}</div>

--- a/apps/web/lib/actions/schicht-generator.ts
+++ b/apps/web/lib/actions/schicht-generator.ts
@@ -62,10 +62,6 @@ export async function generateSchichtenFromTemplate(
     return { success: false, error: 'Veranstaltung nicht gefunden' }
   }
 
-  if (!veranstaltung.startzeit) {
-    return { success: false, error: 'Veranstaltung hat keine Startzeit' }
-  }
-
   // Check if shifts already exist
   const { count: existingSchichtenCount } = await supabase
     .from('auffuehrung_schichten')
@@ -77,19 +73,6 @@ export async function generateSchichtenFromTemplate(
       success: false,
       error: `Diese Veranstaltung hat bereits ${existingSchichtenCount} Schichten. Bitte zuerst zuruecksetzen.`,
     }
-  }
-
-  // Parse the start time
-  const [startHours, startMinutes] = veranstaltung.startzeit.split(':').map(Number)
-  const startTotalMinutes = startHours * 60 + startMinutes
-
-  // Helper function to convert offset minutes to TIME string
-  const minutesToTime = (totalMinutes: number): string => {
-    // Handle wrap-around for times past midnight
-    const normalizedMinutes = ((totalMinutes % 1440) + 1440) % 1440
-    const hours = Math.floor(normalizedMinutes / 60)
-    const minutes = normalizedMinutes % 60
-    return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`
   }
 
   let createdZeitbloecke = 0
@@ -107,8 +90,8 @@ export async function generateSchichtenFromTemplate(
       const zeitblockInserts: ZeitblockInsert[] = template.zeitbloecke.map((tz) => ({
         veranstaltung_id: veranstaltungId,
         name: tz.name,
-        startzeit: minutesToTime(startTotalMinutes + tz.offset_minuten),
-        endzeit: minutesToTime(startTotalMinutes + tz.offset_minuten + tz.dauer_minuten),
+        startzeit: tz.startzeit,
+        endzeit: tz.endzeit,
         typ: tz.typ,
         sortierung: tz.sortierung,
       }))
@@ -162,8 +145,8 @@ export async function generateSchichtenFromTemplate(
         veranstaltung_id: veranstaltungId,
         titel: ib.titel,
         beschreibung: ib.beschreibung,
-        startzeit: minutesToTime(startTotalMinutes + ib.offset_minuten),
-        endzeit: minutesToTime(startTotalMinutes + ib.offset_minuten + ib.dauer_minuten),
+        startzeit: ib.startzeit,
+        endzeit: ib.endzeit,
         sortierung: ib.sortierung,
       }))
 

--- a/apps/web/lib/supabase/types.ts
+++ b/apps/web/lib/supabase/types.ts
@@ -955,8 +955,8 @@ export type TemplateZeitblock = {
   id: string
   template_id: string
   name: string
-  offset_minuten: number
-  dauer_minuten: number
+  startzeit: string
+  endzeit: string
   typ: ZeitblockTyp
   sortierung: number
 }
@@ -994,8 +994,8 @@ export type TemplateInfoBlock = {
   template_id: string
   titel: string
   beschreibung: string | null
-  offset_minuten: number
-  dauer_minuten: number
+  startzeit: string
+  endzeit: string
   sortierung: number
   created_at: string
 }

--- a/apps/web/lib/validations/modul2.ts
+++ b/apps/web/lib/validations/modul2.ts
@@ -170,8 +170,8 @@ export const templateUpdateSchema = templateSchema.partial()
 export const templateZeitblockSchema = z.object({
   template_id: z.string().uuid('Ungültige Template-ID'),
   name: z.string().min(1, 'Name ist erforderlich').max(100, 'Name zu lang'),
-  offset_minuten: z.number().int().default(0),
-  dauer_minuten: z.number().int().min(1, 'Dauer muss mindestens 1 Minute sein'),
+  startzeit: z.string().regex(timeRegex, 'Ungültiges Zeitformat (HH:MM)'),
+  endzeit: z.string().regex(timeRegex, 'Ungültiges Zeitformat (HH:MM)'),
   typ: z
     .enum(['aufbau', 'einlass', 'vorfuehrung', 'pause', 'abbau', 'standard'])
     .optional(),
@@ -215,8 +215,8 @@ export const templateInfoBlockSchema = z.object({
     .max(500, 'Beschreibung zu lang')
     .nullable()
     .optional(),
-  offset_minuten: z.number().int().default(0),
-  dauer_minuten: z.number().int().min(1, 'Dauer muss mindestens 1 Minute sein'),
+  startzeit: z.string().regex(timeRegex, 'Ungültiges Zeitformat (HH:MM)'),
+  endzeit: z.string().regex(timeRegex, 'Ungültiges Zeitformat (HH:MM)'),
   sortierung: z.number().int().min(0).optional(),
 })
 

--- a/journal/decisions/ADR-001-offset-based-template-times.md
+++ b/journal/decisions/ADR-001-offset-based-template-times.md
@@ -1,6 +1,6 @@
 # ADR-001: Offset-Based Time System for Performance Templates
 
-**Status:** Accepted
+**Status:** Superseded (2026-02-16 - Umgestellt auf feste startzeit/endzeit, da Offset-Modell zu unverstaendlich fuer Benutzer)
 **Date:** 2026-02-05
 **Author:** Silke (Documentation Specialist) based on Martin's implementation
 **Issue:** #171

--- a/supabase/migrations/20260216011003_template_startzeit_endzeit.sql
+++ b/supabase/migrations/20260216011003_template_startzeit_endzeit.sql
@@ -1,0 +1,55 @@
+-- Migration: Replace offset_minuten/dauer_minuten with startzeit/endzeit on template tables
+-- Reason: Offset-based model was confusing for users. Fixed times (HH:MM) are more intuitive
+-- and match the real zeitbloecke/info_bloecke format.
+
+-- =============================================================================
+-- template_zeitbloecke: offset_minuten/dauer_minuten -> startzeit/endzeit
+-- =============================================================================
+
+-- Add new columns
+ALTER TABLE template_zeitbloecke
+  ADD COLUMN startzeit TEXT,
+  ADD COLUMN endzeit TEXT;
+
+-- Convert existing data using 19:00 as default performance start
+-- startzeit = 19:00 + offset_minuten
+-- endzeit = startzeit + dauer_minuten
+UPDATE template_zeitbloecke
+SET
+  startzeit = LPAD(((19 * 60 + offset_minuten) / 60)::TEXT, 2, '0') || ':' || LPAD(((19 * 60 + offset_minuten) % 60)::TEXT, 2, '0'),
+  endzeit = LPAD(((19 * 60 + offset_minuten + dauer_minuten) / 60)::TEXT, 2, '0') || ':' || LPAD(((19 * 60 + offset_minuten + dauer_minuten) % 60)::TEXT, 2, '0');
+
+-- Set NOT NULL after data migration
+ALTER TABLE template_zeitbloecke
+  ALTER COLUMN startzeit SET NOT NULL,
+  ALTER COLUMN endzeit SET NOT NULL;
+
+-- Drop old columns
+ALTER TABLE template_zeitbloecke
+  DROP COLUMN offset_minuten,
+  DROP COLUMN dauer_minuten;
+
+-- =============================================================================
+-- template_info_bloecke: offset_minuten/dauer_minuten -> startzeit/endzeit
+-- =============================================================================
+
+-- Add new columns
+ALTER TABLE template_info_bloecke
+  ADD COLUMN startzeit TEXT,
+  ADD COLUMN endzeit TEXT;
+
+-- Convert existing data using 19:00 as default performance start
+UPDATE template_info_bloecke
+SET
+  startzeit = LPAD(((19 * 60 + offset_minuten) / 60)::TEXT, 2, '0') || ':' || LPAD(((19 * 60 + offset_minuten) % 60)::TEXT, 2, '0'),
+  endzeit = LPAD(((19 * 60 + offset_minuten + dauer_minuten) / 60)::TEXT, 2, '0') || ':' || LPAD(((19 * 60 + offset_minuten + dauer_minuten) % 60)::TEXT, 2, '0');
+
+-- Set NOT NULL after data migration
+ALTER TABLE template_info_bloecke
+  ALTER COLUMN startzeit SET NOT NULL,
+  ALTER COLUMN endzeit SET NOT NULL;
+
+-- Drop old columns
+ALTER TABLE template_info_bloecke
+  DROP COLUMN offset_minuten,
+  DROP COLUMN dauer_minuten;


### PR DESCRIPTION
## Summary
- Templates speichern Zeitblöcke und Info-Blöcke jetzt mit festen `startzeit`/`endzeit` (HH:MM) statt `offset_minuten`/`dauer_minuten`
- Beim Anwenden eines Templates werden die Zeiten 1:1 übernommen — keine Offset-Berechnung mehr nötig
- Deutlich intuitivere Benutzeroberfläche: `<input type="time">` statt Minuten-Zahleneingabe

### Geänderte Bereiche (10 Dateien)
- **Migration**: `template_zeitbloecke` und `template_info_bloecke` Spalten getauscht (bestehende Daten mit 19:00 als Basis konvertiert)
- **Types/Validations**: `TemplateZeitblock` und `TemplateInfoBlock` auf `startzeit`/`endzeit` umgestellt
- **Server Actions**: `applyTemplate()`, `createTemplateFromVeranstaltung()`, `generateSchichtenFromTemplate()` vereinfacht (direkte Zeitkopie)
- **UI**: 4 Komponenten auf `<input type="time">` und direkte Zeitanzeige umgestellt
- **ADR-001**: Status auf "Superseded" gesetzt

## Test plan
- [ ] `npm run typecheck` — passed
- [ ] `npm run lint` — passed
- [ ] `npm run test:run` — 96 tests passed
- [ ] Manuell: Template erstellen/bearbeiten mit Uhrzeiten
- [ ] Manuell: Template auf Aufführung anwenden, prüfen ob Zeiten 1:1 übernommen werden
- [ ] Manuell: Template aus bestehender Aufführung erstellen, prüfen ob Zeiten korrekt kopiert werden

🤖 Generated with [Claude Code](https://claude.com/claude-code)