### PR TITLE
feat: nachträgliche Einladung für bestehende Mitglieder

### DIFF
--- a/apps/web/app/(protected)/meetings/[id]/page.tsx
+++ b/apps/web/app/(protected)/meetings/[id]/page.tsx
@@ -24,7 +24,7 @@ export default async function MeetingDetailPage({ params }: MeetingDetailPagePro
   // Hole alle Personen fuer Auswahllisten
   const { data: personen } = await supabase
     .from('personen')
-    .select('id, vorname, nachname, strasse, plz, ort, geburtstag, email, telefon, rolle, aktiv, notizen, notfallkontakt_name, notfallkontakt_telefon, notfallkontakt_beziehung, profilbild_url, biografie, mitglied_seit, austrittsdatum, austrittsgrund, skills, telefon_nummern, bevorzugte_kontaktart, social_media, kontakt_notizen, archiviert_am, archiviert_von, created_at, updated_at')
+    .select('id, vorname, nachname, strasse, plz, ort, geburtstag, email, telefon, rolle, aktiv, notizen, notfallkontakt_name, notfallkontakt_telefon, notfallkontakt_beziehung, profilbild_url, biografie, mitglied_seit, austrittsdatum, austrittsgrund, skills, telefon_nummern, bevorzugte_kontaktart, social_media, kontakt_notizen, archiviert_am, archiviert_von, created_at, updated_at, profile_id')
     .eq('aktiv', true)
     .order('nachname')
 

--- a/apps/web/app/(protected)/meetings/neu/page.tsx
+++ b/apps/web/app/(protected)/meetings/neu/page.tsx
@@ -17,7 +17,7 @@ export default async function NeuesMeetingPage() {
   // Hole alle Personen fuer Auswahllisten
   const { data: personen } = await supabase
     .from('personen')
-    .select('id, vorname, nachname, strasse, plz, ort, geburtstag, email, telefon, rolle, aktiv, notizen, notfallkontakt_name, notfallkontakt_telefon, notfallkontakt_beziehung, profilbild_url, biografie, mitglied_seit, austrittsdatum, austrittsgrund, skills, telefon_nummern, bevorzugte_kontaktart, social_media, kontakt_notizen, archiviert_am, archiviert_von, created_at, updated_at')
+    .select('id, vorname, nachname, strasse, plz, ort, geburtstag, email, telefon, rolle, aktiv, notizen, notfallkontakt_name, notfallkontakt_telefon, notfallkontakt_beziehung, profilbild_url, biografie, mitglied_seit, austrittsdatum, austrittsgrund, skills, telefon_nummern, bevorzugte_kontaktart, social_media, kontakt_notizen, archiviert_am, archiviert_von, created_at, updated_at, profile_id')
     .eq('aktiv', true)
     .order('nachname')
 

--- a/apps/web/app/(protected)/mitglieder/[id]/page.tsx
+++ b/apps/web/app/(protected)/mitglieder/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { getPerson } from '@/lib/actions/personen'
 import { MitgliedForm } from '@/components/mitglieder/MitgliedForm'
+import { InviteButton } from '@/components/mitglieder/InviteButton'
 
 interface PageProps {
   params: Promise<{ id: string }>
@@ -31,6 +32,17 @@ export default async function MitgliedEditPage({ params }: PageProps) {
           </h1>
           <p className="mt-1 text-gray-600">Mitglied bearbeiten</p>
         </div>
+
+        {/* Invite banner for members without app access */}
+        {!person.profile_id && person.email && (
+          <div className="mb-6">
+            <InviteButton
+              personId={id}
+              personRolle={person.rolle}
+              personEmail={person.email}
+            />
+          </div>
+        )}
 
         {/* Form */}
         <div className="rounded-lg bg-white p-6 shadow">

--- a/apps/web/app/(protected)/proben/[id]/page.tsx
+++ b/apps/web/app/(protected)/proben/[id]/page.tsx
@@ -49,7 +49,7 @@ export default async function ProbeDetailPage({
   // Hole alle verfügbaren Personen für Teilnehmer-Auswahl
   const { data: personen } = await supabase
     .from('personen')
-    .select('id, vorname, nachname, strasse, plz, ort, geburtstag, email, telefon, rolle, aktiv, notizen, notfallkontakt_name, notfallkontakt_telefon, notfallkontakt_beziehung, profilbild_url, biografie, mitglied_seit, austrittsdatum, austrittsgrund, skills, telefon_nummern, bevorzugte_kontaktart, social_media, kontakt_notizen, archiviert_am, archiviert_von, created_at, updated_at')
+    .select('id, vorname, nachname, strasse, plz, ort, geburtstag, email, telefon, rolle, aktiv, notizen, notfallkontakt_name, notfallkontakt_telefon, notfallkontakt_beziehung, profilbild_url, biografie, mitglied_seit, austrittsdatum, austrittsgrund, skills, telefon_nummern, bevorzugte_kontaktart, social_media, kontakt_notizen, archiviert_am, archiviert_von, created_at, updated_at, profile_id')
     .eq('aktiv', true)
     .order('nachname')
 

--- a/apps/web/components/mitglieder/InviteButton.tsx
+++ b/apps/web/components/mitglieder/InviteButton.tsx
@@ -1,0 +1,106 @@
+'use client'
+
+import { useState } from 'react'
+import { inviteExistingPerson } from '@/lib/actions/personen'
+import { Alert } from '@/components/ui/Alert'
+import type { Rolle, UserRole } from '@/lib/supabase/types'
+
+const appRollenOptions: { value: UserRole; label: string; description: string }[] = [
+  { value: 'MITGLIED_PASSIV', label: 'Passives Mitglied', description: 'Nur eigenes Profil' },
+  { value: 'MITGLIED_AKTIV', label: 'Aktives Mitglied', description: 'Anmeldungen, Stundenkonto' },
+  { value: 'VORSTAND', label: 'Vorstand', description: 'Alle operativen Module' },
+  { value: 'ADMIN', label: 'Administrator', description: 'Vollzugriff inkl. System' },
+]
+
+function getDefaultAppRole(rolle: Rolle): UserRole {
+  switch (rolle) {
+    case 'vorstand':
+      return 'VORSTAND'
+    case 'mitglied':
+    case 'regie':
+    case 'technik':
+      return 'MITGLIED_AKTIV'
+    case 'gast':
+      return 'MITGLIED_PASSIV'
+    default:
+      return 'MITGLIED_AKTIV'
+  }
+}
+
+interface InviteButtonProps {
+  personId: string
+  personRolle: Rolle
+  personEmail: string
+}
+
+export function InviteButton({ personId, personRolle, personEmail }: InviteButtonProps) {
+  const [appRole, setAppRole] = useState<UserRole>(getDefaultAppRole(personRolle))
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle')
+  const [errorMessage, setErrorMessage] = useState('')
+
+  async function handleInvite() {
+    setStatus('loading')
+    setErrorMessage('')
+
+    const result = await inviteExistingPerson(personId, appRole)
+
+    if (result.success) {
+      setStatus('success')
+    } else {
+      setStatus('error')
+      setErrorMessage(result.error || 'Unbekannter Fehler')
+    }
+  }
+
+  if (status === 'success') {
+    return (
+      <Alert variant="success">
+        Einladung wurde an <strong>{personEmail}</strong> gesendet.
+      </Alert>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      <Alert variant="info">
+        <div className="space-y-3">
+          <p>
+            Dieses Mitglied hat noch keinen App-Zugang. Eine Einladung wird an{' '}
+            <strong>{personEmail}</strong> gesendet.
+          </p>
+          <div className="flex flex-wrap items-end gap-3">
+            <div>
+              <label htmlFor="app-rolle" className="mb-1 block text-xs font-medium">
+                App-Rolle
+              </label>
+              <select
+                id="app-rolle"
+                value={appRole}
+                onChange={(e) => setAppRole(e.target.value as UserRole)}
+                className="rounded border border-info-300 bg-white px-2 py-1 text-sm text-gray-900"
+                disabled={status === 'loading'}
+              >
+                {appRollenOptions.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label} - {opt.description}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <button
+              type="button"
+              onClick={handleInvite}
+              disabled={status === 'loading'}
+              className="rounded bg-blue-600 px-3 py-1 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+            >
+              {status === 'loading' ? 'Wird gesendet...' : 'Einladen'}
+            </button>
+          </div>
+        </div>
+      </Alert>
+      {status === 'error' && (
+        <Alert variant="error">{errorMessage}</Alert>
+      )}
+    </div>
+  )
+}

--- a/apps/web/lib/personen/data.ts
+++ b/apps/web/lib/personen/data.ts
@@ -24,6 +24,8 @@ const defaultExtendedFields = {
   // Archive fields (Issue #5)
   archiviert_am: null,
   archiviert_von: null,
+  // Profile link
+  profile_id: null,
 }
 
 export const dummyPersonen: Person[] = [

--- a/apps/web/lib/supabase/types.ts
+++ b/apps/web/lib/supabase/types.ts
@@ -76,9 +76,10 @@ export type Person = {
   archiviert_von: string | null
   created_at: string
   updated_at: string
+  profile_id: string | null
 }
 
-export type PersonInsert = Omit<Person, 'id' | 'created_at' | 'updated_at'>
+export type PersonInsert = Omit<Person, 'id' | 'created_at' | 'updated_at' | 'profile_id'>
 
 export type PersonUpdate = Partial<PersonInsert>
 


### PR DESCRIPTION
## Summary
- Add `profile_id` to `Person` type and all personen select queries across the app
- New `inviteExistingPerson()` server action to invite existing members who don't have app access yet (reuses the invite pattern from `createPersonWithAccount()`)
- New `InviteButton` client component on the member detail page — shows an info banner with role dropdown and invite button when `profile_id` is null and email is present

## Test plan
- [ ] `npm run typecheck` — passes
- [ ] `npm run lint` — passes
- [ ] `npm run test:run` — 96/96 tests pass
- [ ] Open a member without app access → invite banner visible with role pre-selected based on member role
- [ ] Click "Einladen" → invitation email sent, success message shown
- [ ] Open a member with app access → no invite banner shown
- [ ] Open a member without email → no invite banner shown

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)