### PR TITLE
feat: Dashboard-Restructuring - Stundenkonto & Vorstand Mein Bereich

### DIFF
--- a/apps/web/app/(protected)/dashboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/page.tsx
@@ -16,7 +16,6 @@ import {
 } from '@/components/dashboard'
 import { getAktuelleProduktionFuerDashboard } from '@/lib/actions/produktionen'
 import { getAnmeldungenForPerson } from '@/lib/actions/anmeldungen'
-import { getStundenkontoSummary } from '@/lib/actions/stundenkonto'
 import { getRollenHistorie, getHelfereinsatzHistorie } from '@/lib/actions/historie'
 import { MiniKalender } from '@/components/mein-bereich/MiniKalender'
 import { EditableProfileCard } from '@/components/mein-bereich/EditableProfileCard'
@@ -24,7 +23,6 @@ import { RollenHistorie } from '@/components/mein-bereich/RollenHistorie'
 import { HelfereinsatzHistorie } from '@/components/mein-bereich/HelfereinsatzHistorie'
 import {
   UpcomingEventsWidget,
-  StundenWidget,
   HelferEinsaetzeWidget,
 } from '@/components/mein-bereich/DashboardWidgets'
 import type { KalenderTermin } from '@/components/mein-bereich/MiniKalender'
