### PR TITLE
feat: add onboarding flow after first login (#328)

### DIFF
--- a/apps/web/app/(protected)/willkommen/page.tsx
+++ b/apps/web/app/(protected)/willkommen/page.tsx
@@ -1,70 +1,118 @@
 import Link from 'next/link'
+import { redirect } from 'next/navigation'
 import { getUserProfile } from '@/lib/supabase/server'
+import { ROLE_START_PAGES } from '@/lib/navigation'
+import { OnboardingWizard } from '@/components/onboarding/OnboardingWizard'
+import { getOnboardingPersonData } from '@/lib/actions/onboarding'
 
 export default async function WillkommenPage() {
   const profile = await getUserProfile()
 
-  return (
-    <div className="space-y-6">
-      {/* Header */}
-      <div>
-        <h1 className="text-2xl font-semibold text-neutral-900">
-          Willkommen bei BackstagePass
-        </h1>
-        <p className="mt-1 text-neutral-600">
-          Das Verwaltungssystem der Theatergruppe Widen
-        </p>
-      </div>
+  if (!profile) {
+    redirect('/login')
+  }
 
-      {/* Welcome Card */}
-      <div className="rounded-xl border border-neutral-200 bg-white p-6">
-        <h2 className="mb-4 text-lg font-semibold text-neutral-900">
-          Hallo{profile?.email ? ` ${profile.email}` : ''}!
-        </h2>
-        <p className="mb-4 text-neutral-600">
-          Du bist als Freund der Theatergruppe Widen registriert. Hier kannst
-          du unsere aktuellen Veranstaltungen einsehen und dich über unser
-          Programm informieren.
-        </p>
-        <p className="text-neutral-600">
-          Möchtest du aktiver mitmachen? Wende dich gerne an uns - wir freuen
-          uns immer über neue Helfer und Mitglieder!
-        </p>
-      </div>
+  const startPage = ROLE_START_PAGES[profile.role]
 
-      {/* Quick Links */}
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-        <Link
-          href="/veranstaltungen"
-          className="rounded-xl border border-neutral-200 bg-white p-6 transition-colors hover:border-neutral-300"
-        >
-          <h3 className="mb-2 font-semibold text-neutral-900">
-            Veranstaltungen
+  // Case 1: Onboarding not completed → show wizard
+  if (!profile.onboarding_completed) {
+    const personData = await getOnboardingPersonData()
+
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <OnboardingWizard
+          displayName={profile.display_name}
+          vorname={personData?.vorname ?? null}
+          initialData={
+            personData
+              ? {
+                  telefon: personData.telefon,
+                  notfallkontakt_name: personData.notfallkontakt_name,
+                  notfallkontakt_telefon: personData.notfallkontakt_telefon,
+                  notfallkontakt_beziehung:
+                    personData.notfallkontakt_beziehung,
+                  skills: personData.skills,
+                }
+              : null
+          }
+          startPage={startPage}
+        />
+      </div>
+    )
+  }
+
+  // Case 2: Onboarding completed + FREUNDE → show static welcome page
+  if (profile.role === 'FREUNDE') {
+    return (
+      <div className="space-y-6">
+        {/* Header */}
+        <div>
+          <h1 className="text-2xl font-semibold text-neutral-900">
+            Willkommen bei BackstagePass
+          </h1>
+          <p className="mt-1 text-neutral-600">
+            Das Verwaltungssystem der Theatergruppe Widen
+          </p>
+        </div>
+
+        {/* Welcome Card */}
+        <div className="rounded-xl border border-neutral-200 bg-white p-6">
+          <h2 className="mb-4 text-lg font-semibold text-neutral-900">
+            Hallo{profile.display_name ? ` ${profile.display_name}` : ''}!
+          </h2>
+          <p className="mb-4 text-neutral-600">
+            Du bist als Freund der Theatergruppe Widen registriert. Hier kannst
+            du unsere aktuellen Veranstaltungen einsehen und dich über unser
+            Programm informieren.
+          </p>
+          <p className="text-neutral-600">
+            Möchtest du aktiver mitmachen? Wende dich gerne an uns - wir freuen
+            uns immer über neue Helfer und Mitglieder!
+          </p>
+        </div>
+
+        {/* Quick Links */}
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <Link
+            href="/veranstaltungen"
+            className="rounded-xl border border-neutral-200 bg-white p-6 transition-colors hover:border-neutral-300"
+          >
+            <h3 className="mb-2 font-semibold text-neutral-900">
+              Veranstaltungen
+            </h3>
+            <p className="text-sm text-neutral-600">
+              Aktuelle und kommende Veranstaltungen der TGW
+            </p>
+          </Link>
+
+          <Link
+            href="/profile"
+            className="rounded-xl border border-neutral-200 bg-white p-6 transition-colors hover:border-neutral-300"
+          >
+            <h3 className="mb-2 font-semibold text-neutral-900">
+              Mein Profil
+            </h3>
+            <p className="text-sm text-neutral-600">
+              Deine Kontaktdaten und Einstellungen verwalten
+            </p>
+          </Link>
+        </div>
+
+        {/* CTA for becoming a member */}
+        <div className="rounded-xl border border-blue-200 bg-blue-50 p-6">
+          <h3 className="font-semibold text-blue-900">
+            Interesse am Mitmachen?
           </h3>
-          <p className="text-sm text-neutral-600">
-            Aktuelle und kommende Veranstaltungen der TGW
+          <p className="mt-2 text-sm text-blue-700">
+            Wir freuen uns immer über neue Gesichter! Ob als Helfer bei
+            Veranstaltungen oder als aktives Mitglied - bei uns ist jeder
+            willkommen.
           </p>
-        </Link>
-
-        <Link
-          href="/profile"
-          className="rounded-xl border border-neutral-200 bg-white p-6 transition-colors hover:border-neutral-300"
-        >
-          <h3 className="mb-2 font-semibold text-neutral-900">Mein Profil</h3>
-          <p className="text-sm text-neutral-600">
-            Deine Kontaktdaten und Einstellungen verwalten
-          </p>
-        </Link>
+        </div>
       </div>
+    )
+  }
 
-      {/* CTA for becoming a member */}
-      <div className="rounded-xl border border-blue-200 bg-blue-50 p-6">
-        <h3 className="font-semibold text-blue-900">Interesse am Mitmachen?</h3>
-        <p className="mt-2 text-sm text-blue-700">
-          Wir freuen uns immer über neue Gesichter! Ob als Helfer bei Veranstaltungen
-          oder als aktives Mitglied - bei uns ist jeder willkommen.
-        </p>
-      </div>
-    </div>
-  )
+  // Case 3: Onboarding completed + non-FREUNDE → redirect to start page
+  redirect(startPage as never)
 }

