### PR TITLE
feat: add inline edit for template Ressourcen

### DIFF
--- a/apps/web/lib/actions/templates.ts
+++ b/apps/web/lib/actions/templates.ts
@@ -14,6 +14,7 @@ import type {
   TemplateSchichtInsert,
   TemplateSchichtUpdate,
   TemplateRessourceInsert,
+  TemplateRessourceUpdate,
   TemplateInfoBlock,
   TemplateInfoBlockInsert,
   TemplateInfoBlockUpdate,
@@ -33,6 +34,7 @@ import {
   templateSchichtSchema,
   templateSchichtUpdateSchema,
   templateRessourceSchema,
+  templateRessourceUpdateSchema,
   templateInfoBlockSchema,
   templateInfoBlockUpdateSchema,
   templateSachleistungSchema,
@@ -422,6 +424,31 @@ export async function removeTemplateRessource(
   if (error) {
     console.error('Error removing template ressource:', error)
     return { success: false, error: error.message }
+  }
+
+  revalidatePath(`/templates/${templateId}`)
+  return { success: true }
+}
+
+export async function updateTemplateRessource(
+  id: string,
+  templateId: string,
+  data: TemplateRessourceUpdate
+): Promise<{ success: boolean; error?: string }> {
+  const validation = validateInput(templateRessourceUpdateSchema, data)
+  if (!validation.success) {
+    return { success: false, error: validation.error }
+  }
+
+  const supabase = await createClient()
+  const { error } = await supabase
+    .from('template_ressourcen')
+    .update(validation.data as never)
+    .eq('id', id)
+
+  if (error) {
+    console.error('Error updating template ressource:', error)
+    return { success: false, error: 'Fehler beim Aktualisieren der Ressource' }
   }
 
   revalidatePath(`/templates/${templateId}`)

--- a/apps/web/lib/validations/modul2.ts
+++ b/apps/web/lib/validations/modul2.ts
@@ -204,6 +204,10 @@ export const templateRessourceSchema = z.object({
   menge: z.number().int().min(1, 'Menge muss mindestens 1 sein').default(1),
 })
 
+export const templateRessourceUpdateSchema = templateRessourceSchema
+  .omit({ template_id: true })
+  .partial()
+
 // =============================================================================
 // Template Info-Block Validations (Issue #203)
 // =============================================================================


### PR DESCRIPTION
## Summary
- Add `updateTemplateRessource` server action + `templateRessourceUpdateSchema` validation
- TemplateDetailEditor: inline edit for Menge field (blue theme, matching existing pattern)
- No admin Ressourcen-Editor exists, so only TemplateDetailEditor was updated

## Test plan
- [ ] Edit a Ressource menge in the template detail view — verify value updates
- [ ] Cancel edit — verify original menge is restored
- [ ] `npm run typecheck && npm run lint && npm run test:run` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)