### PR TITLE
feat: add authenticated meine-einsaetze dashboard for helfer

### DIFF
--- a/apps/web/app/(public)/helfer/meine-einsaetze/page.tsx
+++ b/apps/web/app/(public)/helfer/meine-einsaetze/page.tsx
@@ -1,0 +1,41 @@
+import { redirect } from 'next/navigation'
+import type { Metadata } from 'next'
+import { getUserProfile } from '@/lib/supabase/server'
+import { getAuthenticatedHelferDashboard } from '@/lib/actions/helfer-dashboard'
+import { HelferDashboardView } from '@/components/helfer-dashboard/HelferDashboardView'
+import { Card, CardContent } from '@/components/ui'
+
+export const metadata: Metadata = {
+  title: 'Meine Einsätze',
+  description: 'Übersicht deiner Helfer-Einsätze',
+  robots: { index: false },
+}
+
+export default async function MeineEinsaetzePage() {
+  const profile = await getUserProfile()
+  if (!profile) redirect('/login' as never)
+
+  const data = await getAuthenticatedHelferDashboard()
+  if (!data) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-8">
+        <Card>
+          <CardContent className="p-8 text-center">
+            <p className="text-lg font-medium text-neutral-700">
+              Kein Helfer-Profil gefunden
+            </p>
+            <p className="mt-1 text-sm text-neutral-500">
+              Dein Konto konnte keinem Helfer-Profil zugeordnet werden.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8">
+      <HelferDashboardView data={data} />
+    </div>
+  )
+}

--- a/apps/web/lib/actions/helfer-dashboard.ts
+++ b/apps/web/lib/actions/helfer-dashboard.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { createAdminClient } from '@/lib/supabase/admin'
+import { getUserProfile } from '@/lib/supabase/server'
 import type { HelferDashboardData } from '@/lib/supabase/types'
 
 const UUID_REGEX =
@@ -32,4 +33,100 @@ export async function getHelferDashboardData(
   }
 
   return result
+}
+
+export async function getAuthenticatedHelferDashboard(): Promise<HelferDashboardData | null> {
+  const profile = await getUserProfile()
+  if (!profile) return null
+
+  const supabase = createAdminClient()
+
+  // Get person info for display name
+  const { data: person } = await supabase
+    .from('personen')
+    .select('vorname, nachname, email')
+    .eq('email', profile.email)
+    .single()
+
+  const helper = person
+    ? { vorname: person.vorname, nachname: person.nachname, email: person.email ?? profile.email }
+    : { vorname: profile.display_name ?? profile.email, nachname: '', email: profile.email }
+
+  // Get all non-rejected registrations for this profile
+  const { data: anmeldungen, error } = await supabase
+    .from('helfer_anmeldungen')
+    .select(`
+      id,
+      status,
+      abmeldung_token,
+      created_at,
+      rollen_instanz_id,
+      helfer_rollen_instanzen!inner (
+        id,
+        custom_name,
+        zeitblock_start,
+        zeitblock_end,
+        template_id,
+        helfer_event_id,
+        helfer_rollen_templates ( name ),
+        helfer_events!inner (
+          id, name, datum_start, datum_end, ort, public_token, abmeldung_frist
+        )
+      )
+    `)
+    .eq('profile_id', profile.id)
+    .neq('status', 'abgelehnt')
+
+  if (error || !anmeldungen) {
+    return { helper, anmeldungen: [] }
+  }
+
+  const mapped = anmeldungen.map((a) => {
+    const instanz = a.helfer_rollen_instanzen as unknown as {
+      id: string
+      custom_name: string | null
+      zeitblock_start: string | null
+      zeitblock_end: string | null
+      helfer_rollen_templates: { name: string } | null
+      helfer_events: {
+        id: string
+        name: string
+        datum_start: string
+        datum_end: string
+        ort: string | null
+        public_token: string
+        abmeldung_frist: string | null
+      }
+    }
+
+    return {
+      id: a.id,
+      status: a.status,
+      abmeldung_token: a.abmeldung_token,
+      created_at: a.created_at,
+      rolle_name: instanz.helfer_rollen_templates?.name ?? instanz.custom_name ?? 'Helfer',
+      zeitblock_start: instanz.zeitblock_start,
+      zeitblock_end: instanz.zeitblock_end,
+      rollen_instanz_id: instanz.id,
+      event_id: instanz.helfer_events.id,
+      event_name: instanz.helfer_events.name,
+      event_datum_start: instanz.helfer_events.datum_start,
+      event_datum_end: instanz.helfer_events.datum_end,
+      event_ort: instanz.helfer_events.ort,
+      event_public_token: instanz.helfer_events.public_token,
+      event_abmeldung_frist: instanz.helfer_events.abmeldung_frist,
+    }
+  })
+
+  // Sort by event start date, then zeitblock start
+  mapped.sort((a, b) => {
+    const dateCompare = a.event_datum_start.localeCompare(b.event_datum_start)
+    if (dateCompare !== 0) return dateCompare
+    if (a.zeitblock_start && b.zeitblock_start) {
+      return a.zeitblock_start.localeCompare(b.zeitblock_start)
+    }
+    return a.zeitblock_start ? -1 : 1
+  })
+
+  return { helper, anmeldungen: mapped }
 }

--- a/apps/web/lib/navigation.ts
+++ b/apps/web/lib/navigation.ts
@@ -258,6 +258,7 @@ const HELFER_NAVIGATION: NavSection[] = [
   {
     title: 'Meine Einsätze',
     items: [
+      { href: '/helfer/meine-einsaetze', label: 'Meine Einsätze', icon: 'check' },
       { href: '/helfer/schichten', label: 'Meine Schichten', icon: 'list' },
       {
         href: '/helfer/einsaetze',
@@ -461,6 +462,7 @@ export const BREADCRUMB_LABELS: Record<string, string> = {
   stundenkonto: 'Stundenkonto',
   anmeldungen: 'Anmeldungen',
   helfer: 'Helfer',
+  'meine-einsaetze': 'Meine Einsätze',
   schichten: 'Meine Schichten',
   einsaetze: 'Verfügbare Einsätze',
   'partner-portal': 'Partner-Portal',


### PR DESCRIPTION
## Summary
- Add `/helfer/meine-einsaetze` page for logged-in HELFER users, querying `helfer_anmeldungen` by `profile_id` (vs. token-based access for external helpers)
- New `getAuthenticatedHelferDashboard()` server action with joins across `helfer_rollen_instanzen`, `helfer_rollen_templates`, and `helfer_events`
- Reuses existing `HelferDashboardView` + `ShiftCard` components (upcoming/past shifts, cancel links, status badges)
- Adds "Meine Einsätze" link to HELFER sidebar navigation + breadcrumb label

## Test plan
- [ ] Login as HELFER → sidebar shows "Meine Einsätze" link
- [ ] `/helfer/meine-einsaetze` shows own `helfer_anmeldungen` (upcoming + past)
- [ ] Cancel links and "Weitere Schichten" links work
- [ ] `/helfer/meine-einsaetze/[token]` still works for external helpers
- [ ] Not logged in → redirect to `/login`
- [ ] `npm run typecheck` ✅
- [ ] `npm run lint` ✅
- [ ] `npm run test:run` ✅ (96/96)

🤖 Generated with [Claude Code](https://claude.com/claude-code)