### PR TITLE
fix: revalidate admin template path and add Sachleistungen error handling

### DIFF
--- a/apps/web/components/templates/TemplateDetailEditor.tsx
+++ b/apps/web/components/templates/TemplateDetailEditor.tsx
@@ -119,6 +119,7 @@ export function TemplateDetailEditor({
   const [slAnzahl, setSlAnzahl] = useState('1')
   const [slBeschreibung, setSlBeschreibung] = useState('')
   const [slLoading, setSlLoading] = useState(false)
+  const [slError, setSlError] = useState<string | null>(null)
 
   // Sachleistung Edit State
   const [editSlId, setEditSlId] = useState<string | null>(null)
@@ -363,18 +364,25 @@ export function TemplateDetailEditor({
   async function handleAddSachleistung(e: React.FormEvent) {
     e.preventDefault()
     setSlLoading(true)
-    await addTemplateSachleistung({
+    setSlError(null)
+
+    const result = await addTemplateSachleistung({
       template_id: template.id,
       name: slName,
-      anzahl: parseInt(slAnzahl, 10),
+      anzahl: parseInt(slAnzahl, 10) || 1,
       beschreibung: slBeschreibung || null,
     })
-    setSlName('')
-    setSlAnzahl('1')
-    setSlBeschreibung('')
-    setShowSachleistungForm(false)
+
+    if (result.success) {
+      setSlName('')
+      setSlAnzahl('1')
+      setSlBeschreibung('')
+      setShowSachleistungForm(false)
+      router.refresh()
+    } else {
+      setSlError(result.error || 'Ein Fehler ist aufgetreten')
+    }
     setSlLoading(false)
-    router.refresh()
   }
 
   async function handleRemoveSachleistung(id: string, name: string) {
@@ -1183,6 +1191,11 @@ export function TemplateDetailEditor({
             onSubmit={handleAddSachleistung}
             className="space-y-3 border-b bg-green-50 p-4"
           >
+            {slError && (
+              <div className="rounded border border-red-200 bg-red-50 p-2 text-sm text-red-700">
+                {slError}
+              </div>
+            )}
             <input
               type="text"
               placeholder="Name (z.B. Kuchen, Salat) *"

--- a/apps/web/lib/actions/templates.ts
+++ b/apps/web/lib/actions/templates.ts
@@ -42,6 +42,12 @@ import {
   validateInput,
 } from '../validations/modul2'
 
+/** Revalidate both template pages (user-facing + admin) */
+function revalidateTemplate(templateId: string) {
+  revalidatePath(`/templates/${templateId}`)
+  revalidatePath(`/admin/schicht-templates/${templateId}`)
+}
+
 /**
  * Get all templates (non-archived)
  */
@@ -172,6 +178,7 @@ export async function createTemplate(
   }
 
   revalidatePath('/templates')
+  revalidatePath('/admin/schicht-templates')
   return { success: true, id: result?.id }
 }
 
@@ -201,7 +208,8 @@ export async function updateTemplate(
   }
 
   revalidatePath('/templates')
-  revalidatePath(`/templates/${id}`)
+  revalidatePath('/admin/schicht-templates')
+  revalidateTemplate(id)
   return { success: true }
 }
 
@@ -233,6 +241,7 @@ export async function deleteTemplate(
   }
 
   revalidatePath('/templates')
+  revalidatePath('/admin/schicht-templates')
   return { success: true }
 }
 
@@ -261,7 +270,7 @@ export async function addTemplateZeitblock(
     return { success: false, error: 'Fehler beim Hinzufügen des Zeitblocks' }
   }
 
-  revalidatePath(`/templates/${data.template_id}`)
+  revalidateTemplate(data.template_id)
   return { success: true, id: result?.id }
 }
 
@@ -280,7 +289,7 @@ export async function removeTemplateZeitblock(
     return { success: false, error: error.message }
   }
 
-  revalidatePath(`/templates/${templateId}`)
+  revalidateTemplate(templateId)
   return { success: true }
 }
 
@@ -305,7 +314,7 @@ export async function updateTemplateZeitblock(
     return { success: false, error: 'Fehler beim Aktualisieren des Zeitblocks' }
   }
 
-  revalidatePath(`/templates/${templateId}`)
+  revalidateTemplate(templateId)
   return { success: true }
 }
 
@@ -334,7 +343,7 @@ export async function addTemplateSchicht(
     return { success: false, error: 'Fehler beim Hinzufügen der Schicht' }
   }
 
-  revalidatePath(`/templates/${data.template_id}`)
+  revalidateTemplate(data.template_id)
   return { success: true, id: result?.id }
 }
 
@@ -353,7 +362,7 @@ export async function removeTemplateSchicht(
     return { success: false, error: error.message }
   }
 
-  revalidatePath(`/templates/${templateId}`)
+  revalidateTemplate(templateId)
   return { success: true }
 }
 
@@ -378,7 +387,7 @@ export async function updateTemplateSchicht(
     return { success: false, error: 'Fehler beim Aktualisieren der Schicht' }
   }
 
-  revalidatePath(`/templates/${templateId}`)
+  revalidateTemplate(templateId)
   return { success: true }
 }
 
