### PR TITLE
debug: show template_id in Sachleistungen validation error

### DIFF
--- a/apps/web/lib/actions/templates.ts
+++ b/apps/web/lib/actions/templates.ts
@@ -547,7 +547,7 @@ export async function addTemplateSachleistung(
   // Validate input
   const validation = validateInput(templateSachleistungSchema, data)
   if (!validation.success) {
-    return { success: false, error: validation.error }
+    return { success: false, error: `${validation.error} [template_id=${JSON.stringify(data.template_id)}, type=${typeof data.template_id}, keys=${Object.keys(data).join(',')}]` }
   }
 
   const supabase = await createClient()


### PR DESCRIPTION
Temporary debug PR — adds the received template_id value to the validation error message so we can see what's arriving at the server action.

Will be reverted once issue is diagnosed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)