### PR TITLE
feat: branded invitation email with SMTP fallback

### DIFF
--- a/apps/web/lib/actions/email-templates.ts
+++ b/apps/web/lib/actions/email-templates.ts
@@ -612,6 +612,57 @@ Das TGW-Team
 Diese E-Mail wurde automatisch von BackstagePass gesendet.`,
       placeholders: ['vorname', 'nachname', 'veranstaltung', 'rolle'],
     },
+    member_invitation: {
+      subject: 'Willkommen bei BackstagePass – Theatergruppe Widen',
+      body_html: `<div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+  <h1 style="color: #7c3aed;">Willkommen bei BackstagePass!</h1>
+  <p>Hallo {{vorname}},</p>
+  <p>du wurdest eingeladen, <strong>BackstagePass</strong> zu nutzen – die Vereinsplattform der <strong>Theatergruppe Widen (TGW)</strong>.</p>
+
+  <div style="background: #f3f4f6; padding: 20px; border-radius: 8px; margin: 20px 0;">
+    <h2 style="margin-top: 0; color: #374151;">Was ist BackstagePass?</h2>
+    <p>BackstagePass ist unsere interne Plattform für die Organisation von Vereinsaktivitäten, Aufführungen und Helfereinsätzen. Hier kannst du:</p>
+    <ul style="color: #374151;">
+      <li>Dein Profil und deine Kontaktdaten verwalten</li>
+      <li>Dich für Helfereinsätze anmelden</li>
+      <li>Vereinstermine und Proben einsehen</li>
+      <li>Mit dem Team in Kontakt bleiben</li>
+    </ul>
+  </div>
+
+  <p style="text-align: center; margin: 30px 0;">
+    <a href="{{magic_link}}" style="display: inline-block; background: #7c3aed; color: white; padding: 16px 32px; text-decoration: none; border-radius: 6px; font-size: 18px;">Jetzt anmelden</a>
+  </p>
+
+  <p style="color: #6b7280; font-size: 14px;">Der Link ist 24 Stunden gültig. Falls er abgelaufen ist, wende dich an den Vorstand für eine neue Einladung.</p>
+
+  <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 30px 0;">
+  <p style="color: #6b7280; font-size: 14px;">Diese E-Mail wurde automatisch von BackstagePass gesendet.<br>
+  Theatergruppe Widen | <a href="https://www.theatergruppe-widen.ch" style="color: #7c3aed;">www.theatergruppe-widen.ch</a></p>
+</div>`,
+      body_text: `Willkommen bei BackstagePass!
+
+Hallo {{vorname}},
+
+du wurdest eingeladen, BackstagePass zu nutzen – die Vereinsplattform der Theatergruppe Widen (TGW).
+
+WAS IST BACKSTAGEPASS?
+======================
+BackstagePass ist unsere interne Plattform für die Organisation von Vereinsaktivitäten, Aufführungen und Helfereinsätzen. Hier kannst du:
+- Dein Profil und deine Kontaktdaten verwalten
+- Dich für Helfereinsätze anmelden
+- Vereinstermine und Proben einsehen
+- Mit dem Team in Kontakt bleiben
+
+Jetzt anmelden: {{magic_link}}
+
+Der Link ist 24 Stunden gültig. Falls er abgelaufen ist, wende dich an den Vorstand für eine neue Einladung.
+
+---
+Diese E-Mail wurde automatisch von BackstagePass gesendet.
+Theatergruppe Widen | www.theatergruppe-widen.ch`,
+      placeholders: ['vorname', 'magic_link'],
+    },
   }
 
   const defaultTemplate = defaults[typ]

--- a/apps/web/lib/actions/invitation-email.ts
+++ b/apps/web/lib/actions/invitation-email.ts
@@ -1,0 +1,42 @@
+'use server'
+
+import { isEmailServiceConfigured, sendEmailWithRetry } from '@/lib/email'
+import { renderEmailTemplate } from '@/lib/utils/email-renderer'
+import { getEmailTemplateInternal } from './email-templates'
+
+/**
+ * Send a branded invitation email using the member_invitation template.
+ * Returns success/error — caller handles fallback behavior.
+ */
+export async function sendInvitationEmail(
+  email: string,
+  vorname: string,
+  magicLink: string
+): Promise<{ success: boolean; error?: string }> {
+  if (!isEmailServiceConfigured()) {
+    return { success: false, error: 'SMTP nicht konfiguriert' }
+  }
+
+  const template = await getEmailTemplateInternal('member_invitation')
+  if (!template) {
+    return { success: false, error: 'Einladungs-Template nicht gefunden oder inaktiv' }
+  }
+
+  const rendered = renderEmailTemplate(template, {
+    vorname,
+    magic_link: magicLink,
+  })
+
+  const emailResult = await sendEmailWithRetry({
+    to: email,
+    subject: rendered.subject,
+    html: rendered.html,
+    text: rendered.text,
+  })
+
+  if (!emailResult.success) {
+    return { success: false, error: emailResult.error || 'E-Mail-Versand fehlgeschlagen' }
+  }
+
+  return { success: true }
+}

--- a/apps/web/lib/supabase/types.ts
+++ b/apps/web/lib/supabase/types.ts
@@ -2141,12 +2141,14 @@ export type EmailTemplateTyp =
   | 'waitlist_assigned'
   | 'waitlist_timeout'
   | 'thank_you'
+  | 'member_invitation'
 
 export const EMAIL_TEMPLATE_TYP_LABELS: Record<EmailTemplateTyp, string> = {
   confirmation: 'Buchungsbestätigung',
   reminder_48h: 'Erinnerung (48h vorher)',
   reminder_6h: 'Erinnerung (6h vorher)',
   cancellation: 'Abmeldebestätigung',
+  member_invitation: 'Mitglieder-Einladung',
   waitlist_assigned: 'Warteliste: Platz frei',
   waitlist_timeout: 'Warteliste: Timeout',
   thank_you: 'Dankeschön',
@@ -2194,6 +2196,7 @@ export type EmailPlaceholderData = {
   koordinator_email?: string
   koordinator_telefon?: string
   frist?: string
+  magic_link?: string
 }
 
 // =============================================================================

--- a/apps/web/lib/utils/email-renderer.ts
+++ b/apps/web/lib/utils/email-renderer.ts
@@ -24,6 +24,7 @@ function escapeHtml(unsafe: string): string {
 const TRUSTED_PLACEHOLDERS = new Set([
   'absage_link',
   'public_link',
+  'magic_link',
 ])
 
 /**
@@ -92,6 +93,7 @@ export const SAMPLE_PLACEHOLDER_DATA: EmailPlaceholderData = {
   koordinator_email: 'anna@tgw.ch',
   koordinator_telefon: '+41 79 123 45 67',
   frist: 'Freitag, 14. März 2026, 18:00 Uhr',
+  magic_link: 'https://example.com/auth/confirm?token_hash=abc123&type=invite',
 }
 
 /**

--- a/supabase/migrations/20260305000000_add_member_invitation_template.sql
+++ b/supabase/migrations/20260305000000_add_member_invitation_template.sql
@@ -1,0 +1,80 @@
+-- Migration: Add member_invitation email template type
+-- Created: 2026-02-17
+-- Issue: #326
+-- Description: Add branded invitation email template for member onboarding
+
+-- =============================================================================
+-- Extend CHECK constraint to include 'member_invitation'
+-- =============================================================================
+
+ALTER TABLE email_templates DROP CONSTRAINT IF EXISTS email_templates_typ_check;
+ALTER TABLE email_templates ADD CONSTRAINT email_templates_typ_check
+  CHECK (typ IN (
+    'confirmation',
+    'reminder_48h',
+    'reminder_6h',
+    'cancellation',
+    'waitlist_assigned',
+    'waitlist_timeout',
+    'thank_you',
+    'member_invitation'
+  ));
+
+-- =============================================================================
+-- Insert default member_invitation template
+-- =============================================================================
+
+INSERT INTO email_templates (typ, subject, body_html, body_text, placeholders)
+VALUES (
+  'member_invitation',
+  'Willkommen bei BackstagePass – Theatergruppe Widen',
+  '<div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+  <h1 style="color: #7c3aed;">Willkommen bei BackstagePass!</h1>
+  <p>Hallo {{vorname}},</p>
+  <p>du wurdest eingeladen, <strong>BackstagePass</strong> zu nutzen – die Vereinsplattform der <strong>Theatergruppe Widen (TGW)</strong>.</p>
+
+  <div style="background: #f3f4f6; padding: 20px; border-radius: 8px; margin: 20px 0;">
+    <h2 style="margin-top: 0; color: #374151;">Was ist BackstagePass?</h2>
+    <p>BackstagePass ist unsere interne Plattform für die Organisation von Vereinsaktivitäten, Aufführungen und Helfereinsätzen. Hier kannst du:</p>
+    <ul style="color: #374151;">
+      <li>Dein Profil und deine Kontaktdaten verwalten</li>
+      <li>Dich für Helfereinsätze anmelden</li>
+      <li>Vereinstermine und Proben einsehen</li>
+      <li>Mit dem Team in Kontakt bleiben</li>
+    </ul>
+  </div>
+
+  <p style="text-align: center; margin: 30px 0;">
+    <a href="{{magic_link}}" style="display: inline-block; background: #7c3aed; color: white; padding: 16px 32px; text-decoration: none; border-radius: 6px; font-size: 18px;">Jetzt anmelden</a>
+  </p>
+
+  <p style="color: #6b7280; font-size: 14px;">Der Link ist 24 Stunden gültig. Falls er abgelaufen ist, wende dich an den Vorstand für eine neue Einladung.</p>
+
+  <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 30px 0;">
+  <p style="color: #6b7280; font-size: 14px;">Diese E-Mail wurde automatisch von BackstagePass gesendet.<br>
+  Theatergruppe Widen | <a href="https://www.theatergruppe-widen.ch" style="color: #7c3aed;">www.theatergruppe-widen.ch</a></p>
+</div>',
+  'Willkommen bei BackstagePass!
+
+Hallo {{vorname}},
+
+du wurdest eingeladen, BackstagePass zu nutzen – die Vereinsplattform der Theatergruppe Widen (TGW).
+
+WAS IST BACKSTAGEPASS?
+======================
+BackstagePass ist unsere interne Plattform für die Organisation von Vereinsaktivitäten, Aufführungen und Helfereinsätzen. Hier kannst du:
+- Dein Profil und deine Kontaktdaten verwalten
+- Dich für Helfereinsätze anmelden
+- Vereinstermine und Proben einsehen
+- Mit dem Team in Kontakt bleiben
+
+Jetzt anmelden: {{magic_link}}
+
+Der Link ist 24 Stunden gültig. Falls er abgelaufen ist, wende dich an den Vorstand für eine neue Einladung.
+
+---
+Diese E-Mail wurde automatisch von BackstagePass gesendet.
+Theatergruppe Widen | www.theatergruppe-widen.ch',
+  ARRAY['vorname', 'magic_link']
+)
+ON CONFLICT (typ) DO NOTHING;


### PR DESCRIPTION
## Summary
- Use `generateLink({ type: 'invite' })` instead of `inviteUserByEmail()` to create the auth user without sending Supabase's default email, then send a TGW-branded invitation email via the existing Nodemailer/SMTP infrastructure
- Falls back to `inviteUserByEmail()` when SMTP is not configured (no breaking change)
- All 4 invite functions (`createPersonWithAccount`, `inviteExistingPerson`, `resendInvitation`, `bulkInvitePersons`) refactored to use a shared `performInvite()` helper

### New files
- `supabase/migrations/20260305000000_add_member_invitation_template.sql` — DB migration for `member_invitation` template type
- `apps/web/lib/actions/invitation-email.ts` — `sendInvitationEmail()` helper

### Modified files
- `apps/web/lib/supabase/types.ts` — `member_invitation` type + `magic_link` placeholder
- `apps/web/lib/utils/email-renderer.ts` — `magic_link` as trusted placeholder
- `apps/web/lib/actions/email-templates.ts` — Default template for reset function
- `apps/web/lib/actions/personen.ts` — `performInvite()` + all 4 invite functions updated

Closes #326

## Test plan
- [ ] Typecheck, lint, tests, build all pass
- [ ] Admin → E-Mail Templates → `member_invitation` template visible and editable
- [ ] Invite member with SMTP configured → branded email sent with magic link
- [ ] Invite member without SMTP → Supabase default email sent (fallback)
- [ ] Resend invitation → uses branded email path
- [ ] Bulk invite → all invitees receive branded email

🤖 Generated with [Claude Code](https://claude.com/claude-code)