@@ -407,7 +416,7 @@ export async function addTemplateRessource(
     return { success: false, error: 'Fehler beim Hinzufügen der Ressource' }
   }
 
-  revalidatePath(`/templates/${data.template_id}`)
+  revalidateTemplate(data.template_id)
   return { success: true, id: result?.id }
 }
 
@@ -426,7 +435,7 @@ export async function removeTemplateRessource(
     return { success: false, error: error.message }
   }
 
-  revalidatePath(`/templates/${templateId}`)
+  revalidateTemplate(templateId)
   return { success: true }
 }
 
@@ -451,7 +460,7 @@ export async function updateTemplateRessource(
     return { success: false, error: 'Fehler beim Aktualisieren der Ressource' }
   }
 
-  revalidatePath(`/templates/${templateId}`)
+  revalidateTemplate(templateId)
   return { success: true }
 }
 
@@ -480,7 +489,7 @@ export async function addTemplateInfoBlock(
     return { success: false, error: 'Fehler beim Hinzufügen des Info-Blocks' }
   }
 
-  revalidatePath(`/templates/${data.template_id}`)
+  revalidateTemplate(data.template_id)
   return { success: true, id: result?.id }
 }
 
@@ -499,7 +508,7 @@ export async function removeTemplateInfoBlock(
     return { success: false, error: error.message }
   }
 
-  revalidatePath(`/templates/${templateId}`)
+  revalidateTemplate(templateId)
   return { success: true }
 }
 
@@ -524,7 +533,7 @@ export async function updateTemplateInfoBlock(
     return { success: false, error: 'Fehler beim Aktualisieren des Info-Blocks' }
   }
 
-  revalidatePath(`/templates/${templateId}`)
+  revalidateTemplate(templateId)
   return { success: true }
 }
 
@@ -553,7 +562,7 @@ export async function addTemplateSachleistung(
     return { success: false, error: 'Fehler beim Hinzufügen der Sachleistung' }
   }
 
-  revalidatePath(`/templates/${data.template_id}`)
+  revalidateTemplate(data.template_id)
   return { success: true, id: result?.id }
 }
 
@@ -572,7 +581,7 @@ export async function removeTemplateSachleistung(
     return { success: false, error: error.message }
   }
 
-  revalidatePath(`/templates/${templateId}`)
+  revalidateTemplate(templateId)
   return { success: true }
 }
 
@@ -597,7 +606,7 @@ export async function updateTemplateSachleistung(
     return { success: false, error: 'Fehler beim Aktualisieren der Sachleistung' }
   }
 
-  revalidatePath(`/templates/${templateId}`)
+  revalidateTemplate(templateId)
   return { success: true }
 }
 
@@ -856,5 +865,6 @@ export async function createTemplateFromVeranstaltung(
   }
 
   revalidatePath('/templates')
+  revalidatePath('/admin/schicht-templates')
   return { success: true, id: template.id }
 }


### PR DESCRIPTION
## Summary
- Template server actions only called `revalidatePath('/templates/...')` but the admin editor lives at `/admin/schicht-templates/...`. In Next.js 15, server actions no longer auto-invalidate the client Router Cache, so the admin page never refreshed after mutations.
- `handleAddSachleistung` in TemplateDetailEditor silently discarded server action errors — the form would close even on failure.

## Changes
- Added `revalidateTemplate()` helper that revalidates both `/templates/[id]` and `/admin/schicht-templates/[id]`, applied to all 15 template-specific server actions
- Added admin list path revalidation (`/admin/schicht-templates`) to create/update/delete template actions
- Added `slError` state and proper result checking in `handleAddSachleistung` — form now stays open and shows error on failure

## Test plan
- [ ] Open a template in `/admin/schicht-templates/[id]`, add a Sachleistung — verify it appears immediately
- [ ] Edit a Sachleistung in admin editor — verify changes appear immediately
- [ ] Open a template in `/templates/[id]`, add a Sachleistung — verify it appears and errors are shown on failure
- [ ] Verify Zeitblöcke, Schichten, Info-Blöcke also refresh correctly on admin page

🤖 Generated with [Claude Code](https://claude.com/claude-code)