@@ -463,10 +461,6 @@ export default async function DashboardPage({
 
   // Get data if person is linked
   const anmeldungen = person ? await getAnmeldungenForPerson(person.id) : []
-  const stundenSummary =
-    person && !isPassiveMember
-      ? await getStundenkontoSummary(person.id)
-      : { total: 0, thisYear: 0, lastEntries: [] }
 
   // Get available helper events (only for active members)
   const { data: verfuegbareEinsaetze } = !isPassiveMember
@@ -585,14 +579,6 @@ export default async function DashboardPage({
                   <span className="font-semibold text-neutral-900">{upcomingAnmeldungen.length}</span>
                 </div>
                 <div className="flex items-center justify-between">
-                  <span className="text-sm text-neutral-600">Stunden gesamt</span>
-                  <span className="font-semibold text-neutral-900">{stundenSummary.total.toFixed(1)}</span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span className="text-sm text-neutral-600">Dieses Jahr</span>
-                  <span className="font-semibold text-green-600">{stundenSummary.thisYear.toFixed(1)}</span>
-                </div>
-                <div className="flex items-center justify-between">
                   <span className="text-sm text-neutral-600">Offene Einsätze</span>
                   <span className="font-semibold text-blue-600">{verfuegbareEinsaetze?.length ?? 0}</span>
                 </div>
@@ -624,17 +610,6 @@ export default async function DashboardPage({
                     </svg>
                   </span>
                   Helfereinsätze
-                </Link>
-                <Link
-                  href="/mein-bereich/stundenkonto"
-                  className="flex items-center gap-2 rounded-lg px-2 py-2 text-sm text-neutral-700 hover:bg-neutral-50"
-                >
-                  <span className="text-green-500">
-                    <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-                    </svg>
-                  </span>
-                  Stundenkonto
                 </Link>
                 <Link
                   href="/mein-bereich/verfuegbarkeit"
@@ -669,8 +644,6 @@ export default async function DashboardPage({
             <EditableProfileCard
               person={person}
               role={profile.role}
-              stundenTotal={stundenSummary.total}
-              stundenThisYear={stundenSummary.thisYear}
             />
 
             {/* Content Widgets */}
@@ -678,13 +651,6 @@ export default async function DashboardPage({
               <UpcomingEventsWidget anmeldungen={upcomingAnmeldungen} />
               <HelferEinsaetzeWidget einsaetze={verfuegbareEinsaetze ?? []} />
             </div>
-
-            {/* Stunden Widget - Full Width */}
-            <StundenWidget
-              total={stundenSummary.total}
-              thisYear={stundenSummary.thisYear}
-              lastEntries={stundenSummary.lastEntries}
-            />
 
             {/* History Section */}
             <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">

--- a/apps/web/app/(protected)/mein-bereich/stundenkonto/page.tsx
+++ b/apps/web/app/(protected)/mein-bereich/stundenkonto/page.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link'
+import { redirect } from 'next/navigation'
 import { getUserProfile } from '@/lib/supabase/server'
 import { createClient } from '@/lib/supabase/server'
+import { isManagement } from '@/lib/supabase/permissions'
 import {
   getStundenkontoForPerson,
   getStundensaldo,
@@ -23,6 +25,11 @@ export default async function StundenkontoPage() {
         </div>
       </main>
     )
+  }
+
+  // Only management roles can access Stundenkonto
+  if (!isManagement(profile.role)) {
+    redirect('/dashboard' as never)
   }
 
   // Try to find the person linked to this user

--- a/apps/web/app/(protected)/vorstand/einsaetze/page.tsx
+++ b/apps/web/app/(protected)/vorstand/einsaetze/page.tsx
@@ -1,0 +1,221 @@
+import { redirect } from 'next/navigation'
+import { getUserProfile } from '@/lib/supabase/server'
+import { createClient } from '@/lib/supabase/server'
+import { isManagement } from '@/lib/supabase/permissions'
+import { getAuthenticatedHelferDashboard } from '@/lib/actions/helfer-dashboard'
+import { HelferDashboardView } from '@/components/helfer-dashboard/HelferDashboardView'
+
+type HelfereinsatzData = {
+  id: string
+  titel: string
+  datum: string
+  startzeit?: string | null
+  endzeit?: string | null
+  ort?: string | null
+}
+
+type LegacySchicht = {
+  id: string
+  status: string
+  notiz: string | null
+  helfereinsatz: HelfereinsatzData | null
+}
+
+export const metadata = {
+  title: 'Meine Einsätze | BackstagePass',
+  description: 'Übersicht deiner Helfer-Einsätze',
+}
+
+export default async function VorstandEinsaetzePage() {
+  const profile = await getUserProfile()
+
+  if (!profile) {
+    redirect('/login' as never)
+  }
+
+  if (!isManagement(profile.role)) {
+    redirect('/dashboard' as never)
+  }
+
+  const supabase = await createClient()
+
+  // Find person for this user
+  const { data: person } = await supabase
+    .from('personen')
+    .select('id, vorname, nachname')
+    .eq('email', profile.email)
+    .single()
+
+  // Fetch both systems in parallel
+  const [helferDashboardData, legacyResult] = await Promise.all([
+    getAuthenticatedHelferDashboard(),
+    person
+      ? supabase
+          .from('helferschichten')
+          .select(
+            `
+            id,
+            status,
+            notiz,
+            helfereinsatz:helfereinsaetze (
+              id,
+              titel,
+              datum,
+              startzeit,
+              endzeit,
+              ort
+            )
+          `
+          )
+          .eq('person_id', person.id)
+          .order('helfereinsatz(datum)', { ascending: false })
+      : Promise.resolve({ data: [] as LegacySchicht[] }),
+  ])
+
+  const legacySchichten = (legacyResult.data ?? []) as unknown as LegacySchicht[]
+
+  const today = new Date().toISOString().split('T')[0]
+  const upcomingLegacy = legacySchichten.filter(
+    (s) => s.helfereinsatz && s.helfereinsatz.datum >= today
+  )
+  const pastLegacy = legacySchichten.filter(
+    (s) => s.helfereinsatz && s.helfereinsatz.datum < today
+  )
+
+  const hasNewSystem = helferDashboardData && helferDashboardData.anmeldungen.length > 0
+  const hasLegacySystem = legacySchichten.length > 0
+
+  return (
+    <div className="space-y-8">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-bold text-neutral-900">Meine Einsätze</h1>
+        <p className="mt-1 text-neutral-600">
+          Übersicht aller deiner Helfer-Einsätze
+        </p>
+      </div>
+
+      {/* New Helfer System (helfer_anmeldungen) */}
+      {helferDashboardData && (
+        <section>
+          {hasLegacySystem && (
+            <h2 className="mb-4 text-lg font-semibold text-neutral-900">
+              Helferliste-Einsätze
+            </h2>
+          )}
+          <HelferDashboardView data={helferDashboardData} showHeader={false} />
+        </section>
+      )}
+
+      {/* Legacy System (helferschichten) */}
+      {hasLegacySystem && (
+        <section>
+          {hasNewSystem && (
+            <h2 className="mb-4 text-lg font-semibold text-neutral-900">
+              Helfereinsätze (Legacy)
+            </h2>
+          )}
+
+          {/* Upcoming Legacy Shifts */}
+          <div className="mb-6 rounded-lg border border-neutral-200 bg-white p-6 shadow-sm">
+            <h3 className="mb-4 text-lg font-semibold text-neutral-900">
+              Anstehende Einsätze ({upcomingLegacy.length})
+            </h3>
+            {upcomingLegacy.length > 0 ? (
+              <div className="space-y-4">
+                {upcomingLegacy.map((schicht) => (
+                  <div
+                    key={schicht.id}
+                    className="rounded-lg border border-neutral-200 p-4"
+                  >
+                    <div className="flex items-start justify-between">
+                      <div>
+                        <h4 className="font-medium text-neutral-900">
+                          {schicht.helfereinsatz?.titel ?? 'Einsatz'}
+                        </h4>
+                        <p className="mt-1 text-sm text-neutral-600">
+                          {schicht.helfereinsatz?.datum ?? ''}
+                          {schicht.helfereinsatz?.startzeit &&
+                            ` | ${schicht.helfereinsatz.startzeit}`}
+                          {schicht.helfereinsatz?.endzeit &&
+                            ` - ${schicht.helfereinsatz.endzeit}`}
+                        </p>
+                        {schicht.helfereinsatz?.ort && (
+                          <p className="text-sm text-neutral-500">
+                            {schicht.helfereinsatz.ort}
+                          </p>
+                        )}
+                        {schicht.notiz && (
+                          <p className="mt-2 text-sm italic text-neutral-500">
+                            &quot;{schicht.notiz}&quot;
+                          </p>
+                        )}
+                      </div>
+                      <span
+                        className={`rounded px-2 py-1 text-xs font-medium ${
+                          schicht.status === 'bestaetigt'
+                            ? 'bg-green-100 text-green-800'
+                            : 'bg-yellow-100 text-yellow-800'
+                        }`}
+                      >
+                        {schicht.status === 'bestaetigt'
+                          ? 'Bestätigt'
+                          : 'Angefragt'}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-neutral-500">Keine anstehenden Einsätze.</p>
+            )}
+          </div>
+
+          {/* Past Legacy Shifts */}
+          {pastLegacy.length > 0 && (
+            <div className="rounded-lg border border-neutral-200 bg-white p-6 shadow-sm">
+              <h3 className="mb-4 text-lg font-semibold text-neutral-900">
+                Vergangene Einsätze ({pastLegacy.length})
+              </h3>
+              <div className="space-y-3">
+                {pastLegacy.slice(0, 10).map((schicht) => (
+                  <div
+                    key={schicht.id}
+                    className="flex items-center justify-between border-b border-neutral-100 pb-3 text-sm last:border-0 last:pb-0"
+                  >
+                    <div>
+                      <span className="text-neutral-900">
+                        {schicht.helfereinsatz?.titel ?? 'Einsatz'}
+                      </span>
+                      <span className="ml-2 text-neutral-500">
+                        {schicht.helfereinsatz?.datum ?? ''}
+                      </span>
+                    </div>
+                    <span className="text-neutral-500">
+                      {schicht.status === 'bestaetigt'
+                        ? 'Abgeschlossen'
+                        : schicht.status}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </section>
+      )}
+
+      {/* Empty state */}
+      {!hasNewSystem && !hasLegacySystem && (
+        <div className="rounded-lg border border-neutral-200 bg-white p-8 text-center shadow-sm">
+          <p className="text-lg font-medium text-neutral-700">
+            Noch keine Einsätze vorhanden
+          </p>
+          <p className="mt-1 text-sm text-neutral-500">
+            Sobald du dich für einen Helfer-Einsatz anmeldest, siehst du hier
+            deine Übersicht.
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/app/(protected)/vorstand/stundenkonto/page.tsx
+++ b/apps/web/app/(protected)/vorstand/stundenkonto/page.tsx
@@ -1,0 +1,121 @@
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { getUserProfile } from '@/lib/supabase/server'
+import { createClient } from '@/lib/supabase/server'
+import { isManagement } from '@/lib/supabase/permissions'
+import {
+  getStundenkontoForPerson,
+  getStundensaldo,
+} from '@/lib/actions/stundenkonto'
+import { StundenkontoTable } from '@/components/mein-bereich/StundenkontoTable'
+import { HelpButton } from '@/components/help'
+
+export const metadata = {
+  title: 'Stundenkonto | BackstagePass',
+  description: 'Dein persönliches Stundenkonto',
+}
+
+export default async function VorstandStundenkontoPage() {
+  const profile = await getUserProfile()
+
+  if (!profile) {
+    redirect('/login' as never)
+  }
+
+  if (!isManagement(profile.role)) {
+    redirect('/dashboard' as never)
+  }
+
+  const supabase = await createClient()
+  const { data: person } = await supabase
+    .from('personen')
+    .select('id, vorname, nachname')
+    .eq('email', profile.email)
+    .single()
+
+  if (!person) {
+    return (
+      <div className="mx-auto max-w-4xl">
+        <div className="mb-6">
+          <Link
+            href="/dashboard"
+            className="text-blue-600 hover:text-blue-800"
+          >
+            &larr; Zurück
+          </Link>
+        </div>
+        <div className="rounded-lg border border-yellow-200 bg-yellow-50 p-4">
+          <p className="text-yellow-800">
+            Dein Account ist noch nicht mit einem Mitgliederprofil verknüpft.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  const entries = await getStundenkontoForPerson(person.id)
+  const saldo = await getStundensaldo(person.id)
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-6">
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <h1 className="text-2xl font-bold text-gray-900">
+              Mein Stundenkonto
+            </h1>
+            <HelpButton contextKey="stundenkonto" />
+          </div>
+          <p className="mt-1 text-gray-600">
+            Übersicht deiner geleisteten Helferstunden
+          </p>
+        </div>
+        <div className="text-right">
+          <p className="text-sm text-gray-500">Aktueller Saldo</p>
+          <p
+            className={`text-3xl font-bold ${
+              saldo >= 0 ? 'text-green-600' : 'text-red-600'
+            }`}
+          >
+            {saldo >= 0 ? '+' : ''}
+            {saldo.toFixed(1)}
+          </p>
+          <p className="text-sm text-gray-500">Stunden</p>
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+        <div className="rounded-lg bg-white p-4 text-center shadow">
+          <p className="text-2xl font-bold text-blue-600">
+            {entries.filter((e) => e.typ === 'helfereinsatz').length}
+          </p>
+          <p className="text-xs text-gray-500">Helfereinsätze</p>
+        </div>
+        <div className="rounded-lg bg-white p-4 text-center shadow">
+          <p className="text-2xl font-bold text-purple-600">
+            {entries.filter((e) => e.typ === 'vereinsevent').length}
+          </p>
+          <p className="text-xs text-gray-500">Vereinsevents</p>
+        </div>
+        <div className="rounded-lg bg-white p-4 text-center shadow">
+          <p className="text-2xl font-bold text-green-600">
+            {entries
+              .filter((e) => e.stunden > 0)
+              .reduce((sum, e) => sum + e.stunden, 0)
+              .toFixed(1)}
+          </p>
+          <p className="text-xs text-gray-500">Stunden gutgeschrieben</p>
+        </div>
+        <div className="rounded-lg bg-white p-4 text-center shadow">
+          <p className="text-2xl font-bold text-gray-600">{entries.length}</p>
+          <p className="text-xs text-gray-500">Einträge gesamt</p>
+        </div>
+      </div>
+
+      {/* Table */}
+      <StundenkontoTable entries={entries} />
+    </div>
+  )
+}

--- a/apps/web/app/(protected)/vorstand/termine/page.tsx
+++ b/apps/web/app/(protected)/vorstand/termine/page.tsx
@@ -1,0 +1,45 @@
+import { redirect } from 'next/navigation'
+import { getUserProfile } from '@/lib/supabase/server'
+import { isManagement } from '@/lib/supabase/permissions'
+import { getPersonalEvents } from '@/lib/actions/persoenlicher-kalender'
+import { PersonalCalendar } from '@/components/mein-bereich/PersonalCalendar'
+
+export const metadata = {
+  title: 'Meine Termine | BackstagePass',
+  description: 'Dein persönlicher Terminkalender',
+}
+
+export default async function VorstandTerminePage() {
+  const profile = await getUserProfile()
+
+  if (!profile) {
+    redirect('/login' as never)
+  }
+
+  if (!isManagement(profile.role)) {
+    redirect('/dashboard' as never)
+  }
+
+  const today = new Date()
+  const startDatum = new Date(today.getFullYear(), today.getMonth() - 1, 1)
+    .toISOString()
+    .split('T')[0]
+  const endDatum = new Date(today.getFullYear() + 1, today.getMonth(), 0)
+    .toISOString()
+    .split('T')[0]
+
+  const events = await getPersonalEvents(startDatum, endDatum)
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Meine Termine</h1>
+        <p className="mt-1 text-gray-600">
+          Alle deine Veranstaltungen, Proben und Schichten auf einen Blick
+        </p>
+      </div>
+
+      <PersonalCalendar initialEvents={events} />
+    </div>
+  )
+}

--- a/apps/web/components/helfer-dashboard/HelferDashboardView.tsx
+++ b/apps/web/components/helfer-dashboard/HelferDashboardView.tsx
@@ -10,6 +10,7 @@ import type {
 
 interface HelferDashboardViewProps {
   data: HelferDashboardData
+  showHeader?: boolean
 }
 
 function canCancelAnmeldung(anmeldung: HelferDashboardAnmeldung): boolean {
@@ -28,7 +29,7 @@ function canCancelAnmeldung(anmeldung: HelferDashboardAnmeldung): boolean {
   return hoursUntilEvent >= 6
 }
 
-export function HelferDashboardView({ data }: HelferDashboardViewProps) {
+export function HelferDashboardView({ data, showHeader = true }: HelferDashboardViewProps) {
   const [showPast, setShowPast] = useState(false)
 
   const now = new Date()
@@ -41,24 +42,28 @@ export function HelferDashboardView({ data }: HelferDashboardViewProps) {
 
   return (
     <div className="space-y-8">
-      {/* Header */}
-      <div>
-        <h1 className="text-2xl font-bold text-neutral-900">Meine Einsätze</h1>
-        <p className="mt-1 text-neutral-600">
-          Übersicht deiner Helfer-Anmeldungen
-        </p>
-      </div>
+      {showHeader && (
+        <>
+          {/* Header */}
+          <div>
+            <h1 className="text-2xl font-bold text-neutral-900">Meine Einsätze</h1>
+            <p className="mt-1 text-neutral-600">
+              Übersicht deiner Helfer-Anmeldungen
+            </p>
+          </div>
 
-      {/* Helper Info */}
-      <Card>
-        <CardContent className="p-4">
-          <p className="text-sm text-neutral-600">Angemeldet als</p>
-          <p className="font-semibold text-neutral-900">
-            {data.helper.vorname} {data.helper.nachname}
-          </p>
-          <p className="text-sm text-neutral-500">{data.helper.email}</p>
-        </CardContent>
-      </Card>
+          {/* Helper Info */}
+          <Card>
+            <CardContent className="p-4">
+              <p className="text-sm text-neutral-600">Angemeldet als</p>
+              <p className="font-semibold text-neutral-900">
+                {data.helper.vorname} {data.helper.nachname}
+              </p>
+              <p className="text-sm text-neutral-500">{data.helper.email}</p>
+            </CardContent>
+          </Card>
+        </>
+      )}
 
       {/* Upcoming Shifts */}
       <section>

--- a/apps/web/components/mein-bereich/DashboardWidgets.tsx
+++ b/apps/web/components/mein-bereich/DashboardWidgets.tsx
@@ -1,7 +1,6 @@
 import Link from 'next/link'
 import type {
   AnmeldungMitVeranstaltung,
-  StundenkontoEintrag,
 } from '@/lib/supabase/types'
 
 interface UpcomingEventsWidgetProps {
@@ -59,73 +58,6 @@ export function UpcomingEventsWidget({
           className="text-sm text-blue-600 hover:text-blue-800"
         >
           Alle Veranstaltungen &rarr;
-        </Link>
-      </div>
-    </div>
-  )
-}
-
-interface StundenWidgetProps {
-  total: number
-  thisYear: number
-  lastEntries: StundenkontoEintrag[]
-}
-
-export function StundenWidget({
-  total,
-  thisYear,
-  lastEntries,
-}: StundenWidgetProps) {
-  const currentYear = new Date().getFullYear()
-
-  return (
-    <div className="overflow-hidden rounded-xl border border-neutral-200 bg-white">
-      <div className="border-b border-green-100 bg-green-50 px-4 py-3">
-        <h3 className="font-medium text-green-900">Mein Stundenkonto</h3>
-      </div>
-      <div className="p-4">
-        <div className="mb-4 grid grid-cols-2 gap-4">
-          <div className="text-center">
-            <p className="text-2xl font-bold text-neutral-900">
-              {total.toFixed(1)}
-            </p>
-            <p className="text-xs text-neutral-500">Stunden gesamt</p>
-          </div>
-          <div className="text-center">
-            <p className="text-2xl font-bold text-green-600">
-              {thisYear.toFixed(1)}
-            </p>
-            <p className="text-xs text-neutral-500">{currentYear}</p>
-          </div>
-        </div>
-
-        {lastEntries.length > 0 && (
-          <div className="border-t border-neutral-100 pt-3">
-            <p className="mb-2 text-xs text-neutral-500">Letzte Einträge:</p>
-            {lastEntries.slice(0, 3).map((e) => (
-              <div key={e.id} className="flex justify-between py-1 text-sm">
-                <span className="flex-1 truncate text-neutral-600">
-                  {e.beschreibung || e.typ}
-                </span>
-                <span
-                  className={`ml-2 font-medium ${
-                    e.stunden >= 0 ? 'text-green-600' : 'text-red-600'
-                  }`}
-                >
-                  {e.stunden >= 0 ? '+' : ''}
-                  {e.stunden.toFixed(1)}h
-                </span>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
-      <div className="border-t border-neutral-100 bg-neutral-50 px-4 py-2">
-        <Link
-          href="/mein-bereich/stundenkonto"
-          className="text-sm text-green-600 hover:text-green-800"
-        >
-          Details anzeigen &rarr;
         </Link>
       </div>
     </div>
@@ -234,7 +166,6 @@ export function QuickLinksWidget({
   const activeLinks = [
     { href: '/veranstaltungen', icon: '📅', label: 'Veranstaltungen' },
     { href: '/helfereinsaetze', icon: '🤝', label: 'Helfereinsätze' },
-    { href: '/mein-bereich/stundenkonto', icon: '⏱️', label: 'Stundenkonto' },
     { href: '/profile', icon: '⚙️', label: 'Mein Profil' },
   ]
 

--- a/apps/web/components/mein-bereich/index.ts
+++ b/apps/web/components/mein-bereich/index.ts
@@ -15,7 +15,6 @@ export type { HelfereinsatzHistorieProps } from './HelfereinsatzHistorie'
 
 export {
   UpcomingEventsWidget,
-  StundenWidget,
   HelferEinsaetzeWidget,
   QuickLinksWidget,
 } from './DashboardWidgets'

--- a/apps/web/lib/navigation.ts
+++ b/apps/web/lib/navigation.ts
@@ -157,6 +157,14 @@ const MANAGEMENT_NAVIGATION: NavSection[] = [
     ],
   },
   {
+    title: 'Mein Bereich',
+    items: [
+      { href: '/vorstand/termine', label: 'Meine Termine', icon: 'calendar' },
+      { href: '/vorstand/stundenkonto', label: 'Stundenkonto', icon: 'clock' },
+      { href: '/vorstand/einsaetze', label: 'Meine Einsätze', icon: 'check' },
+    ],
+  },
+  {
     title: 'Ansichten',
     items: [
       { href: '/dashboard?ansicht=mitglied', label: 'Mitglieder-Ansicht', icon: 'eye' },
@@ -197,11 +205,6 @@ const MITGLIED_AKTIV_NAVIGATION: NavSection[] = [
         href: '/mein-bereich/termine',
         label: 'Meine Termine',
         icon: 'calendar',
-      },
-      {
-        href: '/mein-bereich/stundenkonto',
-        label: 'Stundenkonto',
-        icon: 'clock',
       },
       {
         href: '/mein-bereich/anmeldungen',
@@ -377,6 +380,7 @@ export function canAccessRoute(role: UserRole, route: string): boolean {
     '/helfer': ['ADMIN', 'VORSTAND', 'HELFER'],
     '/partner-portal': ['ADMIN', 'VORSTAND', 'PARTNER'],
     '/admin': ['ADMIN'],
+    '/vorstand': ['ADMIN', 'VORSTAND'],
     '/helfereinsaetze': ['ADMIN', 'VORSTAND', 'MITGLIED_AKTIV', 'HELFER'],
     '/helferliste': ['ADMIN', 'VORSTAND', 'MITGLIED_AKTIV', 'HELFER'],
     '/mein-bereich': ['ADMIN', 'VORSTAND', 'MITGLIED_AKTIV', 'MITGLIED_PASSIV'],
@@ -457,6 +461,7 @@ export const BREADCRUMB_LABELS: Record<string, string> = {
   admin: 'Admin',
   users: 'Benutzer',
   audit: 'Audit Log',
+  vorstand: 'Vorstand',
   'mein-bereich': 'Mein Bereich',
   termine: 'Meine Termine',
   stundenkonto: 'Stundenkonto',
@@ -464,7 +469,7 @@ export const BREADCRUMB_LABELS: Record<string, string> = {
   helfer: 'Helfer',
   'meine-einsaetze': 'Meine Einsätze',
   schichten: 'Meine Schichten',
-  einsaetze: 'Verfügbare Einsätze',
+  einsaetze: 'Meine Einsätze',
   'partner-portal': 'Partner-Portal',
   daten: 'Meine Daten',
   kontakt: 'Kontakt',

--- a/apps/web/lib/supabase/middleware.ts
+++ b/apps/web/lib/supabase/middleware.ts
@@ -27,6 +27,7 @@ const protectedPrefixes = [
   '/partner-portal',
   '/willkommen',
   '/admin',
+  '/vorstand',
   '/profile',
 ]
 


### PR DESCRIPTION
## Summary

- **Remove Stundenkonto from MITGLIED_AKTIV**: Dashboard no longer shows StundenWidget, Stunden stats, or Stundenkonto quick links for regular members. Direct URL `/mein-bereich/stundenkonto` redirects non-management users to `/dashboard`.
- **New `/vorstand/` section**: ADMIN/VORSTAND get a "Mein Bereich" sidebar section with personal pages for Termine, Stundenkonto, and Einsätze.
- **Combined Einsätze view**: `/vorstand/einsaetze` shows both the new Helferliste system (`helfer_anmeldungen`) and legacy Helferschichten in one page.

## Changes

| Action | File |
|--------|------|
| MODIFY | `app/(protected)/dashboard/page.tsx` — Remove StundenWidget, stats, quick link, related imports |
| MODIFY | `components/mein-bereich/DashboardWidgets.tsx` — Remove StundenWidget export + QuickLinks entry |
| MODIFY | `components/mein-bereich/index.ts` — Remove StundenWidget barrel export |
| MODIFY | `app/(protected)/mein-bereich/stundenkonto/page.tsx` — Add management role check |
| MODIFY | `lib/navigation.ts` — Remove Stundenkonto from MITGLIED_AKTIV, add Mein Bereich to MANAGEMENT, add /vorstand route access + breadcrumbs |
| MODIFY | `lib/supabase/middleware.ts` — Add `/vorstand` as protected prefix |
| MODIFY | `components/helfer-dashboard/HelferDashboardView.tsx` — Add `showHeader` prop |
| NEW | `app/(protected)/vorstand/termine/page.tsx` — Reuses PersonalCalendar |
| NEW | `app/(protected)/vorstand/stundenkonto/page.tsx` — Reuses StundenkontoTable |
| NEW | `app/(protected)/vorstand/einsaetze/page.tsx` — Combined view of both helfer systems |

## Test plan

- [ ] **MITGLIED_AKTIV**: Dashboard shows no StundenWidget, no Stunden stats, no Stundenkonto quick link. Sidebar has no Stundenkonto entry. Direct URL `/mein-bereich/stundenkonto` redirects to `/dashboard`
- [ ] **VORSTAND**: Sidebar shows "Mein Bereich" with 3 links. `/vorstand/termine` shows calendar. `/vorstand/stundenkonto` shows own hours. `/vorstand/einsaetze` shows both systems
- [ ] **ADMIN**: Same as VORSTAND for `/vorstand/` routes
- [ ] Typecheck, lint, and tests all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)