### PR TITLE
feat: add invitation tracking & resend (#325)

### DIFF
--- a/apps/web/app/(protected)/meetings/[id]/page.tsx
+++ b/apps/web/app/(protected)/meetings/[id]/page.tsx
@@ -24,7 +24,7 @@ export default async function MeetingDetailPage({ params }: MeetingDetailPagePro
   // Hole alle Personen fuer Auswahllisten
   const { data: personen } = await supabase
     .from('personen')
-    .select('id, vorname, nachname, strasse, plz, ort, geburtstag, email, telefon, rolle, aktiv, notizen, notfallkontakt_name, notfallkontakt_telefon, notfallkontakt_beziehung, profilbild_url, biografie, mitglied_seit, austrittsdatum, austrittsgrund, skills, telefon_nummern, bevorzugte_kontaktart, social_media, kontakt_notizen, archiviert_am, archiviert_von, created_at, updated_at, profile_id')
+    .select('id, vorname, nachname, strasse, plz, ort, geburtstag, email, telefon, rolle, aktiv, notizen, notfallkontakt_name, notfallkontakt_telefon, notfallkontakt_beziehung, profilbild_url, biografie, mitglied_seit, austrittsdatum, austrittsgrund, skills, telefon_nummern, bevorzugte_kontaktart, social_media, kontakt_notizen, archiviert_am, archiviert_von, created_at, updated_at, profile_id, invited_at, invitation_accepted_at')
     .eq('aktiv', true)
     .order('nachname')
 

--- a/apps/web/app/(protected)/meetings/neu/page.tsx
+++ b/apps/web/app/(protected)/meetings/neu/page.tsx
@@ -17,7 +17,7 @@ export default async function NeuesMeetingPage() {
   // Hole alle Personen fuer Auswahllisten
   const { data: personen } = await supabase
     .from('personen')
-    .select('id, vorname, nachname, strasse, plz, ort, geburtstag, email, telefon, rolle, aktiv, notizen, notfallkontakt_name, notfallkontakt_telefon, notfallkontakt_beziehung, profilbild_url, biografie, mitglied_seit, austrittsdatum, austrittsgrund, skills, telefon_nummern, bevorzugte_kontaktart, social_media, kontakt_notizen, archiviert_am, archiviert_von, created_at, updated_at, profile_id')
+    .select('id, vorname, nachname, strasse, plz, ort, geburtstag, email, telefon, rolle, aktiv, notizen, notfallkontakt_name, notfallkontakt_telefon, notfallkontakt_beziehung, profilbild_url, biografie, mitglied_seit, austrittsdatum, austrittsgrund, skills, telefon_nummern, bevorzugte_kontaktart, social_media, kontakt_notizen, archiviert_am, archiviert_von, created_at, updated_at, profile_id, invited_at, invitation_accepted_at')
     .eq('aktiv', true)
     .order('nachname')
 

--- a/apps/web/app/(protected)/mitglieder/[id]/page.tsx
+++ b/apps/web/app/(protected)/mitglieder/[id]/page.tsx
@@ -40,6 +40,8 @@ export default async function MitgliedEditPage({ params }: PageProps) {
               personId={id}
               personRolle={person.rolle}
               personEmail={person.email}
+              invitedAt={person.invited_at}
+              invitationAcceptedAt={person.invitation_accepted_at}
             />
           </div>
         )}

--- a/apps/web/app/(protected)/proben/[id]/page.tsx
+++ b/apps/web/app/(protected)/proben/[id]/page.tsx
@@ -49,7 +49,7 @@ export default async function ProbeDetailPage({
   // Hole alle verfügbaren Personen für Teilnehmer-Auswahl
   const { data: personen } = await supabase
     .from('personen')
-    .select('id, vorname, nachname, strasse, plz, ort, geburtstag, email, telefon, rolle, aktiv, notizen, notfallkontakt_name, notfallkontakt_telefon, notfallkontakt_beziehung, profilbild_url, biografie, mitglied_seit, austrittsdatum, austrittsgrund, skills, telefon_nummern, bevorzugte_kontaktart, social_media, kontakt_notizen, archiviert_am, archiviert_von, created_at, updated_at, profile_id')
+    .select('id, vorname, nachname, strasse, plz, ort, geburtstag, email, telefon, rolle, aktiv, notizen, notfallkontakt_name, notfallkontakt_telefon, notfallkontakt_beziehung, profilbild_url, biografie, mitglied_seit, austrittsdatum, austrittsgrund, skills, telefon_nummern, bevorzugte_kontaktart, social_media, kontakt_notizen, archiviert_am, archiviert_von, created_at, updated_at, profile_id, invited_at, invitation_accepted_at')
     .eq('aktiv', true)
     .order('nachname')
 

--- a/apps/web/components/mitglieder/InvitationStatusBadge.tsx
+++ b/apps/web/components/mitglieder/InvitationStatusBadge.tsx
@@ -1,0 +1,48 @@
+interface InvitationStatusBadgeProps {
+  profileId: string | null
+  invitedAt: string | null
+  invitationAcceptedAt: string | null
+  email: string | null
+}
+
+function daysSince(dateStr: string): number {
+  return Math.floor(
+    (Date.now() - new Date(dateStr).getTime()) / (1000 * 60 * 60 * 24)
+  )
+}
+
+export function InvitationStatusBadge({
+  profileId,
+  invitedAt,
+  invitationAcceptedAt,
+  email,
+}: InvitationStatusBadgeProps) {
+  // No email → no badge
+  if (!email) return null
+
+  // Profile linked → active
+  if (profileId || invitationAcceptedAt) {
+    return (
+      <span className="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800">
+        Aktiv
+      </span>
+    )
+  }
+
+  // Invited but not yet accepted
+  if (invitedAt) {
+    const days = daysSince(invitedAt)
+    return (
+      <span className="inline-flex items-center rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-medium text-blue-800">
+        Eingeladen{days > 0 ? ` (vor ${days} T.)` : ''}
+      </span>
+    )
+  }
+
+  // Has email but no invite sent
+  return (
+    <span className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800">
+      Kein Zugang
+    </span>
+  )
+}

--- a/apps/web/components/mitglieder/InviteButton.tsx
+++ b/apps/web/components/mitglieder/InviteButton.tsx
@@ -1,9 +1,11 @@
 'use client'
 
 import { useState } from 'react'
-import { inviteExistingPerson } from '@/lib/actions/personen'
+import { inviteExistingPerson, resendInvitation } from '@/lib/actions/personen'
 import { Alert } from '@/components/ui/Alert'
 import type { Rolle, UserRole } from '@/lib/supabase/types'
+
+const RESEND_COOLDOWN_DAYS = 7
 
 const appRollenOptions: { value: UserRole; label: string; description: string }[] = [
   { value: 'MITGLIED_PASSIV', label: 'Passives Mitglied', description: 'Nur eigenes Profil' },
@@ -27,22 +29,52 @@ function getDefaultAppRole(rolle: Rolle): UserRole {
   }
 }
 
+function daysSince(dateStr: string): number {
+  return Math.floor(
+    (Date.now() - new Date(dateStr).getTime()) / (1000 * 60 * 60 * 24)
+  )
+}
+
 interface InviteButtonProps {
   personId: string
   personRolle: Rolle
   personEmail: string
+  invitedAt?: string | null
+  invitationAcceptedAt?: string | null
 }
 
-export function InviteButton({ personId, personRolle, personEmail }: InviteButtonProps) {
+export function InviteButton({
+  personId,
+  personRolle,
+  personEmail,
+  invitedAt,
+  invitationAcceptedAt,
+}: InviteButtonProps) {
   const [appRole, setAppRole] = useState<UserRole>(getDefaultAppRole(personRolle))
   const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle')
   const [errorMessage, setErrorMessage] = useState('')
+
+  const isResendMode = !!invitedAt && !invitationAcceptedAt
 
   async function handleInvite() {
     setStatus('loading')
     setErrorMessage('')
 
     const result = await inviteExistingPerson(personId, appRole)
+
+    if (result.success) {
+      setStatus('success')
+    } else {
+      setStatus('error')
+      setErrorMessage(result.error || 'Unbekannter Fehler')
+    }
+  }
+
+  async function handleResend() {
+    setStatus('loading')
+    setErrorMessage('')
+
+    const result = await resendInvitation(personId)
 
     if (result.success) {
       setStatus('success')
@@ -60,6 +92,47 @@ export function InviteButton({ personId, personRolle, personEmail }: InviteButto
     )
   }
 
+  // Resend mode
+  if (isResendMode) {
+    const days = daysSince(invitedAt!)
+    const canResend = days >= RESEND_COOLDOWN_DAYS
+    const remaining = RESEND_COOLDOWN_DAYS - days
+
+    return (
+      <div className="space-y-3">
+        <Alert variant="warning">
+          <div className="space-y-3">
+            {canResend ? (
+              <>
+                <p>
+                  Einladung an <strong>{personEmail}</strong> wurde vor {days} Tagen
+                  gesendet und noch nicht angenommen.
+                </p>
+                <button
+                  type="button"
+                  onClick={handleResend}
+                  disabled={status === 'loading'}
+                  className="rounded bg-yellow-600 px-3 py-1 text-sm font-medium text-white hover:bg-yellow-700 disabled:opacity-50"
+                >
+                  {status === 'loading' ? 'Wird gesendet...' : 'Erneut einladen'}
+                </button>
+              </>
+            ) : (
+              <p>
+                Einladung an <strong>{personEmail}</strong> wurde vor {days} Tag{days !== 1 ? 'en' : ''} gesendet.
+                Erneutes Senden in {remaining} Tag{remaining !== 1 ? 'en' : ''} möglich.
+              </p>
+            )}
+          </div>
+        </Alert>
+        {status === 'error' && (
+          <Alert variant="error">{errorMessage}</Alert>
+        )}
+      </div>
+    )
+  }
+
+  // First invite mode
   return (
     <div className="space-y-3">
       <Alert variant="info">

--- a/apps/web/components/mitglieder/MitgliederTable.tsx
+++ b/apps/web/components/mitglieder/MitgliederTable.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import { RolleBadge } from './RolleBadge'
+import { InvitationStatusBadge } from './InvitationStatusBadge'
 import { ExportDialog } from './ExportDialog'
 import type { Person, Rolle } from '@/lib/supabase/types'
 import type {
@@ -362,21 +363,24 @@ export function MitgliederTable({
                     {formatDate(person.mitglied_seit)}
                   </td>
                   <td className="whitespace-nowrap px-6 py-4">
-                    <span
-                      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
-                        person.aktiv
-                          ? 'bg-green-100 text-green-800'
-                          : person.archiviert_am
+                    {!person.aktiv ? (
+                      <span
+                        className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                          person.archiviert_am
                             ? 'bg-gray-100 text-gray-800'
                             : 'bg-yellow-100 text-yellow-800'
-                      }`}
-                    >
-                      {person.aktiv
-                        ? 'Aktiv'
-                        : person.archiviert_am
-                          ? 'Archiviert'
-                          : 'Inaktiv'}
-                    </span>
+                        }`}
+                      >
+                        {person.archiviert_am ? 'Archiviert' : 'Inaktiv'}
+                      </span>
+                    ) : (
+                      <InvitationStatusBadge
+                        profileId={person.profile_id}
+                        invitedAt={person.invited_at}
+                        invitationAcceptedAt={person.invitation_accepted_at}
+                        email={person.email}
+                      />
+                    )}
                   </td>
                   <td className="whitespace-nowrap px-6 py-4 text-right text-sm font-medium">
                     <div className="flex items-center justify-end gap-3">

--- a/apps/web/lib/actions/personen.ts
+++ b/apps/web/lib/actions/personen.ts
@@ -28,7 +28,7 @@ export async function getPersonen(): Promise<Person[]> {
   const supabase = await createClient()
   const { data, error } = await supabase
     .from('personen')
-    .select('id, vorname, nachname, strasse, plz, ort, geburtstag, email, telefon, rolle, aktiv, notizen, notfallkontakt_name, notfallkontakt_telefon, notfallkontakt_beziehung, profilbild_url, biografie, mitglied_seit, austrittsdatum, austrittsgrund, skills, telefon_nummern, bevorzugte_kontaktart, social_media, kontakt_notizen, archiviert_am, archiviert_von, created_at, updated_at, profile_id')
+    .select('id, vorname, nachname, strasse, plz, ort, geburtstag, email, telefon, rolle, aktiv, notizen, notfallkontakt_name, notfallkontakt_telefon, notfallkontakt_beziehung, profilbild_url, biografie, mitglied_seit, austrittsdatum, austrittsgrund, skills, telefon_nummern, bevorzugte_kontaktart, social_media, kontakt_notizen, archiviert_am, archiviert_von, created_at, updated_at, profile_id, invited_at, invitation_accepted_at')
     .order('nachname', { ascending: true })
 
   if (error) {
@@ -52,7 +52,7 @@ export async function getPerson(id: string): Promise<Person | null> {
   const supabase = await createClient()
   const { data, error } = await supabase
     .from('personen')
-    .select('id, vorname, nachname, strasse, plz, ort, geburtstag, email, telefon, rolle, aktiv, notizen, notfallkontakt_name, notfallkontakt_telefon, notfallkontakt_beziehung, profilbild_url, biografie, mitglied_seit, austrittsdatum, austrittsgrund, skills, telefon_nummern, bevorzugte_kontaktart, social_media, kontakt_notizen, archiviert_am, archiviert_von, created_at, updated_at, profile_id')
+    .select('id, vorname, nachname, strasse, plz, ort, geburtstag, email, telefon, rolle, aktiv, notizen, notfallkontakt_name, notfallkontakt_telefon, notfallkontakt_beziehung, profilbild_url, biografie, mitglied_seit, austrittsdatum, austrittsgrund, skills, telefon_nummern, bevorzugte_kontaktart, social_media, kontakt_notizen, archiviert_am, archiviert_von, created_at, updated_at, profile_id, invited_at, invitation_accepted_at')
     .eq('id', id)
     .single()
 
@@ -77,7 +77,7 @@ export async function searchPersonenAction(query: string): Promise<Person[]> {
   const supabase = await createClient()
   const { data, error } = await supabase
     .from('personen')
-    .select('id, vorname, nachname, strasse, plz, ort, geburtstag, email, telefon, rolle, aktiv, notizen, notfallkontakt_name, notfallkontakt_telefon, notfallkontakt_beziehung, profilbild_url, biografie, mitglied_seit, austrittsdatum, austrittsgrund, skills, telefon_nummern, bevorzugte_kontaktart, social_media, kontakt_notizen, archiviert_am, archiviert_von, created_at, updated_at, profile_id')
+    .select('id, vorname, nachname, strasse, plz, ort, geburtstag, email, telefon, rolle, aktiv, notizen, notfallkontakt_name, notfallkontakt_telefon, notfallkontakt_beziehung, profilbild_url, biografie, mitglied_seit, austrittsdatum, austrittsgrund, skills, telefon_nummern, bevorzugte_kontaktart, social_media, kontakt_notizen, archiviert_am, archiviert_von, created_at, updated_at, profile_id, invited_at, invitation_accepted_at')
     .or(
       `vorname.ilike.%${sanitizeSearchQuery(query)}%,nachname.ilike.%${sanitizeSearchQuery(query)}%,email.ilike.%${sanitizeSearchQuery(query)}%`
     )
@@ -183,6 +183,12 @@ export async function createPersonWithAccount(
         // Don't fail - the user can still be updated later
       }
     }
+
+    // Track invitation timestamp
+    await adminClient
+      .from('personen')
+      .update({ invited_at: new Date().toISOString() } as never)
+      .eq('email', personData.email)
   } catch (err) {
     console.error('Error in invite flow:', err)
     return {
@@ -261,6 +267,12 @@ export async function inviteExistingPerson(
         console.error('Error updating profile role:', profileError)
       }
     }
+
+    // Track invitation timestamp
+    await adminClient
+      .from('personen')
+      .update({ invited_at: new Date().toISOString() } as never)
+      .eq('id', personId)
   } catch (err) {
     console.error('Error in invite flow:', err)
     return {
@@ -426,7 +438,7 @@ export async function getPersonenFiltered(
 
   const supabase = await createClient()
 
-  let query = supabase.from('personen').select('id, vorname, nachname, strasse, plz, ort, geburtstag, email, telefon, rolle, aktiv, notizen, notfallkontakt_name, notfallkontakt_telefon, notfallkontakt_beziehung, profilbild_url, biografie, mitglied_seit, austrittsdatum, austrittsgrund, skills, telefon_nummern, bevorzugte_kontaktart, social_media, kontakt_notizen, archiviert_am, archiviert_von, created_at, updated_at, profile_id')
+  let query = supabase.from('personen').select('id, vorname, nachname, strasse, plz, ort, geburtstag, email, telefon, rolle, aktiv, notizen, notfallkontakt_name, notfallkontakt_telefon, notfallkontakt_beziehung, profilbild_url, biografie, mitglied_seit, austrittsdatum, austrittsgrund, skills, telefon_nummern, bevorzugte_kontaktart, social_media, kontakt_notizen, archiviert_am, archiviert_von, created_at, updated_at, profile_id, invited_at, invitation_accepted_at')
 
   if (filter === 'aktiv') {
     query = query.eq('aktiv', true)
@@ -528,7 +540,7 @@ export async function getPersonenAdvanced(
 
   const supabase = await createClient()
 
-  let query = supabase.from('personen').select('id, vorname, nachname, strasse, plz, ort, geburtstag, email, telefon, rolle, aktiv, notizen, notfallkontakt_name, notfallkontakt_telefon, notfallkontakt_beziehung, profilbild_url, biografie, mitglied_seit, austrittsdatum, austrittsgrund, skills, telefon_nummern, bevorzugte_kontaktart, social_media, kontakt_notizen, archiviert_am, archiviert_von, created_at, updated_at, profile_id')
+  let query = supabase.from('personen').select('id, vorname, nachname, strasse, plz, ort, geburtstag, email, telefon, rolle, aktiv, notizen, notfallkontakt_name, notfallkontakt_telefon, notfallkontakt_beziehung, profilbild_url, biografie, mitglied_seit, austrittsdatum, austrittsgrund, skills, telefon_nummern, bevorzugte_kontaktart, social_media, kontakt_notizen, archiviert_am, archiviert_von, created_at, updated_at, profile_id, invited_at, invitation_accepted_at')
 
   // Status filter
   if (status === 'aktiv') {
@@ -723,4 +735,97 @@ export async function getMitgliederStatistik(): Promise<{
     archivierte,
     gesamt: aktive + archivierte,
   }
+}
+
+// =============================================================================
+// Invitation Resend (Issue #325)
+// =============================================================================
+
+const RESEND_COOLDOWN_DAYS = 7
+
+/**
+ * Resend an invitation to a person who was already invited but hasn't accepted
+ */
+export async function resendInvitation(
+  personId: string
+): Promise<{ success: boolean; error?: string }> {
+  await requirePermission('mitglieder:write')
+
+  if (USE_DUMMY_DATA) {
+    return { success: true }
+  }
+
+  const supabase = await createClient()
+
+  // Load the person
+  const { data: person, error: fetchError } = await supabase
+    .from('personen')
+    .select('id, vorname, nachname, email, profile_id, invited_at, invitation_accepted_at')
+    .eq('id', personId)
+    .single()
+
+  if (fetchError || !person) {
+    return { success: false, error: 'Person nicht gefunden' }
+  }
+
+  if (!person.email) {
+    return { success: false, error: 'E-Mail ist erforderlich' }
+  }
+
+  if (person.invitation_accepted_at || person.profile_id) {
+    return { success: false, error: 'Einladung wurde bereits angenommen' }
+  }
+
+  if (!person.invited_at) {
+    return { success: false, error: 'Noch keine Einladung gesendet' }
+  }
+
+  // Check cooldown
+  const invitedDate = new Date(person.invited_at)
+  const daysSinceInvite = Math.floor(
+    (Date.now() - invitedDate.getTime()) / (1000 * 60 * 60 * 24)
+  )
+
+  if (daysSinceInvite < RESEND_COOLDOWN_DAYS) {
+    const remaining = RESEND_COOLDOWN_DAYS - daysSinceInvite
+    return {
+      success: false,
+      error: `Erneutes Senden erst in ${remaining} Tag${remaining !== 1 ? 'en' : ''} möglich`,
+    }
+  }
+
+  try {
+    const adminClient = createAdminClient()
+
+    const { error: inviteError } =
+      await adminClient.auth.admin.inviteUserByEmail(person.email, {
+        data: {
+          display_name: `${person.vorname} ${person.nachname}`,
+        },
+      })
+
+    if (inviteError) {
+      console.error('Error resending invitation:', inviteError)
+      return {
+        success: false,
+        error: `Einladung fehlgeschlagen: ${inviteError.message}`,
+      }
+    }
+
+    // Update invited_at timestamp
+    await adminClient
+      .from('personen')
+      .update({ invited_at: new Date().toISOString() } as never)
+      .eq('id', personId)
+  } catch (err) {
+    console.error('Error in resend flow:', err)
+    return {
+      success: false,
+      error: 'Einladung konnte nicht gesendet werden. Ist SUPABASE_SERVICE_ROLE_KEY konfiguriert?',
+    }
+  }
+
+  revalidatePath('/mitglieder')
+  revalidatePath(`/mitglieder/${personId}`)
+  return { success: true }
 }

--- a/apps/web/lib/personen/data.ts
+++ b/apps/web/lib/personen/data.ts
@@ -26,6 +26,9 @@ const defaultExtendedFields = {
   archiviert_von: null,
   // Profile link
   profile_id: null,
+  // Invitation tracking (Issue #325)
+  invited_at: null,
+  invitation_accepted_at: null,
 }
 
 export const dummyPersonen: Person[] = [

--- a/apps/web/lib/supabase/types.ts
+++ b/apps/web/lib/supabase/types.ts
@@ -77,9 +77,12 @@ export type Person = {
   created_at: string
   updated_at: string
   profile_id: string | null
+  // Invitation tracking (Issue #325)
+  invited_at: string | null
+  invitation_accepted_at: string | null
 }
 
-export type PersonInsert = Omit<Person, 'id' | 'created_at' | 'updated_at' | 'profile_id'>
+export type PersonInsert = Omit<Person, 'id' | 'created_at' | 'updated_at' | 'profile_id' | 'invited_at' | 'invitation_accepted_at'>
 
 export type PersonUpdate = Partial<PersonInsert>
 

--- a/supabase/migrations/20260301000000_einladungs_tracking.sql
+++ b/supabase/migrations/20260301000000_einladungs_tracking.sql
@@ -1,0 +1,30 @@
+-- Migration: Einladungs-Tracking (Issue #325)
+-- Adds invitation tracking columns to personen table
+
+-- 1. New columns
+ALTER TABLE personen ADD COLUMN IF NOT EXISTS invited_at TIMESTAMPTZ;
+ALTER TABLE personen ADD COLUMN IF NOT EXISTS invitation_accepted_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_personen_invited_at ON personen(invited_at);
+
+-- 2. Trigger: set invitation_accepted_at when profile_id changes from NULL to a value
+CREATE OR REPLACE FUNCTION set_invitation_accepted_at() RETURNS TRIGGER AS $$
+BEGIN
+  IF OLD.profile_id IS NULL AND NEW.profile_id IS NOT NULL
+     AND NEW.invited_at IS NOT NULL AND NEW.invitation_accepted_at IS NULL THEN
+    NEW.invitation_accepted_at = now();
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER on_profile_linked_set_accepted
+  BEFORE UPDATE OF profile_id ON personen
+  FOR EACH ROW EXECUTE FUNCTION set_invitation_accepted_at();
+
+-- 3. Backfill: existing members with profile_id get timestamps from profiles.created_at
+UPDATE personen p SET
+  invited_at = COALESCE(p.invited_at, pr.created_at),
+  invitation_accepted_at = COALESCE(p.invitation_accepted_at, pr.created_at)
+FROM profiles pr
+WHERE p.profile_id = pr.id AND p.profile_id IS NOT NULL AND p.invitation_accepted_at IS NULL;


### PR DESCRIPTION
## Summary
- **DB migration**: Adds `invited_at` and `invitation_accepted_at` columns to `personen`, with a trigger that auto-sets `invitation_accepted_at` when `profile_id` is linked, plus backfill for existing members
- **Invitation tracking**: `inviteExistingPerson()` and `createPersonWithAccount()` now record `invited_at` timestamp; new `resendInvitation()` action with 7-day cooldown
- **Status badges**: New `InvitationStatusBadge` component in the Mitglieder table showing Aktiv (green), Eingeladen vor X T. (blue), or Kein Zugang (gray)
- **Resend UI**: `InviteButton` extended with resend mode — shows cooldown info or "Erneut einladen" button after 7 days

Closes #325

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm run test:run` passes (96/96)
- [ ] Mitglieder-Liste: Status badges show correctly (Aktiv/Eingeladen/Kein Zugang)
- [ ] Detail page without invite: shows "Einladen" banner with role dropdown
- [ ] Detail page after invite: shows warning banner with cooldown info
- [ ] Resend only possible after 7 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)