### PR TITLE
feat: add nur_mitglieder flag to template shifts

### DIFF
--- a/apps/web/components/admin/templates/SchichtenEditor.tsx
+++ b/apps/web/components/admin/templates/SchichtenEditor.tsx
@@ -22,6 +22,7 @@ export function SchichtenEditor({ templateId, schichten, zeitbloecke }: Schichte
     rolle: '',
     zeitblock_name: '',
     anzahl_benoetigt: 1,
+    nur_mitglieder: false,
   })
 
   const resetForm = () => {
@@ -29,6 +30,7 @@ export function SchichtenEditor({ templateId, schichten, zeitbloecke }: Schichte
       rolle: '',
       zeitblock_name: '',
       anzahl_benoetigt: 1,
+      nur_mitglieder: false,
     })
     setError(null)
   }
@@ -44,6 +46,7 @@ export function SchichtenEditor({ templateId, schichten, zeitbloecke }: Schichte
         rolle: formData.rolle.trim(),
         zeitblock_name: formData.zeitblock_name || null,
         anzahl_benoetigt: formData.anzahl_benoetigt,
+        nur_mitglieder: formData.nur_mitglieder,
       })
 
       if (!result.success) {
@@ -164,6 +167,16 @@ export function SchichtenEditor({ templateId, schichten, zeitbloecke }: Schichte
                 />
               </div>
 
+              <label className="mt-3 flex items-center gap-2 text-sm text-neutral-700">
+                <input
+                  type="checkbox"
+                  checked={formData.nur_mitglieder}
+                  onChange={(e) => setFormData((prev) => ({ ...prev, nur_mitglieder: e.target.checked }))}
+                  className="rounded border-neutral-300"
+                />
+                Nur Vereinsmitglieder
+              </label>
+
               <div className="mt-4 flex justify-end gap-2">
                 <Button
                   type="button"
@@ -209,6 +222,9 @@ export function SchichtenEditor({ templateId, schichten, zeitbloecke }: Schichte
                           <th className="pb-2 text-left text-xs font-medium uppercase tracking-wider text-neutral-500">
                             Anzahl
                           </th>
+                          <th className="pb-2 text-left text-xs font-medium uppercase tracking-wider text-neutral-500">
+                            Nur Mitglieder
+                          </th>
                           <th className="pb-2 text-right text-xs font-medium uppercase tracking-wider text-neutral-500">
                             Aktionen
                           </th>
@@ -224,6 +240,15 @@ export function SchichtenEditor({ templateId, schichten, zeitbloecke }: Schichte
                               <span className="inline-flex items-center justify-center rounded-full bg-blue-100 px-2.5 py-0.5 text-sm font-medium text-blue-800">
                                 {schicht.anzahl_benoetigt}
                               </span>
+                            </td>
+                            <td className="py-2">
+                              {schicht.nur_mitglieder ? (
+                                <span className="inline-flex items-center rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-800">
+                                  Ja
+                                </span>
+                              ) : (
+                                <span className="text-sm text-neutral-400">Nein</span>
+                              )}
                             </td>
                             <td className="py-2 text-right">
                               <Button

--- a/apps/web/components/templates/TemplateDetailEditor.tsx
+++ b/apps/web/components/templates/TemplateDetailEditor.tsx
@@ -67,6 +67,7 @@ export function TemplateDetailEditor({
   const [schichtRolle, setSchichtRolle] = useState('')
   const [schichtZeitblock, setSchichtZeitblock] = useState('')
   const [schichtAnzahl, setSchichtAnzahl] = useState('1')
+  const [schichtNurMitglieder, setSchichtNurMitglieder] = useState(false)
   const [schichtLoading, setSchichtLoading] = useState(false)
 
   // Schicht Edit State
@@ -74,6 +75,7 @@ export function TemplateDetailEditor({
   const [editSchichtRolle, setEditSchichtRolle] = useState('')
   const [editSchichtZeitblock, setEditSchichtZeitblock] = useState('')
   const [editSchichtAnzahl, setEditSchichtAnzahl] = useState('1')
+  const [editSchichtNurMitglieder, setEditSchichtNurMitglieder] = useState(false)
   const [editSchichtLoading, setEditSchichtLoading] = useState(false)
   const [editSchichtError, setEditSchichtError] = useState<string | null>(null)
 
@@ -172,10 +174,12 @@ export function TemplateDetailEditor({
       zeitblock_name: schichtZeitblock || null,
       rolle: schichtRolle,
       anzahl_benoetigt: parseInt(schichtAnzahl, 10),
+      nur_mitglieder: schichtNurMitglieder,
     })
     setSchichtRolle('')
     setSchichtZeitblock('')
     setSchichtAnzahl('1')
+    setSchichtNurMitglieder(false)
     setShowSchichtForm(false)
     setSchichtLoading(false)
     router.refresh()
@@ -192,6 +196,7 @@ export function TemplateDetailEditor({
     setEditSchichtRolle(s.rolle)
     setEditSchichtZeitblock(s.zeitblock_name || '')
     setEditSchichtAnzahl(String(s.anzahl_benoetigt))
+    setEditSchichtNurMitglieder(s.nur_mitglieder)
     setEditSchichtError(null)
   }
 
@@ -206,6 +211,7 @@ export function TemplateDetailEditor({
       rolle: editSchichtRolle,
       zeitblock_name: editSchichtZeitblock || null,
       anzahl_benoetigt: parseInt(editSchichtAnzahl, 10) || 1,
+      nur_mitglieder: editSchichtNurMitglieder,
     })
 
     if (result.success) {
@@ -553,6 +559,15 @@ export function TemplateDetailEditor({
                 className="rounded-lg border border-gray-300 px-3 py-2 text-sm"
               />
             </div>
+            <label className="flex items-center gap-2 text-sm text-gray-700">
+              <input
+                type="checkbox"
+                checked={schichtNurMitglieder}
+                onChange={(e) => setSchichtNurMitglieder(e.target.checked)}
+                className="rounded border-gray-300"
+              />
+              Nur Vereinsmitglieder
+            </label>
             <div className="flex gap-2">
               <button
                 type="submit"
@@ -629,6 +644,15 @@ export function TemplateDetailEditor({
                     />
                   </div>
                 </div>
+                <label className="flex items-center gap-2 text-sm text-gray-700">
+                  <input
+                    type="checkbox"
+                    checked={editSchichtNurMitglieder}
+                    onChange={(e) => setEditSchichtNurMitglieder(e.target.checked)}
+                    className="rounded border-gray-300"
+                  />
+                  Nur Vereinsmitglieder
+                </label>
                 <div className="flex gap-2">
                   <button
                     type="submit"
@@ -659,6 +683,11 @@ export function TemplateDetailEditor({
                   {s.zeitblock_name && (
                     <span className="ml-2 text-sm text-gray-400">
                       - {s.zeitblock_name}
+                    </span>
+                  )}
+                  {s.nur_mitglieder && (
+                    <span className="ml-2 inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800">
+                      nur Mitglieder
                     </span>
                   )}
                 </div>

--- a/apps/web/lib/actions/schicht-generator.ts
+++ b/apps/web/lib/actions/schicht-generator.ts
@@ -121,6 +121,7 @@ export async function generateSchichtenFromTemplate(
         zeitblock_id: ts.zeitblock_name ? zeitblockMap[ts.zeitblock_name] ?? null : null,
         rolle: ts.rolle,
         anzahl_benoetigt: ts.anzahl_benoetigt,
+        sichtbarkeit: ts.nur_mitglieder ? 'intern' as const : 'public' as const,
       }))
 
       const { data: createdSchichtData, error: schichtError } = await supabase

--- a/apps/web/lib/actions/templates.ts
+++ b/apps/web/lib/actions/templates.ts
@@ -103,7 +103,7 @@ export async function getTemplate(
   // Get schichten
   const { data: schichten } = await supabase
     .from('template_schichten')
-    .select('id, template_id, zeitblock_name, rolle, anzahl_benoetigt')
+    .select('id, template_id, zeitblock_name, rolle, anzahl_benoetigt, nur_mitglieder')
     .eq('template_id', id)
 
   // Get ressourcen with details
@@ -586,6 +586,7 @@ export async function applyTemplate(
           : null,
         rolle: ts.rolle,
         anzahl_benoetigt: ts.anzahl_benoetigt,
+        sichtbarkeit: ts.nur_mitglieder ? 'intern' as const : 'public' as const,
       })
     )
 
@@ -744,6 +745,7 @@ export async function createTemplateFromVeranstaltung(
       zeitblock_name: (s.zeitblock as { name: string } | null)?.name || null,
       rolle: s.rolle,
       anzahl_benoetigt: s.anzahl_benoetigt,
+      nur_mitglieder: s.sichtbarkeit === 'intern',
     }))
 
     await supabase

--- a/apps/web/lib/supabase/types.ts
+++ b/apps/web/lib/supabase/types.ts
@@ -970,6 +970,7 @@ export type TemplateSchicht = {
   zeitblock_name: string | null
   rolle: string
   anzahl_benoetigt: number
+  nur_mitglieder: boolean
 }
 
 export type TemplateSchichtInsert = Omit<TemplateSchicht, 'id'>

--- a/apps/web/lib/validations/modul2.ts
+++ b/apps/web/lib/validations/modul2.ts
@@ -187,6 +187,7 @@ export const templateSchichtSchema = z.object({
     .int()
     .min(1, 'Mindestens 1 Person benötigt')
     .default(1),
+  nur_mitglieder: z.boolean().optional().default(false),
 })
 
 export const templateZeitblockUpdateSchema = templateZeitblockSchema

--- a/supabase/migrations/20260216100000_template_schichten_nur_mitglieder.sql
+++ b/supabase/migrations/20260216100000_template_schichten_nur_mitglieder.sql
@@ -1,0 +1,6 @@
+-- Add nur_mitglieder flag to template_schichten
+-- When true, generated auffuehrung_schichten get sichtbarkeit='intern'
+-- When false (default), they get sichtbarkeit='public'
+
+ALTER TABLE template_schichten
+  ADD COLUMN nur_mitglieder BOOLEAN DEFAULT false NOT NULL;


### PR DESCRIPTION
## Summary
- Adds `nur_mitglieder BOOLEAN DEFAULT false` column to `template_schichten`
- When applying a template: `nur_mitglieder=true` → `sichtbarkeit='intern'`, `false` → `'public'`
- When creating a template from a performance: `sichtbarkeit='intern'` → `nur_mitglieder=true`
- Both template editors (TemplateDetailEditor + admin SchichtenEditor) show checkbox in forms and badge/column in display

## Test plan
- [ ] Run migration on Supabase
- [ ] Create a template, add shifts with "Nur Vereinsmitglieder" checked — verify badge appears
- [ ] Apply template to a performance — verify intern shifts get `sichtbarkeit='intern'`, others `'public'`
- [ ] Create template from a performance with mixed sichtbarkeit — verify `nur_mitglieder` is set correctly
- [ ] Verify admin SchichtenEditor shows "Nur Mitglieder" column with Ja/Nein values
- [ ] `npm run typecheck && npm run lint && npm run test:run` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)