### PR TITLE
fix: resolve invite trigger chain failure (#325)

### DIFF
--- a/supabase/migrations/20260302000000_fix_link_profile_trigger.sql
+++ b/supabase/migrations/20260302000000_fix_link_profile_trigger.sql
@@ -1,0 +1,39 @@
+-- Migration: Fix link_profile_to_person trigger (Issue #325)
+-- The original trigger caused nested trigger chain failures during
+-- inviteUserByEmail(): auth.users INSERT → handle_new_user() → profiles INSERT
+-- → link_profile_to_person() → personen UPDATE → audit_trigger → fail
+-- Profile linking is now handled in application code (getUserProfile auto-link).
+
+-- 1. Make link_profile_to_person() a permanent no-op
+CREATE OR REPLACE FUNCTION link_profile_to_person()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- No-op: profile linking handled in app code (getUserProfile auto-link)
+  -- to avoid nested trigger chain issues with audit system
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 2. Apply invitation acceptance trigger (from einladungs_tracking migration)
+-- Sets invitation_accepted_at when profile_id changes from NULL to a value
+CREATE OR REPLACE FUNCTION set_invitation_accepted_at() RETURNS TRIGGER AS $$
+BEGIN
+  IF OLD.profile_id IS NULL AND NEW.profile_id IS NOT NULL
+     AND NEW.invited_at IS NOT NULL AND NEW.invitation_accepted_at IS NULL THEN
+    NEW.invitation_accepted_at = now();
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS on_profile_linked_set_accepted ON personen;
+CREATE TRIGGER on_profile_linked_set_accepted
+  BEFORE UPDATE OF profile_id ON personen
+  FOR EACH ROW EXECUTE FUNCTION set_invitation_accepted_at();
+
+-- 3. Backfill: existing members with profile_id get timestamps from profiles.created_at
+UPDATE personen p SET
+  invited_at = COALESCE(p.invited_at, pr.created_at),
+  invitation_accepted_at = COALESCE(p.invitation_accepted_at, pr.created_at)
+FROM profiles pr
+WHERE p.profile_id = pr.id AND p.profile_id IS NOT NULL AND p.invitation_accepted_at IS NULL;


### PR DESCRIPTION
## Summary

- **Root cause**: `link_profile_to_person()` DB trigger caused `inviteUserByEmail()` to fail with "Database error saving new user" due to a 4-level nested trigger chain: `auth.users INSERT → handle_new_user() → profiles INSERT → link_profile_to_person() → personen UPDATE → audit_trigger_function()`. The audit system's `log_audit_event()` fails in the trigger context where there's no authenticated user session.
- **Fix**: Made `link_profile_to_person()` a permanent no-op and moved profile linking to application code in `getUserProfile()`. When a user first logs in, the app detects an unlinked personen record matching their email and automatically sets `profile_id` + `invitation_accepted_at`.
- Added migration SQL that also applies the `set_invitation_accepted_at` trigger and backfills existing members.

## Changed files

| File | Change |
|------|--------|
| `apps/web/lib/supabase/server.ts` | Auto-link profile to personen on first login |
| `supabase/migrations/20260302000000_fix_link_profile_trigger.sql` | No-op trigger + acceptance trigger + backfill |

## Test plan

- [ ] Run migration SQL on Supabase
- [ ] Invite a user via Mitglieder detail page → should succeed (no "Database error")
- [ ] Verify `invited_at` is set, badge shows "Eingeladen"
- [ ] Accept invite, log in → verify `profile_id` and `invitation_accepted_at` are set
- [ ] Verify badge changes to "Aktiv"
- [ ] `npm run typecheck` ✅
- [ ] `npm run lint` ✅  
- [ ] `npm run test:run` ✅ (96/96)

🤖 Generated with [Claude Code](https://claude.com/claude-code)