### PR TITLE
fix: replace Zod v4 .uuid() with relaxed regex for seed UUIDs

### DIFF
--- a/apps/web/lib/actions/templates.ts
+++ b/apps/web/lib/actions/templates.ts
@@ -547,7 +547,7 @@ export async function addTemplateSachleistung(
   // Validate input
   const validation = validateInput(templateSachleistungSchema, data)
   if (!validation.success) {
-    return { success: false, error: `${validation.error} [template_id=${JSON.stringify(data.template_id)}, type=${typeof data.template_id}, keys=${Object.keys(data).join(',')}]` }
+    return { success: false, error: validation.error }
   }
 
   const supabase = await createClient()

--- a/apps/web/lib/validations/helfereinsaetze.ts
+++ b/apps/web/lib/validations/helfereinsaetze.ts
@@ -1,10 +1,15 @@
 import { z } from 'zod'
 
+const UUID_REGEX =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
+const uuid = (message = 'Ungültige UUID') =>
+  z.string().regex(UUID_REGEX, message)
+
 export const helfereinsatzSchema = z.object({
   titel: z.string().min(1, 'Titel ist erforderlich').max(200, 'Titel zu lang'),
   datum: z.string().min(1, 'Datum ist erforderlich'),
   status: z.enum(['offen', 'bestaetigt', 'abgeschlossen', 'abgesagt']),
-  partner_id: z.string().uuid('Ungültige Partner-ID').nullable().optional(),
+  partner_id: uuid('Ungültige Partner-ID').nullable().optional(),
   beschreibung: z
     .string()
     .max(2000, 'Beschreibung zu lang')
@@ -23,7 +28,7 @@ export const helfereinsatzSchema = z.object({
 export const helfereinsatzUpdateSchema = helfereinsatzSchema.partial()
 
 export const helferrolleSchema = z.object({
-  helfereinsatz_id: z.string().uuid('Ungültige Helfereinsatz-ID'),
+  helfereinsatz_id: uuid('Ungültige Helfereinsatz-ID'),
   rolle: z
     .string()
     .min(1, 'Rolle ist erforderlich')

--- a/apps/web/lib/validations/meeting.ts
+++ b/apps/web/lib/validations/meeting.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod'
 
+const UUID_REGEX =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
+const uuid = (message = 'Ungültige UUID') =>
+  z.string().regex(UUID_REGEX, message)
+
 // =============================================================================
 // Enum Schemas
 // =============================================================================
@@ -16,8 +21,8 @@ export type WiederholungTypMeetingSchema = z.infer<typeof wiederholungTypMeeting
 
 export const meetingSchema = z.object({
   meeting_typ: meetingTypSchema,
-  leiter_id: z.string().uuid().nullable().optional(),
-  protokollant_id: z.string().uuid().nullable().optional(),
+  leiter_id: uuid().nullable().optional(),
+  protokollant_id: uuid().nullable().optional(),
 })
 
 export type MeetingFormData = z.infer<typeof meetingSchema>
@@ -38,8 +43,8 @@ export const meetingVeranstaltungSchema = z.object({
 
   // Meeting fields
   meeting_typ: meetingTypSchema,
-  leiter_id: z.string().uuid().nullable().optional(),
-  protokollant_id: z.string().uuid().nullable().optional(),
+  leiter_id: uuid().nullable().optional(),
+  protokollant_id: uuid().nullable().optional(),
 })
 
 export type MeetingVeranstaltungFormData = z.infer<typeof meetingVeranstaltungSchema>
@@ -53,7 +58,7 @@ export const agendaItemSchema = z.object({
   titel: z.string().min(1, 'Titel ist erforderlich'),
   beschreibung: z.string().nullable().optional(),
   dauer_minuten: z.number().positive().nullable().optional(),
-  verantwortlich_id: z.string().uuid().nullable().optional(),
+  verantwortlich_id: uuid().nullable().optional(),
 })
 
 export type AgendaItemFormData = z.infer<typeof agendaItemSchema>
@@ -66,12 +71,12 @@ export const beschlussSchema = z.object({
   nummer: z.number().positive('Nummer muss positiv sein'),
   titel: z.string().min(1, 'Titel ist erforderlich'),
   beschreibung: z.string().nullable().optional(),
-  agenda_item_id: z.string().uuid().nullable().optional(),
+  agenda_item_id: uuid().nullable().optional(),
   abstimmung_ja: z.number().nonnegative().nullable().optional(),
   abstimmung_nein: z.number().nonnegative().nullable().optional(),
   abstimmung_enthaltung: z.number().nonnegative().nullable().optional(),
   status: z.enum(['beschlossen', 'abgelehnt', 'vertagt', 'umgesetzt']).default('beschlossen'),
-  zustaendig_id: z.string().uuid().nullable().optional(),
+  zustaendig_id: uuid().nullable().optional(),
   faellig_bis: z.string().nullable().optional(),
 })
 
@@ -88,7 +93,7 @@ export const meetingTemplateSchema = z.object({
   default_ort: z.string().nullable().optional(),
   default_startzeit: z.string().nullable().optional(),
   default_dauer_minuten: z.number().positive().default(60),
-  default_leiter_id: z.string().uuid().nullable().optional(),
+  default_leiter_id: uuid().nullable().optional(),
   wiederholung_typ: wiederholungTypMeetingSchema.nullable().optional(),
   wiederholung_tag: z.number().min(0).max(31).nullable().optional(),
   standard_agenda: z.array(z.object({
@@ -105,7 +110,7 @@ export type MeetingTemplateFormData = z.infer<typeof meetingTemplateSchema>
 // =============================================================================
 
 export const meetingGeneratorSchema = z.object({
-  template_id: z.string().uuid('Template ist erforderlich'),
+  template_id: uuid('Template ist erforderlich'),
   start_datum: z.string().min(1, 'Startdatum ist erforderlich'),
   end_datum: z.string().min(1, 'Enddatum ist erforderlich'),
   anzahl: z.number().positive().max(52, 'Maximal 52 Meetings erlaubt').optional(),

--- a/apps/web/lib/validations/modul2.ts
+++ b/apps/web/lib/validations/modul2.ts
@@ -1,5 +1,12 @@
 import { z } from 'zod'
 
+// Zod v4 .uuid() rejects non-RFC-4122 UUIDs (version digit must be 1-8).
+// Our seed data uses version-0 UUIDs, so we use a relaxed regex instead.
+const UUID_REGEX =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
+const uuid = (message = 'Ungültige UUID') =>
+  z.string().regex(UUID_REGEX, message)
+
 // =============================================================================
 // Räume Validations
 // =============================================================================
@@ -55,7 +62,7 @@ const timeRegex = /^([01]?[0-9]|2[0-3]):[0-5][0-9](:[0-5][0-9])?$/
 
 export const zeitblockSchema = z
   .object({
-    veranstaltung_id: z.string().uuid('Ungültige Veranstaltungs-ID'),
+    veranstaltung_id: uuid('Ungültige Veranstaltungs-ID'),
     name: z.string().min(1, 'Name ist erforderlich').max(100, 'Name zu lang'),
     startzeit: z.string().regex(timeRegex, 'Ungültiges Zeitformat (HH:MM)'),
     endzeit: z.string().regex(timeRegex, 'Ungültiges Zeitformat (HH:MM)'),
@@ -100,8 +107,8 @@ export const zeitblockUpdateSchema = z.object({
 // =============================================================================
 
 export const schichtSchema = z.object({
-  veranstaltung_id: z.string().uuid('Ungültige Veranstaltungs-ID'),
-  zeitblock_id: z.string().uuid().nullable().optional(),
+  veranstaltung_id: uuid('Ungültige Veranstaltungs-ID'),
+  zeitblock_id: uuid().nullable().optional(),
   rolle: z.string().min(1, 'Rolle ist erforderlich').max(100, 'Rolle zu lang'),
   anzahl_benoetigt: z
     .number()
@@ -119,8 +126,8 @@ export const schichtUpdateSchema = schichtSchema
 // =============================================================================
 
 export const zuweisungSchema = z.object({
-  schicht_id: z.string().uuid('Ungültige Schicht-ID'),
-  person_id: z.string().uuid('Ungültige Personen-ID'),
+  schicht_id: uuid('Ungültige Schicht-ID'),
+  person_id: uuid('Ungültige Personen-ID'),
   status: z
     .enum(['zugesagt', 'abgesagt', 'erschienen', 'nicht_erschienen'])
     .optional(),
@@ -139,14 +146,14 @@ export const zuweisungUpdateSchema = z.object({
 // =============================================================================
 
 export const raumReservierungSchema = z.object({
-  veranstaltung_id: z.string().uuid('Ungültige Veranstaltungs-ID'),
-  raum_id: z.string().uuid('Ungültiger Raum'),
+  veranstaltung_id: uuid('Ungültige Veranstaltungs-ID'),
+  raum_id: uuid('Ungültiger Raum'),
   notizen: z.string().max(500, 'Notizen zu lang').nullable().optional(),
 })
 
 export const ressourcenReservierungSchema = z.object({
-  veranstaltung_id: z.string().uuid('Ungültige Veranstaltungs-ID'),
-  ressource_id: z.string().uuid('Ungültige Ressource'),
+  veranstaltung_id: uuid('Ungültige Veranstaltungs-ID'),
+  ressource_id: uuid('Ungültige Ressource'),
   menge: z.number().int().min(1, 'Menge muss mindestens 1 sein').default(1),
   notizen: z.string().max(500, 'Notizen zu lang').nullable().optional(),
 })
@@ -168,7 +175,7 @@ export const templateSchema = z.object({
 export const templateUpdateSchema = templateSchema.partial()
 
 export const templateZeitblockSchema = z.object({
-  template_id: z.string().uuid('Ungültige Template-ID'),
+  template_id: uuid('Ungültige Template-ID'),
   name: z.string().min(1, 'Name ist erforderlich').max(100, 'Name zu lang'),
   startzeit: z.string().regex(timeRegex, 'Ungültiges Zeitformat (HH:MM)'),
   endzeit: z.string().regex(timeRegex, 'Ungültiges Zeitformat (HH:MM)'),
@@ -179,7 +186,7 @@ export const templateZeitblockSchema = z.object({
 })
 
 export const templateSchichtSchema = z.object({
-  template_id: z.string().uuid('Ungültige Template-ID'),
+  template_id: uuid('Ungültige Template-ID'),
   zeitblock_name: z.string().max(100).nullable().optional(),
   rolle: z.string().min(1, 'Rolle ist erforderlich').max(100, 'Rolle zu lang'),
   anzahl_benoetigt: z
@@ -199,8 +206,8 @@ export const templateSchichtUpdateSchema = templateSchichtSchema
   .partial()
 
 export const templateRessourceSchema = z.object({
-  template_id: z.string().uuid('Ungültige Template-ID'),
-  ressource_id: z.string().uuid('Ungültige Ressource'),
+  template_id: uuid('Ungültige Template-ID'),
+  ressource_id: uuid('Ungültige Ressource'),
   menge: z.number().int().min(1, 'Menge muss mindestens 1 sein').default(1),
 })
 
@@ -213,7 +220,7 @@ export const templateRessourceUpdateSchema = templateRessourceSchema
 // =============================================================================
 
 export const templateInfoBlockSchema = z.object({
-  template_id: z.string().uuid('Ungültige Template-ID'),
+  template_id: uuid('Ungültige Template-ID'),
   titel: z.string().min(1, 'Titel ist erforderlich').max(100, 'Titel zu lang'),
   beschreibung: z
     .string()
@@ -234,7 +241,7 @@ export const templateInfoBlockUpdateSchema = templateInfoBlockSchema
 // =============================================================================
 
 export const templateSachleistungSchema = z.object({
-  template_id: z.string().uuid('Ungültige Template-ID'),
+  template_id: uuid('Ungültige Template-ID'),
   name: z.string().min(1, 'Name ist erforderlich').max(100, 'Name zu lang'),
   anzahl: z.number().int().min(1, 'Anzahl muss mindestens 1 sein').default(1),
   beschreibung: z

--- a/apps/web/lib/validations/probenplan.ts
+++ b/apps/web/lib/validations/probenplan.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod'
 
+const UUID_REGEX =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
+const uuid = (message = 'Ungültige UUID') =>
+  z.string().regex(UUID_REGEX, message)
+
 // Recurring pattern options
 export const wiederholungTypSchema = z.enum([
   'woechentlich',
@@ -28,7 +33,7 @@ export const WOCHENTAG_LABELS: Record<number, string> = {
 
 // Schema for generating proben (recurring)
 export const probenGeneratorSchema = z.object({
-  stueck_id: z.string().uuid('Ungültige Stück-ID'),
+  stueck_id: uuid('Ungültige Stück-ID'),
   titel_prefix: z.string().min(1, 'Titel-Präfix ist erforderlich'),
   beschreibung: z.string().optional(),
   // Recurring settings
@@ -42,7 +47,7 @@ export const probenGeneratorSchema = z.object({
   // Location
   ort: z.string().optional(),
   // Scenes to include
-  szenen_ids: z.array(z.string().uuid()).optional(),
+  szenen_ids: z.array(uuid()).optional(),
   // Auto-invite based on cast
   auto_einladen: z.boolean().default(true),
 }).refine(
@@ -57,7 +62,7 @@ export type ProbenGeneratorFormData = z.infer<typeof probenGeneratorSchema>
 
 // Schema for saving a template
 export const probenplanTemplateSchema = z.object({
-  stueck_id: z.string().uuid('Ungültige Stück-ID'),
+  stueck_id: uuid('Ungültige Stück-ID'),
   name: z.string().min(1, 'Name ist erforderlich'),
   beschreibung: z.string().optional(),
   wiederholung_typ: wiederholungTypSchema,
@@ -66,18 +71,18 @@ export const probenplanTemplateSchema = z.object({
   endzeit: z.string().regex(/^\d{2}:\d{2}$/, 'Ungültiges Zeitformat'),
   dauer_wochen: z.number().min(1).max(52).default(1),
   ort: z.string().optional(),
-  szenen_ids: z.array(z.string().uuid()).optional(),
+  szenen_ids: z.array(uuid()).optional(),
 })
 
 export type ProbenplanTemplateFormData = z.infer<typeof probenplanTemplateSchema>
 
 // Schema for conflict check request
 export const konfliktCheckSchema = z.object({
-  stueck_id: z.string().uuid(),
+  stueck_id: uuid(),
   datum: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   startzeit: z.string().regex(/^\d{2}:\d{2}$/).optional(),
   endzeit: z.string().regex(/^\d{2}:\d{2}$/).optional(),
-  szenen_ids: z.array(z.string().uuid()).optional(),
+  szenen_ids: z.array(uuid()).optional(),
 })
 
 export type KonfliktCheckData = z.infer<typeof konfliktCheckSchema>

--- a/apps/web/lib/validations/produktionen.ts
+++ b/apps/web/lib/validations/produktionen.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod'
 
+const UUID_REGEX =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
+const uuid = (message = 'Ungültige UUID') =>
+  z.string().regex(UUID_REGEX, message)
+
 // =============================================================================
 // Produktion Validations
 // =============================================================================
@@ -14,7 +19,7 @@ export const produktionSchema = z.object({
     .max(2000, 'Beschreibung zu lang')
     .nullable()
     .optional(),
-  stueck_id: z.string().uuid().nullable().optional(),
+  stueck_id: uuid().nullable().optional(),
   status: z
     .enum([
       'draft',
@@ -34,7 +39,7 @@ export const produktionSchema = z.object({
   proben_start: z.string().nullable().optional(),
   premiere: z.string().nullable().optional(),
   derniere: z.string().nullable().optional(),
-  produktionsleitung_id: z.string().uuid().nullable().optional(),
+  produktionsleitung_id: uuid().nullable().optional(),
 })
 
 export const produktionUpdateSchema = produktionSchema.partial()
@@ -44,7 +49,7 @@ export const produktionUpdateSchema = produktionSchema.partial()
 // =============================================================================
 
 export const serieSchema = z.object({
-  produktion_id: z.string().uuid('Ungültige Produktions-ID'),
+  produktion_id: uuid('Ungültige Produktions-ID'),
   name: z.string().min(1, 'Name ist erforderlich').max(200, 'Name zu lang'),
   beschreibung: z
     .string()
@@ -63,7 +68,7 @@ export const serieSchema = z.object({
     .max(120)
     .nullable()
     .optional(),
-  template_id: z.string().uuid().nullable().optional(),
+  template_id: uuid().nullable().optional(),
 })
 
 export const serieUpdateSchema = serieSchema

--- a/apps/web/lib/validations/produktions-besetzungen.ts
+++ b/apps/web/lib/validations/produktions-besetzungen.ts
@@ -1,9 +1,14 @@
 import { z } from 'zod'
 
+const UUID_REGEX =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
+const uuid = (message = 'Ungültige UUID') =>
+  z.string().regex(UUID_REGEX, message)
+
 export const produktionsBesetzungSchema = z.object({
-  produktion_id: z.string().uuid('Ungültige Produktions-ID'),
-  rolle_id: z.string().uuid('Ungültige Rollen-ID'),
-  person_id: z.string().uuid().nullable().optional(),
+  produktion_id: uuid('Ungültige Produktions-ID'),
+  rolle_id: uuid('Ungültige Rollen-ID'),
+  person_id: uuid().nullable().optional(),
   typ: z
     .enum(['hauptbesetzung', 'zweitbesetzung', 'ersatz'])
     .default('hauptbesetzung'),

--- a/apps/web/lib/validations/veranstaltungen.ts
+++ b/apps/web/lib/validations/veranstaltungen.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod'
 
+const UUID_REGEX =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
+const uuid = (message = 'Ungültige UUID') =>
+  z.string().regex(UUID_REGEX, message)
+
 export const veranstaltungSchema = z.object({
   titel: z.string().min(1, 'Titel ist erforderlich').max(200, 'Titel zu lang'),
   datum: z.string().min(1, 'Datum ist erforderlich'),
@@ -20,14 +25,10 @@ export const veranstaltungSchema = z.object({
     .min(1, 'Mindestens 1 Teilnehmer')
     .nullable()
     .optional(),
-  organisator_id: z
-    .string()
-    .uuid('Ungültige Organisator-ID')
+  organisator_id: uuid('Ungültige Organisator-ID')
     .nullable()
     .optional(),
-  helfer_template_id: z
-    .string()
-    .uuid('Ungültige Template-ID')
+  helfer_template_id: uuid('Ungültige Template-ID')
     .nullable()
     .optional(),
   helfer_status: z
@@ -43,9 +44,7 @@ export const veranstaltungSchema = z.object({
     .optional(),
   helfer_buchung_deadline: z.string().nullable().optional(),
   helfer_buchung_limit_aktiv: z.boolean().optional(),
-  koordinator_id: z
-    .string()
-    .uuid('Ungültige Koordinator-ID')
+  koordinator_id: uuid('Ungültige Koordinator-ID')
     .nullable()
     .optional(),
 })


### PR DESCRIPTION
## Summary
- **Root cause found**: Zod v4's `.uuid()` strictly validates RFC 4122 UUIDs — the version digit (3rd group, 1st char) must be 1-8 and the variant digit must be 8/9/a/b
- Our seed data uses UUIDs like `a0000000-0000-0000-0000-000000000001` with version digit `0`, which Zod v4 rejects as invalid
- This broke ALL server actions that validate UUID fields (not just Sachleistungen)

## Changes
- Added a `uuid()` helper to all 7 validation files that uses a relaxed regex accepting any hex-formatted UUID
- Replaced all 28+ `z.string().uuid()` calls with the new `uuid()` helper
- Removed debug logging from `addTemplateSachleistung`

## Affected files
- `lib/validations/modul2.ts`
- `lib/validations/veranstaltungen.ts`
- `lib/validations/produktionen.ts`
- `lib/validations/probenplan.ts`
- `lib/validations/produktions-besetzungen.ts`
- `lib/validations/helfereinsaetze.ts`
- `lib/validations/meeting.ts`
- `lib/actions/templates.ts` (debug removal)

## Test plan
- [ ] Add a Sachleistung to a template — should work now
- [ ] Edit/remove Sachleistungen
- [ ] Add/edit Zeitblöcke, Schichten, Info-Blöcke, Ressourcen
- [ ] Create/edit Veranstaltungen, Proben, Helfereinsätze

🤖 Generated with [Claude Code](https://claude.com/claude-code)