### PR TITLE
fix: pass templateId explicitly to all admin template editors

### DIFF
--- a/apps/web/app/(protected)/admin/schicht-templates/[id]/page.tsx
+++ b/apps/web/app/(protected)/admin/schicht-templates/[id]/page.tsx
@@ -74,30 +74,30 @@ export default async function TemplateDetailPage({ params }: PageProps) {
       />
 
       {/* Edit Grunddaten */}
-      <TemplateForm template={template} />
+      <TemplateForm template={template} templateId={id} />
 
       {/* Zeitbloecke */}
       <ZeitbloeckeEditor
-        templateId={template.id}
+        templateId={id}
         zeitbloecke={template.zeitbloecke}
       />
 
       {/* Schichten */}
       <SchichtenEditor
-        templateId={template.id}
+        templateId={id}
         schichten={template.schichten}
         zeitbloecke={template.zeitbloecke}
       />
 
       {/* Info-Bloecke */}
       <InfoBloeckeEditor
-        templateId={template.id}
+        templateId={id}
         infoBloecke={template.info_bloecke}
       />
 
       {/* Sachleistungen */}
       <SachleistungenEditor
-        templateId={template.id}
+        templateId={id}
         sachleistungen={template.sachleistungen}
       />
     </div>

--- a/apps/web/app/(protected)/templates/[id]/page.tsx
+++ b/apps/web/app/(protected)/templates/[id]/page.tsx
@@ -58,7 +58,7 @@ export default async function TemplateDetailPage({ params }: PageProps) {
           <div>
             <div className="rounded-lg bg-white p-4 shadow">
               <h2 className="mb-4 font-medium text-gray-900">Grunddaten</h2>
-              <TemplateForm template={template} mode="edit" />
+              <TemplateForm template={template} templateId={id} mode="edit" />
             </div>
           </div>
 

--- a/apps/web/components/admin/templates/TemplateForm.tsx
+++ b/apps/web/components/admin/templates/TemplateForm.tsx
@@ -8,9 +8,10 @@ import { Card, CardHeader, CardTitle, CardContent, CardFooter, Button, Input } f
 
 interface TemplateFormProps {
   template?: AuffuehrungTemplate
+  templateId?: string
 }
 
-export function TemplateForm({ template }: TemplateFormProps) {
+export function TemplateForm({ template, templateId }: TemplateFormProps) {
   const router = useRouter()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -31,12 +32,13 @@ export function TemplateForm({ template }: TemplateFormProps) {
           name: formData.name.trim(),
           beschreibung: formData.beschreibung.trim() || null,
         }
-        const result = await updateTemplate(template.id, updateData)
+        const tid = templateId || template.id
+        const result = await updateTemplate(tid, updateData)
         if (!result.success) {
           setError(result.error ?? 'Fehler beim Aktualisieren')
           return
         }
-        router.push(`/admin/schicht-templates/${template.id}` as never)
+        router.push(`/admin/schicht-templates/${tid}` as never)
       } else {
         const createData = {
           name: formData.name.trim(),

--- a/apps/web/components/templates/TemplateForm.tsx
+++ b/apps/web/components/templates/TemplateForm.tsx
@@ -11,10 +11,11 @@ import type { AuffuehrungTemplate } from '@/lib/supabase/types'
 
 interface TemplateFormProps {
   template?: AuffuehrungTemplate
+  templateId?: string
   mode: 'create' | 'edit'
 }
 
-export function TemplateForm({ template, mode }: TemplateFormProps) {
+export function TemplateForm({ template, templateId, mode }: TemplateFormProps) {
   const router = useRouter()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -36,7 +37,7 @@ export function TemplateForm({ template, mode }: TemplateFormProps) {
     const result =
       mode === 'create'
         ? await createTemplate(data)
-        : await updateTemplate(template!.id, data)
+        : await updateTemplate(templateId || template!.id, data)
 
     if (result.success) {
       if (mode === 'create' && 'id' in result && result.id) {
@@ -56,7 +57,7 @@ export function TemplateForm({ template, mode }: TemplateFormProps) {
     if (!confirm(`"${template.name}" wirklich archivieren?`)) return
 
     setLoading(true)
-    const result = await archiveTemplate(template.id)
+    const result = await archiveTemplate(templateId || template.id)
 
     if (result.success) {
       router.push('/templates' as never)


### PR DESCRIPTION
## Summary
- Same RSC serialization issue as #312 — `template.id` is `undefined` when the template object is passed from server to client components
- The admin page at `/admin/schicht-templates/[id]` passed `template.id` to all 4 editors (ZeitbloeckeEditor, SchichtenEditor, InfoBloeckeEditor, SachleistungenEditor) and to TemplateForm
- Both TemplateForm components (admin + user-facing) also used `template.id` for update/archive operations

## Changes
- `admin/schicht-templates/[id]/page.tsx`: Use URL `id` for all editor `templateId` props and TemplateForm
- `templates/[id]/page.tsx`: Pass `templateId={id}` to user-facing TemplateForm
- `admin/templates/TemplateForm.tsx`: Accept `templateId` prop, use with fallback
- `components/templates/TemplateForm.tsx`: Accept `templateId` prop, use with fallback

## Test plan
- [ ] Open `/admin/schicht-templates/[id]` — add/edit/remove Sachleistungen, Info-Blöcke, Zeitblöcke, Schichten
- [ ] Edit template Grunddaten (name/beschreibung) on admin page
- [ ] Edit template Grunddaten on `/templates/[id]` page
- [ ] Archive a template from `/templates/[id]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)