### PR TITLE
fix: add auth callback routes for magic link login

### DIFF
--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server'
+import { createServerClient, type CookieOptions } from '@supabase/ssr'
+
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url)
+  const code = searchParams.get('code')
+  const next = searchParams.get('next') ?? '/dashboard'
+
+  if (code) {
+    const response = NextResponse.redirect(`${origin}${next}`)
+
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          getAll() {
+            return request.headers
+              .get('cookie')
+              ?.split('; ')
+              .map((c) => {
+                const [name, ...rest] = c.split('=')
+                return { name, value: rest.join('=') }
+              }) ?? []
+          },
+          setAll(
+            cookiesToSet: {
+              name: string
+              value: string
+              options?: CookieOptions
+            }[]
+          ) {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              response.cookies.set(name, value, options)
+            )
+          },
+        },
+      }
+    )
+
+    const { error } = await supabase.auth.exchangeCodeForSession(code)
+
+    if (!error) {
+      return response
+    }
+  }
+
+  // Auth code exchange failed — redirect to login with error
+  return NextResponse.redirect(`${origin}/login?error=auth_callback_failed`)
+}

--- a/apps/web/app/auth/confirm/route.ts
+++ b/apps/web/app/auth/confirm/route.ts
@@ -1,0 +1,23 @@
+import { type EmailOtpType } from '@supabase/supabase-js'
+import { type NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const token_hash = searchParams.get('token_hash')
+  const type = searchParams.get('type') as EmailOtpType | null
+  const next = searchParams.get('next') ?? '/dashboard'
+
+  if (token_hash && type) {
+    const supabase = await createClient()
+    const { error } = await supabase.auth.verifyOtp({ type, token_hash })
+
+    if (!error) {
+      return NextResponse.redirect(new URL(next, request.url))
+    }
+  }
+
+  return NextResponse.redirect(
+    new URL('/login?error=link_invalid', request.url)
+  )
+}


### PR DESCRIPTION
## Summary
- Added `/auth/confirm` route for server-side token_hash verification (magic links, invites, email confirmation, password reset)
- Added `/auth/callback` route for PKCE code exchange
- Updated all Supabase email templates to use `/auth/confirm?token_hash={{ .TokenHash }}&type=...` instead of `{{ .ConfirmationURL }}`
- Templates now in German with BackstagePass branding

## Why
Magic links and invite emails used Supabase's implicit flow, redirecting with tokens in the URL hash fragment (`#access_token=...`). Server-side Next.js routes can't read hash fragments, so the session was never established after clicking the link.

## Test plan
- [ ] Send magic link → click → verify login works
- [ ] Send invite → click → verify account creation and onboarding
- [ ] Password reset → click → verify reset form loads with active session

🤖 Generated with [Claude Code](https://claude.com/claude-code)