### PR TITLE
feat: add bulk invite from Mitglieder list

### DIFF
--- a/apps/web/components/mitglieder/InviteButton.tsx
+++ b/apps/web/components/mitglieder/InviteButton.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { inviteExistingPerson, resendInvitation } from '@/lib/actions/personen'
+import { inviteExistingPerson, resendInvitation, getDefaultAppRole } from '@/lib/actions/personen'
 import { Alert } from '@/components/ui/Alert'
 import type { Rolle, UserRole } from '@/lib/supabase/types'
 
@@ -13,21 +13,6 @@ const appRollenOptions: { value: UserRole; label: string; description: string }[
   { value: 'VORSTAND', label: 'Vorstand', description: 'Alle operativen Module' },
   { value: 'ADMIN', label: 'Administrator', description: 'Vollzugriff inkl. System' },
 ]
-
-function getDefaultAppRole(rolle: Rolle): UserRole {
-  switch (rolle) {
-    case 'vorstand':
-      return 'VORSTAND'
-    case 'mitglied':
-    case 'regie':
-    case 'technik':
-      return 'MITGLIED_AKTIV'
-    case 'gast':
-      return 'MITGLIED_PASSIV'
-    default:
-      return 'MITGLIED_AKTIV'
-  }
-}
 
 function daysSince(dateStr: string): number {
   return Math.floor(


### PR DESCRIPTION
## Summary

- Add checkbox selection to `MitgliederTable` for uninvited members (active, has email, no profile_id, no pending invite)
- Add action bar with "Einladen" (bulk invite), "E-Mails kopieren", and "Auswahl aufheben" buttons
- Add `bulkInvitePersons` server action that fetches all selected persons in one query, invites sequentially to avoid rate limiting, and returns a summary with per-person errors
- Move `getDefaultAppRole()` from `InviteButton.tsx` to `personen.ts` for shared use
- Show result banner after bulk invite with success/failure count and error details

Closes #327

## Test plan

- [ ] Open Mitglieder list — checkboxes appear only for invitable members (has email, no profile, active, not yet invited)
- [ ] Select all via header checkbox — only invitable rows are selected
- [ ] Action bar appears with correct count when selections are made
- [ ] "E-Mails kopieren" copies selected emails to clipboard
- [ ] "Auswahl aufheben" clears all selections
- [ ] Changing filters clears the selection
- [ ] "Einladen" triggers bulk invite and shows result summary
- [ ] Result summary shows error details for any failed invites
- [ ] Existing single invite via InviteButton on detail page still works
- [ ] `npm run typecheck`, `npm run lint`, `npm run test:run` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)