### PR TITLE
feat: cross-system conflict detection for assignments (#343)

### DIFF
--- a/apps/web/app/(protected)/auffuehrungen/[id]/page.tsx
+++ b/apps/web/app/(protected)/auffuehrungen/[id]/page.tsx
@@ -213,6 +213,7 @@ export default async function AuffuehrungDetailPage({ params }: PageProps) {
               zuweisungen={zuweisungen}
               personen={personen}
               canEdit={canEdit}
+              datum={veranstaltung.datum}
             />
           </div>
         </div>

--- a/apps/web/app/(protected)/proben/[id]/page.tsx
+++ b/apps/web/app/(protected)/proben/[id]/page.tsx
@@ -216,6 +216,9 @@ export default async function ProbeDetailPage({
         personen={personen ?? []}
         canEdit={canEdit}
         hasSzenen={probeSzenen.length > 0}
+        datum={probe.datum}
+        startzeit={probe.startzeit}
+        endzeit={probe.endzeit}
       />
 
       {/* Notizen (nur für Regie) */}

--- a/apps/web/components/koordination/HelferAssignmentModal.tsx
+++ b/apps/web/components/koordination/HelferAssignmentModal.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { searchHelfer, validateAssignment, assignHelferManual, createExternalAndAssign } from '@/lib/actions/manual-assignment'
 import type { HelferSearchResult, AssignmentValidation } from '@/lib/actions/manual-assignment'
+import { ConflictWarning } from '@/components/ui/ConflictWarning'
 
 interface HelferAssignmentModalProps {
   open: boolean
@@ -310,6 +311,11 @@ export function HelferAssignmentModal({
                       </div>
                     )}
 
+                    {/* Cross-system conflicts */}
+                    {validation.crossSystemConflicts.length > 0 && (
+                      <ConflictWarning conflicts={validation.crossSystemConflicts} />
+                    )}
+
                     {/* Booking limit */}
                     {validation.bookingLimitReached && (
                       <div className="rounded-lg bg-orange-50 p-3">
@@ -324,7 +330,7 @@ export function HelferAssignmentModal({
                     )}
 
                     {/* Override checkbox */}
-                    {(validation.hasConflict || validation.bookingLimitReached) && (
+                    {(validation.hasConflict || validation.bookingLimitReached || validation.crossSystemConflicts.length > 0) && (
                       <label className="flex items-center gap-2">
                         <input
                           type="checkbox"
@@ -339,7 +345,7 @@ export function HelferAssignmentModal({
                     )}
 
                     {/* No conflicts */}
-                    {!validation.hasConflict && !validation.bookingLimitReached && (
+                    {!validation.hasConflict && !validation.bookingLimitReached && validation.crossSystemConflicts.length === 0 && (
                       <div className="rounded-lg bg-green-50 p-3">
                         <p className="text-sm text-green-700">
                           Keine Konflikte - Zuweisung moeglich
@@ -437,7 +443,7 @@ export function HelferAssignmentModal({
             <button
               onClick={handleAssign}
               disabled={!selectedHelfer || isAssigning || isValidating || !!(
-                validation && (validation.hasConflict || validation.bookingLimitReached) && !override
+                validation && (validation.hasConflict || validation.bookingLimitReached || validation.crossSystemConflicts.length > 0) && !override
               )}
               className="rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700 disabled:cursor-not-allowed disabled:opacity-50"
             >

--- a/apps/web/components/ui/ConflictWarning.tsx
+++ b/apps/web/components/ui/ConflictWarning.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+import type { PersonConflict } from '@/lib/supabase/types'
+
+const TYPE_LABELS: Record<string, string> = {
+  verfuegbarkeit: 'Verfuegbarkeit',
+  zuweisung: 'Schichtzuweisung',
+  anmeldung: 'Veranstaltung',
+  probe: 'Probe',
+  helfer: 'Helfereinsatz',
+}
+
+const TYPE_COLORS: Record<string, { bg: string; text: string; border: string }> = {
+  verfuegbarkeit: { bg: 'bg-red-50', text: 'text-red-700', border: 'border-red-200' },
+  zuweisung: { bg: 'bg-yellow-50', text: 'text-yellow-700', border: 'border-yellow-200' },
+  anmeldung: { bg: 'bg-orange-50', text: 'text-orange-700', border: 'border-orange-200' },
+  probe: { bg: 'bg-orange-50', text: 'text-orange-700', border: 'border-orange-200' },
+  helfer: { bg: 'bg-yellow-50', text: 'text-yellow-700', border: 'border-yellow-200' },
+}
+
+interface ConflictWarningProps {
+  conflicts: PersonConflict[]
+  isLoading?: boolean
+  showOverride?: boolean
+  overrideChecked?: boolean
+  onOverrideChange?: (checked: boolean) => void
+}
+
+function formatTime(isoString: string): string {
+  try {
+    const date = new Date(isoString)
+    if (isNaN(date.getTime())) return isoString
+    return date.toLocaleString('de-CH', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  } catch {
+    return isoString
+  }
+}
+
+export function ConflictWarning({
+  conflicts,
+  isLoading,
+  showOverride,
+  overrideChecked,
+  onOverrideChange,
+}: ConflictWarningProps) {
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 rounded-lg border border-neutral-200 bg-neutral-50 p-3 text-sm text-neutral-500">
+        <svg className="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
+          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+        </svg>
+        Pruefe systemweite Konflikte...
+      </div>
+    )
+  }
+
+  if (conflicts.length === 0) return null
+
+  const grouped = conflicts.reduce<Record<string, PersonConflict[]>>((acc, c) => {
+    if (!acc[c.type]) acc[c.type] = []
+    acc[c.type].push(c)
+    return acc
+  }, {})
+
+  return (
+    <div className="space-y-2">
+      <p className="text-sm font-medium text-red-800">
+        Systemweite Konflikte erkannt
+      </p>
+      {Object.entries(grouped).map(([type, items]) => {
+        const colors = TYPE_COLORS[type] || TYPE_COLORS.anmeldung
+        const label = TYPE_LABELS[type] || type
+        return (
+          <div
+            key={type}
+            className={`rounded-lg border ${colors.border} ${colors.bg} p-3`}
+          >
+            <p className={`text-sm font-medium ${colors.text}`}>
+              {label} ({items.length})
+            </p>
+            <ul className="mt-1 space-y-1">
+              {items.map((c) => (
+                <li key={c.reference_id} className={`text-sm ${colors.text}`}>
+                  {c.description}
+                  {c.severity && (
+                    <span className="ml-1 opacity-75">
+                      ({c.severity === 'nicht_verfuegbar' ? 'Nicht verfuegbar' : 'Eingeschraenkt'})
+                    </span>
+                  )}
+                  <span className="ml-1 opacity-75">
+                    &mdash; {formatTime(c.start_time)} bis {formatTime(c.end_time)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )
+      })}
+      {showOverride && onOverrideChange && (
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={overrideChecked}
+            onChange={(e) => onOverrideChange(e.target.checked)}
+            className="h-4 w-4 rounded border-neutral-300 text-primary-600"
+          />
+          <span className="text-sm text-neutral-700">
+            Trotzdem zuweisen (Admin-Override)
+          </span>
+        </label>
+      )}
+    </div>
+  )
+}

--- a/apps/web/lib/actions/conflict-check.test.ts
+++ b/apps/web/lib/actions/conflict-check.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit Tests for Cross-System Conflict Detection
+ * Issue #343
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createMockClient } from '@/tests/mocks/supabase'
+
+const mockSupabase = createMockClient()
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(() => Promise.resolve(mockSupabase)),
+}))
+
+const mockRequirePermission = vi.fn()
+
+vi.mock('@/lib/supabase/auth-helpers', () => ({
+  requirePermission: (...args: unknown[]) => mockRequirePermission(...args),
+}))
+
+import { checkPersonConflicts } from './conflict-check'
+
+describe('checkPersonConflicts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns no conflicts when RPC returns empty', async () => {
+    mockSupabase.rpc.mockResolvedValueOnce({
+      data: { has_conflicts: false, conflicts: [] },
+      error: null,
+    })
+
+    const result = await checkPersonConflicts(
+      'person-1',
+      '2026-03-01 10:00:00 Europe/Zurich',
+      '2026-03-01 12:00:00 Europe/Zurich'
+    )
+
+    expect(result.has_conflicts).toBe(false)
+    expect(result.conflicts).toEqual([])
+    expect(mockSupabase.rpc).toHaveBeenCalledWith('check_person_conflicts', {
+      p_person_id: 'person-1',
+      p_start_zeit: '2026-03-01 10:00:00 Europe/Zurich',
+      p_end_zeit: '2026-03-01 12:00:00 Europe/Zurich',
+    })
+  })
+
+  it('returns conflicts from multiple sources', async () => {
+    const conflicts = [
+      {
+        type: 'verfuegbarkeit',
+        description: 'Urlaub',
+        start_time: '2026-03-01T00:00:00+01:00',
+        end_time: '2026-03-02T00:00:00+01:00',
+        reference_id: 'verf-1',
+        severity: 'nicht_verfuegbar',
+      },
+      {
+        type: 'probe',
+        description: 'Durchlaufprobe',
+        start_time: '2026-03-01T10:00:00+01:00',
+        end_time: '2026-03-01T12:00:00+01:00',
+        reference_id: 'probe-1',
+      },
+    ]
+
+    mockSupabase.rpc.mockResolvedValueOnce({
+      data: { has_conflicts: true, conflicts },
+      error: null,
+    })
+
+    const result = await checkPersonConflicts(
+      'person-1',
+      '2026-03-01 10:00:00 Europe/Zurich',
+      '2026-03-01 12:00:00 Europe/Zurich'
+    )
+
+    expect(result.has_conflicts).toBe(true)
+    expect(result.conflicts).toHaveLength(2)
+    expect(result.conflicts[0].type).toBe('verfuegbarkeit')
+    expect(result.conflicts[1].type).toBe('probe')
+  })
+
+  it('returns empty result on RPC error', async () => {
+    mockSupabase.rpc.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'RPC failed' },
+    })
+
+    const result = await checkPersonConflicts(
+      'person-1',
+      '2026-03-01 10:00:00 Europe/Zurich',
+      '2026-03-01 12:00:00 Europe/Zurich'
+    )
+
+    expect(result.has_conflicts).toBe(false)
+    expect(result.conflicts).toEqual([])
+  })
+
+  it('returns empty result when data is null', async () => {
+    mockSupabase.rpc.mockResolvedValueOnce({
+      data: null,
+      error: null,
+    })
+
+    const result = await checkPersonConflicts(
+      'person-1',
+      '2026-03-01 10:00:00 Europe/Zurich',
+      '2026-03-01 12:00:00 Europe/Zurich'
+    )
+
+    expect(result.has_conflicts).toBe(false)
+    expect(result.conflicts).toEqual([])
+  })
+
+  it('requires veranstaltungen:write permission', async () => {
+    mockRequirePermission.mockRejectedValueOnce(new Error('Unauthorized'))
+
+    await expect(
+      checkPersonConflicts(
+        'person-1',
+        '2026-03-01 10:00:00 Europe/Zurich',
+        '2026-03-01 12:00:00 Europe/Zurich'
+      )
+    ).rejects.toThrow('Unauthorized')
+
+    expect(mockRequirePermission).toHaveBeenCalledWith('veranstaltungen:write')
+  })
+})

--- a/apps/web/lib/actions/conflict-check.ts
+++ b/apps/web/lib/actions/conflict-check.ts
@@ -1,0 +1,28 @@
+'use server'
+
+import { createClient } from '../supabase/server'
+import { requirePermission } from '../supabase/auth-helpers'
+import type { CheckPersonConflictsResult } from '../supabase/types'
+
+export async function checkPersonConflicts(
+  personId: string,
+  startZeit: string,
+  endZeit: string
+): Promise<CheckPersonConflictsResult> {
+  await requirePermission('veranstaltungen:write')
+
+  const supabase = await createClient()
+
+  const { data, error } = await supabase.rpc('check_person_conflicts', {
+    p_person_id: personId,
+    p_start_zeit: startZeit,
+    p_end_zeit: endZeit,
+  })
+
+  if (error) {
+    console.error('Error checking person conflicts:', error)
+    return { has_conflicts: false, conflicts: [] }
+  }
+
+  return (data as unknown as CheckPersonConflictsResult) ?? { has_conflicts: false, conflicts: [] }
+}

--- a/apps/web/lib/supabase/types.ts
+++ b/apps/web/lib/supabase/types.ts
@@ -1722,6 +1722,26 @@ export type CheckHelferTimeConflictsResult = {
 }
 
 // =============================================================================
+// Cross-System Conflict Detection (Issue #343)
+// =============================================================================
+
+export type PersonConflictType = 'verfuegbarkeit' | 'zuweisung' | 'anmeldung' | 'probe' | 'helfer'
+
+export type PersonConflict = {
+  type: PersonConflictType
+  description: string
+  start_time: string
+  end_time: string
+  reference_id: string
+  severity?: string
+}
+
+export type CheckPersonConflictsResult = {
+  has_conflicts: boolean
+  conflicts: PersonConflict[]
+}
+
+// =============================================================================
 // Helfer Dashboard (US-9)
 // =============================================================================
 

--- a/supabase/migrations/20260306000000_check_person_conflicts.sql
+++ b/supabase/migrations/20260306000000_check_person_conflicts.sql
@@ -1,0 +1,180 @@
+-- =============================================================================
+-- check_person_conflicts()
+-- Cross-system conflict detection for shift assignments
+-- Checks 5 sources: verfuegbarkeiten, zuweisungen, anmeldungen, proben, helfer
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION check_person_conflicts(
+  p_person_id UUID,
+  p_start_zeit TIMESTAMPTZ,
+  p_end_zeit TIMESTAMPTZ
+) RETURNS JSONB
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_conflicts JSONB := '[]'::JSONB;
+  v_record RECORD;
+  v_profile_id UUID;
+BEGIN
+  -- Get the profile_id for this person (needed for helfer_anmeldungen)
+  SELECT profile_id INTO v_profile_id
+  FROM personen
+  WHERE id = p_person_id;
+
+  -- 1. Verfuegbarkeiten (availability blocks)
+  FOR v_record IN
+    SELECT
+      v.id,
+      v.status::TEXT AS severity,
+      COALESCE(v.grund, v.status::TEXT) AS description,
+      CASE
+        WHEN v.zeitfenster_von IS NOT NULL THEN
+          ((v.datum_von + v.zeitfenster_von) AT TIME ZONE 'Europe/Zurich')::TEXT
+        ELSE
+          (v.datum_von AT TIME ZONE 'Europe/Zurich')::TEXT
+      END AS start_time,
+      CASE
+        WHEN v.zeitfenster_bis IS NOT NULL THEN
+          ((v.datum_bis + v.zeitfenster_bis) AT TIME ZONE 'Europe/Zurich')::TEXT
+        ELSE
+          ((v.datum_bis + INTERVAL '1 day') AT TIME ZONE 'Europe/Zurich')::TEXT
+      END AS end_time
+    FROM verfuegbarkeiten v
+    WHERE v.mitglied_id = p_person_id
+      AND v.status IN ('nicht_verfuegbar', 'eingeschraenkt')
+      AND v.datum_von <= (p_end_zeit AT TIME ZONE 'Europe/Zurich')::DATE
+      AND v.datum_bis >= (p_start_zeit AT TIME ZONE 'Europe/Zurich')::DATE
+      AND (
+        v.zeitfenster_von IS NULL
+        OR (
+          v.zeitfenster_von < (p_end_zeit AT TIME ZONE 'Europe/Zurich')::TIME
+          AND v.zeitfenster_bis > (p_start_zeit AT TIME ZONE 'Europe/Zurich')::TIME
+        )
+      )
+  LOOP
+    v_conflicts := v_conflicts || jsonb_build_object(
+      'type', 'verfuegbarkeit',
+      'description', v_record.description,
+      'start_time', v_record.start_time,
+      'end_time', v_record.end_time,
+      'reference_id', v_record.id,
+      'severity', v_record.severity
+    );
+  END LOOP;
+
+  -- 2. Auffuehrung-Zuweisungen (existing shift assignments)
+  FOR v_record IN
+    SELECT
+      az.id,
+      s.rolle AS description,
+      ((ve.datum + zb.startzeit) AT TIME ZONE 'Europe/Zurich')::TEXT AS start_time,
+      ((ve.datum + zb.endzeit) AT TIME ZONE 'Europe/Zurich')::TEXT AS end_time
+    FROM auffuehrung_zuweisungen az
+    JOIN auffuehrung_schichten s ON s.id = az.schicht_id
+    JOIN zeitbloecke zb ON zb.id = s.zeitblock_id
+    JOIN veranstaltungen ve ON ve.id = s.veranstaltung_id
+    WHERE az.person_id = p_person_id
+      AND az.status != 'abgesagt'
+      AND ve.status != 'abgesagt'
+      AND ((ve.datum + zb.startzeit) AT TIME ZONE 'Europe/Zurich') < p_end_zeit
+      AND ((ve.datum + zb.endzeit) AT TIME ZONE 'Europe/Zurich') > p_start_zeit
+  LOOP
+    v_conflicts := v_conflicts || jsonb_build_object(
+      'type', 'zuweisung',
+      'description', v_record.description,
+      'start_time', v_record.start_time,
+      'end_time', v_record.end_time,
+      'reference_id', v_record.id
+    );
+  END LOOP;
+
+  -- 3. Anmeldungen (event registrations)
+  FOR v_record IN
+    SELECT
+      a.id,
+      ve.titel AS description,
+      ((ve.datum + ve.startzeit) AT TIME ZONE 'Europe/Zurich')::TEXT AS start_time,
+      ((ve.datum + ve.endzeit) AT TIME ZONE 'Europe/Zurich')::TEXT AS end_time
+    FROM anmeldungen a
+    JOIN veranstaltungen ve ON ve.id = a.veranstaltung_id
+    WHERE a.person_id = p_person_id
+      AND a.status != 'abgemeldet'
+      AND ve.status != 'abgesagt'
+      AND ve.startzeit IS NOT NULL
+      AND ve.endzeit IS NOT NULL
+      AND ((ve.datum + ve.startzeit) AT TIME ZONE 'Europe/Zurich') < p_end_zeit
+      AND ((ve.datum + ve.endzeit) AT TIME ZONE 'Europe/Zurich') > p_start_zeit
+  LOOP
+    v_conflicts := v_conflicts || jsonb_build_object(
+      'type', 'anmeldung',
+      'description', v_record.description,
+      'start_time', v_record.start_time,
+      'end_time', v_record.end_time,
+      'reference_id', v_record.id
+    );
+  END LOOP;
+
+  -- 4. Proben (rehearsals)
+  FOR v_record IN
+    SELECT
+      pt.id,
+      p.titel AS description,
+      ((p.datum + p.startzeit) AT TIME ZONE 'Europe/Zurich')::TEXT AS start_time,
+      ((p.datum + p.endzeit) AT TIME ZONE 'Europe/Zurich')::TEXT AS end_time
+    FROM proben_teilnehmer pt
+    JOIN proben p ON p.id = pt.probe_id
+    WHERE pt.person_id = p_person_id
+      AND pt.status != 'abgesagt'
+      AND p.status != 'abgesagt'
+      AND p.startzeit IS NOT NULL
+      AND p.endzeit IS NOT NULL
+      AND ((p.datum + p.startzeit) AT TIME ZONE 'Europe/Zurich') < p_end_zeit
+      AND ((p.datum + p.endzeit) AT TIME ZONE 'Europe/Zurich') > p_start_zeit
+  LOOP
+    v_conflicts := v_conflicts || jsonb_build_object(
+      'type', 'probe',
+      'description', v_record.description,
+      'start_time', v_record.start_time,
+      'end_time', v_record.end_time,
+      'reference_id', v_record.id
+    );
+  END LOOP;
+
+  -- 5. Helfer-Anmeldungen (helper registrations via profile_id)
+  IF v_profile_id IS NOT NULL THEN
+    FOR v_record IN
+      SELECT
+        ha.id,
+        COALESCE(hrt.name, hri.custom_name, he.name) AS description,
+        COALESCE(hri.zeitblock_start, he.datum_start)::TEXT AS start_time,
+        COALESCE(hri.zeitblock_end, he.datum_end)::TEXT AS end_time
+      FROM helfer_anmeldungen ha
+      JOIN helfer_rollen_instanzen hri ON hri.id = ha.rollen_instanz_id
+      JOIN helfer_events he ON he.id = hri.helfer_event_id
+      LEFT JOIN helfer_rollen_templates hrt ON hrt.id = hri.template_id
+      WHERE ha.profile_id = v_profile_id
+        AND ha.status != 'abgelehnt'
+        AND COALESCE(hri.zeitblock_start, he.datum_start) < p_end_zeit
+        AND COALESCE(hri.zeitblock_end, he.datum_end) > p_start_zeit
+    LOOP
+      v_conflicts := v_conflicts || jsonb_build_object(
+        'type', 'helfer',
+        'description', v_record.description,
+        'start_time', v_record.start_time,
+        'end_time', v_record.end_time,
+        'reference_id', v_record.id
+      );
+    END LOOP;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'has_conflicts', jsonb_array_length(v_conflicts) > 0,
+    'conflicts', v_conflicts
+  );
+END;
+$$;
+
+-- Grant access to authenticated users
+GRANT EXECUTE ON FUNCTION check_person_conflicts(UUID, TIMESTAMPTZ, TIMESTAMPTZ) TO authenticated;


### PR DESCRIPTION
## Summary
- Add `check_person_conflicts()` DB function (migration) that detects scheduling overlaps across Verfügbarkeit, Schichtzuweisungen, Anmeldungen, Proben, and Helfereinsätze
- Integrate non-blocking conflict warnings into **SchichtZuweisungListe** (Aufführungen) and **TeilnehmerList** (Proben) — triggered on person selection via `useEffect`, same pattern as HelferAssignmentModal
- Add cross-system conflict checking to **HelferAssignmentModal** and `manual-assignment.ts` (validateAssignment / assignHelferManual)
- New shared `ConflictWarning` UI component and `checkPersonConflicts` server action with unit tests

## Files changed (11)
- `supabase/migrations/20260306000000_check_person_conflicts.sql` — DB function
- `apps/web/lib/supabase/types.ts` — `PersonConflict`, `CheckPersonConflictsResult` types
- `apps/web/lib/actions/conflict-check.ts` — Server action
- `apps/web/lib/actions/conflict-check.test.ts` — 5 unit tests
- `apps/web/components/ui/ConflictWarning.tsx` — Reusable warning component
- `apps/web/components/auffuehrungen/SchichtZuweisungListe.tsx` — Conflict check integration
- `apps/web/app/(protected)/auffuehrungen/[id]/page.tsx` — Pass `datum` prop
- `apps/web/components/proben/TeilnehmerList.tsx` — Conflict check integration
- `apps/web/app/(protected)/proben/[id]/page.tsx` — Pass `datum`, `startzeit`, `endzeit` props
- `apps/web/components/koordination/HelferAssignmentModal.tsx` — Cross-system conflicts display
- `apps/web/lib/actions/manual-assignment.ts` — Cross-system validation logic

## Test plan
- [ ] Assign a person to a Schicht (Aufführung) who has an overlapping Probe — verify warning appears but assignment still works
- [ ] Add a Teilnehmer to a Probe who has an overlapping Schichtzuweisung — verify warning appears but invite still works
- [ ] Assign via HelferAssignmentModal with cross-system conflict — verify warning + override checkbox
- [ ] Assign a person with no conflicts — verify no warning is shown
- [ ] Select a Schicht without a Zeitblock — verify no conflict check fires
- [ ] Select a Probe without start/end time — verify no conflict check fires
- [ ] `npm run typecheck` ✅
- [ ] `npm run lint` ✅
- [ ] `npm run test:run` — 101/101 tests pass ✅
- [ ] `npm run build` ✅

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)