### PR TITLE
feat: Dashboard-Konsolidierung mit Profil-Checkliste & Einsätze-Widget

### DIFF
--- a/apps/web/app/(protected)/dashboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/page.tsx
@@ -25,7 +25,9 @@ import { HelfereinsatzHistorie } from '@/components/mein-bereich/HelfereinsatzHi
 import {
   UpcomingEventsWidget,
   MitgliederHelferEventsWidget,
+  HelferEinsaetzeWidget,
 } from '@/components/mein-bereich/DashboardWidgets'
+import { ProfileCompletionWidget } from '@/components/mein-bereich/ProfileCompletionWidget'
 import type { KalenderTermin } from '@/components/mein-bereich/MiniKalender'
 
 export const metadata = {
@@ -453,7 +455,7 @@ export default async function DashboardPage({
   // Try to find the person linked to this user
   const { data: person } = await supabase
     .from('personen')
-    .select('id, vorname, nachname, email, telefon, strasse, plz, ort, geburtstag')
+    .select('id, vorname, nachname, email, telefon, strasse, plz, ort, geburtstag, notfallkontakt_name, notfallkontakt_telefon, notfallkontakt_beziehung, skills')
     .eq('email', profile.email)
     .single()
 
@@ -549,7 +551,10 @@ export default async function DashboardPage({
 
           {/* Right Column - Profile & Events */}
           <div className="space-y-6 lg:col-span-2">
-            <EditableProfileCard person={person} role={profile.role} />
+            <ProfileCompletionWidget person={person} />
+            <div id="profile-card">
+              <EditableProfileCard person={person} role={profile.role} />
+            </div>
             <UpcomingEventsWidget anmeldungen={upcomingAnmeldungen} />
 
             {/* CTA for passive members */}
@@ -646,16 +651,22 @@ export default async function DashboardPage({
 
           {/* Main Content Area */}
           <div className="space-y-6 lg:col-span-8 xl:col-span-9">
+            {/* Profile Completion */}
+            <ProfileCompletionWidget person={person} />
+
             {/* Profile Card */}
-            <EditableProfileCard
-              person={person}
-              role={profile.role}
-            />
+            <div id="profile-card">
+              <EditableProfileCard
+                person={person}
+                role={profile.role}
+              />
+            </div>
 
             {/* Content Widgets */}
-            <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
+            <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
               <UpcomingEventsWidget anmeldungen={upcomingAnmeldungen} />
               <MitgliederHelferEventsWidget events={mitgliederHelferEvents} />
+              <HelferEinsaetzeWidget einsaetze={verfuegbareEinsaetze ?? []} />
             </div>
 
             {/* History Section */}

--- a/apps/web/components/mein-bereich/EditableProfileCard.tsx
+++ b/apps/web/components/mein-bereich/EditableProfileCard.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import type { UserRole } from '@/lib/supabase/types'
 import { USER_ROLE_LABELS } from '@/lib/supabase/types'
 import { updateOwnProfile } from '@/lib/actions/personen'
+import { TagInput } from '@/components/ui/TagInput'
 
 interface EditableProfileCardProps {
   person: {
@@ -17,6 +18,10 @@ interface EditableProfileCardProps {
     plz?: string | null
     ort?: string | null
     geburtstag?: string | null
+    notfallkontakt_name?: string | null
+    notfallkontakt_telefon?: string | null
+    notfallkontakt_beziehung?: string | null
+    skills?: string[] | null
   } | null
   role?: UserRole
   stundenTotal?: number
@@ -41,6 +46,10 @@ export function EditableProfileCard({
     strasse: person?.strasse || '',
     plz: person?.plz || '',
     ort: person?.ort || '',
+    notfallkontakt_name: person?.notfallkontakt_name || '',
+    notfallkontakt_telefon: person?.notfallkontakt_telefon || '',
+    notfallkontakt_beziehung: person?.notfallkontakt_beziehung || '',
+    skills: person?.skills || [] as string[],
   })
 
   const displayName = person
@@ -65,6 +74,10 @@ export function EditableProfileCard({
         strasse: formData.strasse || null,
         plz: formData.plz || null,
         ort: formData.ort || null,
+        notfallkontakt_name: formData.notfallkontakt_name || null,
+        notfallkontakt_telefon: formData.notfallkontakt_telefon || null,
+        notfallkontakt_beziehung: formData.notfallkontakt_beziehung || null,
+        skills: formData.skills.length > 0 ? formData.skills : [],
       })
 
       if (result.success) {
@@ -81,6 +94,10 @@ export function EditableProfileCard({
       strasse: person?.strasse || '',
       plz: person?.plz || '',
       ort: person?.ort || '',
+      notfallkontakt_name: person?.notfallkontakt_name || '',
+      notfallkontakt_telefon: person?.notfallkontakt_telefon || '',
+      notfallkontakt_beziehung: person?.notfallkontakt_beziehung || '',
+      skills: person?.skills || [],
     })
     setIsEditing(false)
     setError(null)
@@ -216,6 +233,64 @@ export function EditableProfileCard({
             </div>
           )}
 
+          {/* Notfallkontakt */}
+          <div className="border-t border-neutral-200 pt-4">
+            <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-neutral-500">
+              Notfallkontakt
+            </p>
+            <div className="space-y-3">
+              <div>
+                <label className="mb-1 block text-xs font-medium text-neutral-500">
+                  Name
+                </label>
+                <input
+                  type="text"
+                  value={formData.notfallkontakt_name}
+                  onChange={(e) => setFormData({ ...formData, notfallkontakt_name: e.target.value })}
+                  className="w-full rounded-lg border border-neutral-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                  placeholder="z.B. Maria Müller"
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-2">
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-neutral-500">
+                    Telefon
+                  </label>
+                  <input
+                    type="tel"
+                    value={formData.notfallkontakt_telefon}
+                    onChange={(e) => setFormData({ ...formData, notfallkontakt_telefon: e.target.value })}
+                    className="w-full rounded-lg border border-neutral-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                    placeholder="079 123 45 67"
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-neutral-500">
+                    Beziehung
+                  </label>
+                  <input
+                    type="text"
+                    value={formData.notfallkontakt_beziehung}
+                    onChange={(e) => setFormData({ ...formData, notfallkontakt_beziehung: e.target.value })}
+                    className="w-full rounded-lg border border-neutral-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                    placeholder="z.B. Ehepartner"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Skills */}
+          <div className="border-t border-neutral-200 pt-4">
+            <TagInput
+              label="Skills"
+              value={formData.skills}
+              onChange={(tags) => setFormData({ ...formData, skills: tags })}
+              placeholder="Skill eingeben..."
+              helperText="Enter oder Komma zum Hinzufügen"
+            />
+          </div>
+
           {/* Action Buttons */}
           <div className="flex justify-end gap-2 pt-2">
             <button
@@ -276,6 +351,39 @@ export function EditableProfileCard({
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 15.546c-.523 0-1.046.151-1.5.454a2.704 2.704 0 01-3 0 2.704 2.704 0 00-3 0 2.704 2.704 0 01-3 0 2.704 2.704 0 00-3 0 2.704 2.704 0 01-3 0 2.701 2.701 0 00-1.5-.454M9 6v2m3-2v2m3-2v2M9 3h.01M12 3h.01M15 3h.01M21 21v-7a2 2 0 00-2-2H5a2 2 0 00-2 2v7h18zm-3-9v-2a2 2 0 00-2-2H8a2 2 0 00-2 2v2h12z" />
               </svg>
               <span className="text-sm text-neutral-600">{formatGeburtsdatum(person.geburtstag)}</span>
+            </div>
+          )}
+
+          {/* Notfallkontakt */}
+          {person.notfallkontakt_name && (
+            <div className="flex items-start gap-3 px-4 py-3">
+              <svg className="mt-0.5 h-4 w-4 text-neutral-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18.364 5.636l-3.536 3.536m0 5.656l3.536 3.536M9.172 9.172L5.636 5.636m3.536 9.192l-3.536 3.536M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-5 0a4 4 0 11-8 0 4 4 0 018 0z" />
+              </svg>
+              <div className="text-sm text-neutral-600">
+                <p className="font-medium">Notfallkontakt</p>
+                <p>{person.notfallkontakt_name}{person.notfallkontakt_beziehung ? ` (${person.notfallkontakt_beziehung})` : ''}</p>
+                {person.notfallkontakt_telefon && <p>{person.notfallkontakt_telefon}</p>}
+              </div>
+            </div>
+          )}
+
+          {/* Skills */}
+          {person.skills && person.skills.length > 0 && (
+            <div className="flex items-start gap-3 px-4 py-3">
+              <svg className="mt-0.5 h-4 w-4 text-neutral-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+              </svg>
+              <div className="flex flex-wrap gap-1">
+                {person.skills.map((skill) => (
+                  <span
+                    key={skill}
+                    className="rounded-full bg-primary-100 px-2 py-0.5 text-xs font-medium text-primary-700"
+                  >
+                    {skill}
+                  </span>
+                ))}
+              </div>
             </div>
           )}
 

--- a/apps/web/components/mein-bereich/ProfileCompletionWidget.tsx
+++ b/apps/web/components/mein-bereich/ProfileCompletionWidget.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+interface ProfileCompletionWidgetProps {
+  person: {
+    telefon?: string | null
+    strasse?: string | null
+    plz?: string | null
+    ort?: string | null
+    notfallkontakt_name?: string | null
+    notfallkontakt_telefon?: string | null
+    skills?: string[] | null
+  } | null
+}
+
+interface CheckItem {
+  label: string
+  completed: boolean
+}
+
+export function ProfileCompletionWidget({ person }: ProfileCompletionWidgetProps) {
+  if (!person) return null
+
+  const checks: CheckItem[] = [
+    {
+      label: 'Telefonnummer',
+      completed: !!person.telefon,
+    },
+    {
+      label: 'Adresse',
+      completed: !!(person.strasse && person.plz && person.ort),
+    },
+    {
+      label: 'Notfallkontakt',
+      completed: !!(person.notfallkontakt_name && person.notfallkontakt_telefon),
+    },
+    {
+      label: 'Skills',
+      completed: !!(person.skills && person.skills.length > 0),
+    },
+  ]
+
+  const completedCount = checks.filter((c) => c.completed).length
+  const totalCount = checks.length
+
+  // Hide when all complete
+  if (completedCount === totalCount) return null
+
+  const percentage = Math.round((completedCount / totalCount) * 100)
+
+  return (
+    <div className="rounded-xl border border-amber-200 bg-amber-50 p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-amber-900">
+          Profil vervollständigen
+        </h3>
+        <span className="text-xs font-medium text-amber-700">
+          {completedCount} von {totalCount}
+        </span>
+      </div>
+
+      {/* Progress bar */}
+      <div className="mb-3 h-2 overflow-hidden rounded-full bg-amber-200">
+        <div
+          className="h-full rounded-full bg-amber-500 transition-all duration-300"
+          style={{ width: `${percentage}%` }}
+        />
+      </div>
+
+      {/* Checklist */}
+      <ul className="space-y-1.5">
+        {checks.map((check) => (
+          <li key={check.label} className="flex items-center gap-2">
+            {check.completed ? (
+              <svg className="h-4 w-4 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+            ) : (
+              <svg className="h-4 w-4 text-amber-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            )}
+            <span
+              className={`text-sm ${
+                check.completed
+                  ? 'text-neutral-500 line-through'
+                  : 'text-amber-900'
+              }`}
+            >
+              {check.label}
+            </span>
+            {!check.completed && (
+              <a
+                href="#profile-card"
+                className="ml-auto text-xs font-medium text-amber-700 hover:text-amber-900"
+              >
+                Ausfüllen
+              </a>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/apps/web/lib/actions/personen.ts
+++ b/apps/web/lib/actions/personen.ts
@@ -354,7 +354,7 @@ export async function deletePerson(
  * Only allows updating certain fields and validates ownership
  */
 export async function updateOwnProfile(
-  personData: Pick<PersonUpdate, 'telefon' | 'strasse' | 'plz' | 'ort'>
+  personData: Pick<PersonUpdate, 'telefon' | 'strasse' | 'plz' | 'ort' | 'notfallkontakt_name' | 'notfallkontakt_telefon' | 'notfallkontakt_beziehung' | 'skills'>
 ): Promise<{ success: boolean; error?: string }> {
   if (USE_DUMMY_DATA) {
     revalidatePath('/mein-bereich')
@@ -403,6 +403,10 @@ export async function updateOwnProfile(
       strasse: personData.strasse,
       plz: personData.plz,
       ort: personData.ort,
+      notfallkontakt_name: personData.notfallkontakt_name,
+      notfallkontakt_telefon: personData.notfallkontakt_telefon,
+      notfallkontakt_beziehung: personData.notfallkontakt_beziehung,
+      skills: personData.skills,
     } as never)
     .eq('id', person.id)
 
@@ -412,6 +416,7 @@ export async function updateOwnProfile(
   }
 
   revalidatePath('/mein-bereich')
+  revalidatePath('/dashboard')
   return { success: true }
 }
 


### PR DESCRIPTION
## Summary

- **Profil-Vollständigkeits-Checkliste**: Neues `ProfileCompletionWidget` zeigt Mitgliedern fehlende Profilfelder (Telefon, Adresse, Notfallkontakt, Skills) mit Fortschrittsbalken und "Ausfüllen"-Links. Blendet sich automatisch aus bei 4/4 komplett.
- **Notfallkontakt & Skills im Profil**: `EditableProfileCard` und `updateOwnProfile` um Notfallkontakt (Name, Telefon, Beziehung) und Skills (TagInput) erweitert — sowohl Edit- als auch View-Modus.
- **Einsätze-Widget aktiviert**: Das bereits vorhandene `HelferEinsaetzeWidget` wird jetzt im aktiven Mitglieder-Dashboard angezeigt (3-spaltig auf XL). Die Daten wurden schon abgefragt, aber nie gerendert.

## Geänderte Dateien

| Datei | Änderung |
|---|---|
| `lib/actions/personen.ts` | `updateOwnProfile` um Notfallkontakt + Skills erweitert |
| `components/mein-bereich/EditableProfileCard.tsx` | Notfallkontakt + Skills (Edit + View) |
| `components/mein-bereich/ProfileCompletionWidget.tsx` | Neu: Profil-Checkliste |
| `app/(protected)/dashboard/page.tsx` | Query erweitert, neue Widgets integriert, 3-Spalten-Layout |

## Test plan

- [ ] Dashboard als aktives Mitglied: Profil-Checkliste sichtbar wenn Felder fehlen
- [ ] Profil bearbeiten → Notfallkontakt + Skills ausfüllen → Speichern → Checkliste aktualisiert
- [ ] Checkliste verschwindet bei 4/4 komplett
- [ ] Offene Einsätze-Widget zeigt verfügbare Helfereinsätze
- [ ] Dashboard als passives Mitglied → Checkliste sichtbar, kein Einsätze-Widget
- [ ] `npm run typecheck` ✅
- [ ] `npm run lint` ✅
- [ ] `npm run build` ✅
- [ ] `npm run test:run` ✅ (96/96)

🤖 Generated with [Claude Code](https://claude.com/claude-code)