--- a/apps/web/app/actions/profile.ts
+++ b/apps/web/app/actions/profile.ts
@@ -46,7 +46,7 @@ export async function getProfile() {
 
   const { data: profile } = await supabase
     .from('profiles')
-    .select('id, email, display_name, role, created_at, updated_at')
+    .select('id, email, display_name, role, onboarding_completed, created_at, updated_at')
     .eq('id', user.id)
     .single()
 
@@ -59,7 +59,7 @@ export async function getAllUsers(search?: string) {
 
   let query = supabase
     .from('profiles')
-    .select('id, email, display_name, role, created_at, updated_at')
+    .select('id, email, display_name, role, onboarding_completed, created_at, updated_at')
     .order('created_at', { ascending: false })
 
   if (search && search.trim()) {

--- a/apps/web/components/onboarding/OnboardingWizard.tsx
+++ b/apps/web/components/onboarding/OnboardingWizard.tsx
@@ -1,0 +1,226 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Input } from '@/components/ui/Input'
+import { TagInput } from '@/components/ui/TagInput'
+import {
+  completeOnboarding,
+  skipOnboarding,
+} from '@/lib/actions/onboarding'
+import type { OnboardingProfileData } from '@/lib/validations/onboarding'
+
+interface OnboardingWizardProps {
+  displayName: string | null
+  vorname: string | null
+  initialData: {
+    telefon: string | null
+    notfallkontakt_name: string | null
+    notfallkontakt_telefon: string | null
+    notfallkontakt_beziehung: string | null
+    skills: string[]
+  } | null
+  startPage: string
+}
+
+export function OnboardingWizard({
+  displayName,
+  vorname,
+  initialData,
+  startPage,
+}: OnboardingWizardProps) {
+  const router = useRouter()
+  const [step, setStep] = useState(1)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Form state
+  const [telefon, setTelefon] = useState(initialData?.telefon ?? '')
+  const [notfallkontaktName, setNotfallkontaktName] = useState(
+    initialData?.notfallkontakt_name ?? ''
+  )
+  const [notfallkontaktTelefon, setNotfallkontaktTelefon] = useState(
+    initialData?.notfallkontakt_telefon ?? ''
+  )
+  const [notfallkontaktBeziehung, setNotfallkontaktBeziehung] = useState(
+    initialData?.notfallkontakt_beziehung ?? ''
+  )
+  const [skills, setSkills] = useState<string[]>(initialData?.skills ?? [])
+
+  const greetingName = vorname || displayName || ''
+
+  async function handleSkip() {
+    setLoading(true)
+    setError(null)
+    const result = await skipOnboarding()
+    if (result.success) {
+      router.push(startPage as never)
+    } else {
+      setError(result.error ?? 'Ein Fehler ist aufgetreten')
+      setLoading(false)
+    }
+  }
+
+  async function handleComplete() {
+    setLoading(true)
+    setError(null)
+
+    const data: OnboardingProfileData = {
+      telefon: telefon || null,
+      notfallkontakt_name: notfallkontaktName || null,
+      notfallkontakt_telefon: notfallkontaktTelefon || null,
+      notfallkontakt_beziehung: notfallkontaktBeziehung || null,
+      skills: skills.length > 0 ? skills : undefined,
+    }
+
+    const result = await completeOnboarding(data)
+    if (result.success) {
+      router.push(startPage as never)
+    } else {
+      setError(result.error ?? 'Ein Fehler ist aufgetreten')
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-lg space-y-6">
+      {/* Step Indicator */}
+      <div className="flex items-center justify-center gap-2">
+        <div
+          className={`h-2.5 w-2.5 rounded-full ${
+            step >= 1 ? 'bg-primary-600' : 'bg-neutral-300'
+          }`}
+        />
+        <div
+          className={`h-2.5 w-2.5 rounded-full ${
+            step >= 2 ? 'bg-primary-600' : 'bg-neutral-300'
+          }`}
+        />
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-error-200 bg-error-50 p-3 text-sm text-error-700">
+          {error}
+        </div>
+      )}
+
+      {step === 1 && (
+        <div className="rounded-xl border border-neutral-200 bg-white p-6">
+          <h1 className="mb-4 text-2xl font-semibold text-neutral-900">
+            Willkommen bei BackstagePass
+            {greetingName ? `, ${greetingName}` : ''}!
+          </h1>
+          <p className="mb-4 text-neutral-600">
+            Schön, dass du dabei bist! BackstagePass ist das Verwaltungssystem
+            der Theatergruppe Widen. Hier kannst du deine Einsätze verwalten,
+            dich für Veranstaltungen anmelden und vieles mehr.
+          </p>
+          <p className="mb-6 text-neutral-600">
+            Im nächsten Schritt kannst du optional dein Profil vervollständigen.
+            Alle Angaben sind freiwillig und können auch später jederzeit
+            geändert werden.
+          </p>
+          <div className="flex gap-3">
+            <button
+              onClick={() => setStep(2)}
+              disabled={loading}
+              className="rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-700 disabled:opacity-50"
+            >
+              Profil vervollständigen
+            </button>
+            <button
+              onClick={handleSkip}
+              disabled={loading}
+              className="rounded-lg px-4 py-2 text-sm font-medium text-neutral-600 transition-colors hover:bg-neutral-100 disabled:opacity-50"
+            >
+              {loading ? 'Wird geladen...' : 'Überspringen'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {step === 2 && (
+        <div className="rounded-xl border border-neutral-200 bg-white p-6">
+          <h2 className="mb-4 text-lg font-semibold text-neutral-900">
+            Profil vervollständigen
+          </h2>
+          <p className="mb-6 text-sm text-neutral-500">
+            Alle Angaben sind freiwillig.
+          </p>
+
+          <div className="space-y-4">
+            <Input
+              label="Telefon"
+              type="tel"
+              value={telefon}
+              onChange={(e) => setTelefon(e.target.value)}
+              placeholder="+41 79 123 45 67"
+            />
+
+            <div className="border-t border-neutral-100 pt-4">
+              <h3 className="mb-3 text-sm font-medium text-neutral-700">
+                Notfallkontakt
+              </h3>
+              <div className="space-y-3">
+                <Input
+                  label="Name"
+                  value={notfallkontaktName}
+                  onChange={(e) => setNotfallkontaktName(e.target.value)}
+                />
+                <Input
+                  label="Telefon"
+                  type="tel"
+                  value={notfallkontaktTelefon}
+                  onChange={(e) => setNotfallkontaktTelefon(e.target.value)}
+                  placeholder="+41 79 123 45 67"
+                />
+                <Input
+                  label="Beziehung"
+                  value={notfallkontaktBeziehung}
+                  onChange={(e) => setNotfallkontaktBeziehung(e.target.value)}
+                  placeholder="z.B. Partner/in, Elternteil"
+                />
+              </div>
+            </div>
+
+            <div className="border-t border-neutral-100 pt-4">
+              <TagInput
+                label="Fähigkeiten / Skills"
+                value={skills}
+                onChange={setSkills}
+                placeholder="z.B. Beleuchtung, Bühnenbau, Maske..."
+                helperText="Drücke Enter oder Komma zum Hinzufügen"
+                maxTags={20}
+                maxTagLength={50}
+              />
+            </div>
+          </div>
+
+          <div className="mt-6 flex gap-3">
+            <button
+              onClick={handleComplete}
+              disabled={loading}
+              className="rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-700 disabled:opacity-50"
+            >
+              {loading ? 'Wird gespeichert...' : 'Speichern & Weiter'}
+            </button>
+            <button
+              onClick={() => setStep(1)}
+              disabled={loading}
+              className="rounded-lg px-4 py-2 text-sm font-medium text-neutral-600 transition-colors hover:bg-neutral-100 disabled:opacity-50"
+            >
+              Zurück
+            </button>
+            <button
+              onClick={handleSkip}
+              disabled={loading}
+              className="rounded-lg px-4 py-2 text-sm font-medium text-neutral-600 transition-colors hover:bg-neutral-100 disabled:opacity-50"
+            >
+              Überspringen
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/lib/actions/onboarding.ts
+++ b/apps/web/lib/actions/onboarding.ts
@@ -1,0 +1,149 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { createClient } from '../supabase/server'
+import {
+  onboardingProfileSchema,
+  type OnboardingProfileData,
+} from '../validations/onboarding'
+
+export async function completeOnboarding(
+  data: OnboardingProfileData
+): Promise<{ success: boolean; error?: string }> {
+  const validated = onboardingProfileSchema.parse(data)
+
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return { success: false, error: 'Nicht angemeldet' }
+  }
+
+  // Get the user's profile to find their email
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('email')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile?.email) {
+    return { success: false, error: 'Profil nicht gefunden' }
+  }
+
+  // Find the person linked to this email
+  const { data: person } = await supabase
+    .from('personen')
+    .select('id')
+    .eq('email', profile.email)
+    .maybeSingle()
+
+  // Update personen fields if person exists
+  if (person) {
+    const { error: personError } = await supabase
+      .from('personen')
+      .update({
+        telefon: validated.telefon ?? null,
+        notfallkontakt_name: validated.notfallkontakt_name ?? null,
+        notfallkontakt_telefon: validated.notfallkontakt_telefon ?? null,
+        notfallkontakt_beziehung: validated.notfallkontakt_beziehung ?? null,
+        skills: validated.skills ?? [],
+      } as never)
+      .eq('id', person.id)
+
+    if (personError) {
+      console.error('Error updating person during onboarding:', personError)
+      return { success: false, error: personError.message }
+    }
+  }
+
+  // Mark onboarding as completed
+  const { error: profileError } = await supabase
+    .from('profiles')
+    .update({ onboarding_completed: true } as never)
+    .eq('id', user.id)
+
+  if (profileError) {
+    console.error('Error completing onboarding:', profileError)
+    return { success: false, error: profileError.message }
+  }
+
+  revalidatePath('/willkommen')
+  revalidatePath('/dashboard')
+  return { success: true }
+}
+
+export async function skipOnboarding(): Promise<{
+  success: boolean
+  error?: string
+}> {
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return { success: false, error: 'Nicht angemeldet' }
+  }
+
+  const { error } = await supabase
+    .from('profiles')
+    .update({ onboarding_completed: true } as never)
+    .eq('id', user.id)
+
+  if (error) {
+    console.error('Error skipping onboarding:', error)
+    return { success: false, error: error.message }
+  }
+
+  revalidatePath('/willkommen')
+  revalidatePath('/dashboard')
+  return { success: true }
+}
+
+export async function getOnboardingPersonData(): Promise<{
+  vorname: string
+  telefon: string | null
+  notfallkontakt_name: string | null
+  notfallkontakt_telefon: string | null
+  notfallkontakt_beziehung: string | null
+  skills: string[]
+} | null> {
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) return null
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('email')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile?.email) return null
+
+  const { data: person } = await supabase
+    .from('personen')
+    .select(
+      'vorname, telefon, notfallkontakt_name, notfallkontakt_telefon, notfallkontakt_beziehung, skills'
+    )
+    .eq('email', profile.email)
+    .maybeSingle()
+
+  if (!person) return null
+
+  return {
+    vorname: person.vorname,
+    telefon: person.telefon,
+    notfallkontakt_name: person.notfallkontakt_name,
+    notfallkontakt_telefon: person.notfallkontakt_telefon,
+    notfallkontakt_beziehung: person.notfallkontakt_beziehung,
+    skills: (person.skills as string[]) ?? [],
+  }
+}

--- a/apps/web/lib/supabase/server.ts
+++ b/apps/web/lib/supabase/server.ts
@@ -52,7 +52,7 @@ export async function getUserProfile(): Promise<Profile | null> {
 
   const { data } = await supabase
     .from('profiles')
-    .select('id, email, display_name, role, created_at, updated_at')
+    .select('id, email, display_name, role, onboarding_completed, created_at, updated_at')
     .eq('id', user.id)
     .single()
 

--- a/apps/web/lib/supabase/types.ts
+++ b/apps/web/lib/supabase/types.ts
@@ -277,6 +277,7 @@ export type Profile = {
   email: string
   display_name: string | null
   role: UserRole
+  onboarding_completed: boolean
   created_at: string
   updated_at: string
 }

--- a/apps/web/lib/validations/onboarding.ts
+++ b/apps/web/lib/validations/onboarding.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+
+export const onboardingProfileSchema = z.object({
+  telefon: z.string().max(50).optional().nullable(),
+  notfallkontakt_name: z.string().max(100).optional().nullable(),
+  notfallkontakt_telefon: z.string().max(50).optional().nullable(),
+  notfallkontakt_beziehung: z.string().max(100).optional().nullable(),
+  skills: z.array(z.string().max(50)).max(20).optional(),
+})
+
+export type OnboardingProfileData = z.infer<typeof onboardingProfileSchema>

--- a/supabase/migrations/20260303000000_onboarding_flag.sql
+++ b/supabase/migrations/20260303000000_onboarding_flag.sql
@@ -1,0 +1,27 @@
+-- Migration: Add onboarding_completed flag to profiles
+-- Created: 2026-03-03
+-- Description: Track whether a user has completed the onboarding wizard
+-- after their first login (Issue #328)
+
+-- 1. Add onboarding_completed column (defaults to false for new users)
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS onboarding_completed BOOLEAN NOT NULL DEFAULT false;
+
+-- 2. Backfill all existing profiles to true (they don't need onboarding)
+UPDATE profiles SET onboarding_completed = true WHERE onboarding_completed = false;
+
+-- 3. Update handle_new_user() to explicitly set onboarding_completed = false
+CREATE OR REPLACE FUNCTION handle_new_user()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO public.profiles (id, email, display_name, role, onboarding_completed)
+  VALUES (
+    NEW.id,
+    NEW.email,
+    COALESCE(NEW.raw_user_meta_data->>'display_name', split_part(NEW.email, '@', 1)),
+    'MITGLIED_PASSIV',
+    false
+  );
+  RETURN NEW;
+END;
+$$ language 'plpgsql' SECURITY DEFINER;


### PR DESCRIPTION
## Summary
- Adds `onboarding_completed` boolean flag to `profiles` table with migration (existing profiles backfilled to `true`)
- Redirects first-login users to `/willkommen` via middleware, where a 2-step wizard offers optional profile completion (phone, emergency contact, skills)
- Preserves existing FREUNDE welcome page; non-FREUNDE users with completed onboarding are redirected to their role's start page

## Test plan
- [ ] Verify new user signup → redirected to `/willkommen` with wizard
- [ ] Step 1: greeting with name, "Profil vervollständigen" and "Überspringen" buttons work
- [ ] Step 2: all fields optional, prefilled from personen data, save updates personen + sets flag
- [ ] "Überspringen" at any step sets flag and redirects to start page
- [ ] Existing users are not affected (backfilled to `onboarding_completed = true`)
- [ ] FREUNDE users with completed onboarding see static welcome page as before
- [ ] Middleware exempts `/willkommen` and `/profile` from redirect loop
- [ ] Auth routes redirect to `/willkommen` if onboarding incomplete

🤖 Generated with [Claude Code](https://claude.com/claude-code)