### PR TITLE
fix: move getDefaultAppRole to utility file to fix build

### DIFF
--- a/apps/web/components/mitglieder/InviteButton.tsx
+++ b/apps/web/components/mitglieder/InviteButton.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useState } from 'react'
-import { inviteExistingPerson, resendInvitation, getDefaultAppRole } from '@/lib/actions/personen'
+import { inviteExistingPerson, resendInvitation } from '@/lib/actions/personen'
+import { getDefaultAppRole } from '@/lib/utils/roles'
 import { Alert } from '@/components/ui/Alert'
 import type { Rolle, UserRole } from '@/lib/supabase/types'
 

--- a/apps/web/lib/actions/personen.ts
+++ b/apps/web/lib/actions/personen.ts
@@ -13,6 +13,7 @@ import type {
   UserRole,
 } from '../supabase/types'
 import { sanitizeSearchQuery } from '../utils/search'
+import { getDefaultAppRole } from '../utils/roles'
 
 const USE_DUMMY_DATA = !process.env.NEXT_PUBLIC_SUPABASE_URL
 
@@ -834,24 +835,6 @@ export async function resendInvitation(
 // =============================================================================
 // Bulk Invite (Issue #327)
 // =============================================================================
-
-/**
- * Map a person's Vereins-Rolle to the default app role
- */
-export function getDefaultAppRole(rolle: Rolle): UserRole {
-  switch (rolle) {
-    case 'vorstand':
-      return 'VORSTAND'
-    case 'mitglied':
-    case 'regie':
-    case 'technik':
-      return 'MITGLIED_AKTIV'
-    case 'gast':
-      return 'MITGLIED_PASSIV'
-    default:
-      return 'MITGLIED_AKTIV'
-  }
-}
 
 export interface BulkInviteResult {
   total: number

--- a/apps/web/lib/utils/roles.ts
+++ b/apps/web/lib/utils/roles.ts
@@ -1,0 +1,19 @@
+import type { Rolle, UserRole } from '../supabase/types'
+
+/**
+ * Map a person's Vereins-Rolle to the default app role
+ */
+export function getDefaultAppRole(rolle: Rolle): UserRole {
+  switch (rolle) {
+    case 'vorstand':
+      return 'VORSTAND'
+    case 'mitglied':
+    case 'regie':
+    case 'technik':
+      return 'MITGLIED_AKTIV'
+    case 'gast':
+      return 'MITGLIED_PASSIV'
+    default:
+      return 'MITGLIED_AKTIV'
+  }
+}


### PR DESCRIPTION
## Summary

- Move `getDefaultAppRole()` from `lib/actions/personen.ts` (a `'use server'` file) to `lib/utils/roles.ts`
- Next.js requires all exports from `'use server'` files to be async functions — the non-async `getDefaultAppRole` caused the production build to fail
- Update imports in `InviteButton.tsx` and `personen.ts`

Fixes build error from #334 / #327

## Test plan

- [x] `npm run build` passes
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run test:run` passes (96/96)

🤖 Generated with [Claude Code](https://claude.com/claude-code)