### PR TITLE
feat: add inline edit for template Sachleistungen

### DIFF
--- a/apps/web/lib/actions/templates.ts
+++ b/apps/web/lib/actions/templates.ts
@@ -19,6 +19,7 @@ import type {
   TemplateInfoBlockUpdate,
   TemplateSachleistung,
   TemplateSachleistungInsert,
+  TemplateSachleistungUpdate,
   ZeitblockInsert,
   AuffuehrungSchichtInsert,
   InfoBlockInsert,
@@ -35,6 +36,7 @@ import {
   templateInfoBlockSchema,
   templateInfoBlockUpdateSchema,
   templateSachleistungSchema,
+  templateSachleistungUpdateSchema,
   validateInput,
 } from '../validations/modul2'
 
@@ -541,6 +543,31 @@ export async function removeTemplateSachleistung(
   if (error) {
     console.error('Error removing template sachleistung:', error)
     return { success: false, error: error.message }
+  }
+
+  revalidatePath(`/templates/${templateId}`)
+  return { success: true }
+}
+
+export async function updateTemplateSachleistung(
+  id: string,
+  templateId: string,
+  data: TemplateSachleistungUpdate
+): Promise<{ success: boolean; error?: string }> {
+  const validation = validateInput(templateSachleistungUpdateSchema, data)
+  if (!validation.success) {
+    return { success: false, error: validation.error }
+  }
+
+  const supabase = await createClient()
+  const { error } = await supabase
+    .from('template_sachleistungen')
+    .update(validation.data as never)
+    .eq('id', id)
+
+  if (error) {
+    console.error('Error updating template sachleistung:', error)
+    return { success: false, error: 'Fehler beim Aktualisieren der Sachleistung' }
   }
 
   revalidatePath(`/templates/${templateId}`)

--- a/apps/web/lib/validations/modul2.ts
+++ b/apps/web/lib/validations/modul2.ts
@@ -240,6 +240,10 @@ export const templateSachleistungSchema = z.object({
     .optional(),
 })
 
+export const templateSachleistungUpdateSchema = templateSachleistungSchema
+  .omit({ template_id: true })
+  .partial()
+
 // =============================================================================
 // Helper function for validation
 // =============================================================================


### PR DESCRIPTION
## Summary
- Add `updateTemplateSachleistung` server action + `templateSachleistungUpdateSchema` validation
- TemplateDetailEditor: inline edit form (green theme, matching existing pattern)
- Admin SachleistungenEditor: inline edit form within table rows with Bearbeiten button

## Test plan
- [ ] Edit a Sachleistung in the template detail view — verify name, anzahl, beschreibung update
- [ ] Edit a Sachleistung in the admin editor — verify inline form replaces table row
- [ ] Cancel edit — verify original values are restored
- [ ] Submit invalid data (empty name) — verify error message
- [ ] `npm run typecheck && npm run lint && npm run test:run` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)