### PR TITLE
feat: add inline edit for template Info-Blöcke

### DIFF
--- a/apps/web/lib/actions/templates.ts
+++ b/apps/web/lib/actions/templates.ts
@@ -16,6 +16,7 @@ import type {
   TemplateRessourceInsert,
   TemplateInfoBlock,
   TemplateInfoBlockInsert,
+  TemplateInfoBlockUpdate,
   TemplateSachleistung,
   TemplateSachleistungInsert,
   ZeitblockInsert,
@@ -32,6 +33,7 @@ import {
   templateSchichtUpdateSchema,
   templateRessourceSchema,
   templateInfoBlockSchema,
+  templateInfoBlockUpdateSchema,
   templateSachleistungSchema,
   validateInput,
 } from '../validations/modul2'
@@ -466,6 +468,31 @@ export async function removeTemplateInfoBlock(
   if (error) {
     console.error('Error removing template info block:', error)
     return { success: false, error: error.message }
+  }
+
+  revalidatePath(`/templates/${templateId}`)
+  return { success: true }
+}
+
+export async function updateTemplateInfoBlock(
+  id: string,
+  templateId: string,
+  data: TemplateInfoBlockUpdate
+): Promise<{ success: boolean; error?: string }> {
+  const validation = validateInput(templateInfoBlockUpdateSchema, data)
+  if (!validation.success) {
+    return { success: false, error: validation.error }
+  }
+
+  const supabase = await createClient()
+  const { error } = await supabase
+    .from('template_info_bloecke')
+    .update(validation.data as never)
+    .eq('id', id)
+
+  if (error) {
+    console.error('Error updating template info block:', error)
+    return { success: false, error: 'Fehler beim Aktualisieren des Info-Blocks' }
   }
 
   revalidatePath(`/templates/${templateId}`)

--- a/apps/web/lib/validations/modul2.ts
+++ b/apps/web/lib/validations/modul2.ts
@@ -221,6 +221,10 @@ export const templateInfoBlockSchema = z.object({
   sortierung: z.number().int().min(0).optional(),
 })
 
+export const templateInfoBlockUpdateSchema = templateInfoBlockSchema
+  .omit({ template_id: true })
+  .partial()
+
 // =============================================================================
 // Template Sachleistung Validations (Issue #202)
 // =============================================================================


### PR DESCRIPTION
## Summary
- Add `updateTemplateInfoBlock` server action + `templateInfoBlockUpdateSchema` validation
- TemplateDetailEditor: inline edit form (amber theme, matching Zeitblöcke/Schichten pattern)
- Admin InfoBloeckeEditor: inline edit form within table rows with Bearbeiten button

## Test plan
- [ ] Edit an Info-Block in the template detail view — verify titel, beschreibung, zeiten update
- [ ] Edit an Info-Block in the admin editor — verify inline form replaces table row
- [ ] Cancel edit — verify original values are restored
- [ ] Submit invalid data (empty titel) — verify error message
- [ ] `npm run typecheck && npm run lint && npm run test:run` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)