### PR TITLE
feat: zentrale Personen-Einsatzübersicht (Mein Kalender)

### DIFF
--- a/apps/web/app/(protected)/mein-bereich/termine/page.tsx
+++ b/apps/web/app/(protected)/mein-bereich/termine/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from 'next/navigation'
 import { getUserProfile } from '@/lib/supabase/server'
-import { getPersonalEvents } from '@/lib/actions/persoenlicher-kalender'
+import { getPersonalEvents, getPersonVerfuegbarkeiten } from '@/lib/actions/persoenlicher-kalender'
 import { PersonalCalendar } from '@/components/mein-bereich/PersonalCalendar'
 
 export const metadata = {
@@ -24,18 +24,21 @@ export default async function MeineTerminePage() {
     .toISOString()
     .split('T')[0]
 
-  const events = await getPersonalEvents(startDatum, endDatum)
+  const [events, verfuegbarkeiten] = await Promise.all([
+    getPersonalEvents(startDatum, endDatum),
+    getPersonVerfuegbarkeiten(undefined, startDatum, endDatum),
+  ])
 
   return (
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-bold text-gray-900">Meine Termine</h1>
         <p className="mt-1 text-gray-600">
-          Alle deine Veranstaltungen, Proben und Schichten auf einen Blick
+          Alle deine Veranstaltungen, Proben und Einsätze auf einen Blick
         </p>
       </div>
 
-      <PersonalCalendar initialEvents={events} />
+      <PersonalCalendar initialEvents={events} verfuegbarkeiten={verfuegbarkeiten} />
     </div>
   )
 }

--- a/apps/web/app/(protected)/vorstand/termine/page.tsx
+++ b/apps/web/app/(protected)/vorstand/termine/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from 'next/navigation'
 import { getUserProfile } from '@/lib/supabase/server'
 import { isManagement } from '@/lib/supabase/permissions'
-import { getPersonalEvents } from '@/lib/actions/persoenlicher-kalender'
+import { getPersonalEvents, getPersonVerfuegbarkeiten } from '@/lib/actions/persoenlicher-kalender'
 import { PersonalCalendar } from '@/components/mein-bereich/PersonalCalendar'
 
 export const metadata = {
@@ -28,18 +28,21 @@ export default async function VorstandTerminePage() {
     .toISOString()
     .split('T')[0]
 
-  const events = await getPersonalEvents(startDatum, endDatum)
+  const [events, verfuegbarkeiten] = await Promise.all([
+    getPersonalEvents(startDatum, endDatum),
+    getPersonVerfuegbarkeiten(undefined, startDatum, endDatum),
+  ])
 
   return (
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-bold text-gray-900">Meine Termine</h1>
         <p className="mt-1 text-gray-600">
-          Alle deine Veranstaltungen, Proben und Schichten auf einen Blick
+          Alle deine Veranstaltungen, Proben und Einsätze auf einen Blick
         </p>
       </div>
 
-      <PersonalCalendar initialEvents={events} />
+      <PersonalCalendar initialEvents={events} verfuegbarkeiten={verfuegbarkeiten} />
     </div>
   )
 }

--- a/apps/web/lib/actions/persoenlicher-kalender.test.ts
+++ b/apps/web/lib/actions/persoenlicher-kalender.test.ts
@@ -1,0 +1,412 @@
+/**
+ * Unit Tests for Persönlicher Kalender (Issue #346)
+ * Tests getPersonalEvents (5 sources), getPersonVerfuegbarkeiten,
+ * personId management view, and decline actions for new types.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createMockClient } from '@/tests/mocks/supabase'
+
+const mockSupabase = createMockClient()
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(() => Promise.resolve(mockSupabase)),
+  getUserProfile: vi.fn(() =>
+    Promise.resolve({
+      id: 'profile-1',
+      email: 'test@example.com',
+      role: 'MITGLIED_AKTIV',
+      display_name: 'Test User',
+    })
+  ),
+}))
+
+const mockRequirePermission = vi.fn()
+
+vi.mock('@/lib/supabase/auth-helpers', () => ({
+  requirePermission: (...args: unknown[]) => mockRequirePermission(...args),
+}))
+
+import {
+  getPersonalEvents,
+  getPersonVerfuegbarkeiten,
+  declinePersonalEvent,
+} from './persoenlicher-kalender'
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function setupPersonLookup(personId = 'person-1', profileId: string | null = 'profile-1') {
+  // Mock the personen lookup chain for resolvePersonIds
+  const chain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    neq: vi.fn().mockReturnThis(),
+    gte: vi.fn().mockReturnThis(),
+    lte: vi.fn().mockReturnThis(),
+    not: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({
+      data: { id: personId, profile_id: profileId },
+      error: null,
+    }),
+  }
+  return chain
+}
+
+function createEmptyChain() {
+  const chain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    neq: vi.fn().mockReturnThis(),
+    gte: vi.fn().mockReturnThis(),
+    lte: vi.fn().mockReturnThis(),
+    not: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({ data: null, error: null }),
+    then: (resolve: (r: { data: unknown[]; error: null }) => void) => {
+      resolve({ data: [], error: null })
+      return Promise.resolve({ data: [], error: null })
+    },
+  }
+  return chain
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('getPersonalEvents', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns empty when person not found', async () => {
+    // personen lookup returns null
+    const personChain = createEmptyChain()
+    mockSupabase.from.mockReturnValue(personChain)
+
+    const result = await getPersonalEvents()
+    expect(result).toEqual([])
+  })
+
+  it('returns events from all 5 sources', async () => {
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'personen') {
+        return setupPersonLookup('person-1', 'profile-1')
+      }
+
+      if (table === 'anmeldungen') {
+        const chain = createEmptyChain()
+        // Override the then to return anmeldungen data
+        const resultData = [
+          {
+            id: 'anm-1',
+            status: 'angemeldet',
+            person_id: 'person-1',
+            veranstaltung: {
+              id: 'v-1',
+              titel: 'GV 2026',
+              beschreibung: null,
+              datum: '2026-06-01',
+              startzeit: '19:00:00',
+              endzeit: '22:00:00',
+              ort: 'Gemeindesaal',
+              typ: 'vereinsevent',
+              status: 'geplant',
+            },
+          },
+        ]
+        chain.then = (resolve: (r: { data: unknown[]; error: null }) => void) => {
+          resolve({ data: resultData, error: null })
+          return Promise.resolve({ data: resultData, error: null })
+        }
+        return chain
+      }
+
+      if (table === 'proben_teilnehmer') {
+        const chain = createEmptyChain()
+        const resultData = [
+          {
+            id: 'pt-1',
+            status: 'zugesagt',
+            person_id: 'person-1',
+            probe: {
+              id: 'p-1',
+              titel: 'Leseprobe',
+              beschreibung: null,
+              datum: '2026-05-15',
+              startzeit: '18:00:00',
+              endzeit: '20:00:00',
+              ort: 'Proberaum',
+              status: 'geplant',
+              stueck: { id: 's-1', titel: 'Hamlet' },
+            },
+          },
+        ]
+        chain.then = (resolve: (r: { data: unknown[]; error: null }) => void) => {
+          resolve({ data: resultData, error: null })
+          return Promise.resolve({ data: resultData, error: null })
+        }
+        return chain
+      }
+
+      if (table === 'auffuehrung_zuweisungen') {
+        const chain = createEmptyChain()
+        const resultData = [
+          {
+            id: 'z-1',
+            status: 'zugesagt',
+            person_id: 'person-1',
+            notizen: null,
+            schicht: {
+              id: 'sch-1',
+              rolle: 'Kasse',
+              veranstaltung_id: 'v-2',
+              zeitblock: { id: 'zb-1', name: 'Abend', startzeit: '18:00:00', endzeit: '22:00:00' },
+              veranstaltung: { id: 'v-2', titel: 'Premiere', datum: '2026-07-01', ort: 'Bühne' },
+            },
+          },
+        ]
+        chain.then = (resolve: (r: { data: unknown[]; error: null }) => void) => {
+          resolve({ data: resultData, error: null })
+          return Promise.resolve({ data: resultData, error: null })
+        }
+        return chain
+      }
+
+      if (table === 'helfer_anmeldungen') {
+        const chain = createEmptyChain()
+        const resultData = [
+          {
+            id: 'ha-1',
+            status: 'bestaetigt',
+            helfer_rollen_instanzen: {
+              id: 'ri-1',
+              custom_name: null,
+              zeitblock_start: '08:00:00',
+              zeitblock_end: '12:00:00',
+              helfer_rollen_templates: { name: 'Aufbau' },
+              helfer_events: {
+                id: 'he-1',
+                name: 'Festbetrieb',
+                beschreibung: 'Dorffest',
+                datum_start: '2026-08-01',
+                datum_end: '2026-08-01',
+                ort: 'Festplatz',
+              },
+            },
+          },
+        ]
+        chain.then = (resolve: (r: { data: unknown[]; error: null }) => void) => {
+          resolve({ data: resultData, error: null })
+          return Promise.resolve({ data: resultData, error: null })
+        }
+        return chain
+      }
+
+      if (table === 'helferschichten') {
+        const chain = createEmptyChain()
+        const resultData = [
+          {
+            id: 'hs-1',
+            startzeit: '14:00:00',
+            endzeit: '18:00:00',
+            status: 'zugesagt',
+            notizen: null,
+            helferrolle: { id: 'hr-1', rolle: 'Service' },
+            helfereinsatz: {
+              id: 'hei-1',
+              titel: 'Hochzeit Müller',
+              beschreibung: null,
+              datum: '2026-09-01',
+              startzeit: '14:00:00',
+              endzeit: '22:00:00',
+              ort: 'Restaurant',
+            },
+          },
+        ]
+        chain.then = (resolve: (r: { data: unknown[]; error: null }) => void) => {
+          resolve({ data: resultData, error: null })
+          return Promise.resolve({ data: resultData, error: null })
+        }
+        return chain
+      }
+
+      return createEmptyChain()
+    })
+
+    const result = await getPersonalEvents()
+
+    expect(result).toHaveLength(5)
+
+    // Check all 5 types are present
+    const types = result.map((e) => e.typ)
+    expect(types).toContain('veranstaltung')
+    expect(types).toContain('probe')
+    expect(types).toContain('schicht')
+    expect(types).toContain('helfer')
+    expect(types).toContain('helfereinsatz_legacy')
+
+    // Verify sorted by date
+    for (let i = 1; i < result.length; i++) {
+      expect(result[i].datum >= result[i - 1].datum).toBe(true)
+    }
+
+    // Check helfer event details
+    const helferEvent = result.find((e) => e.typ === 'helfer')!
+    expect(helferEvent.id).toBe('ha-ha-1')
+    expect(helferEvent.helfer_rolle).toBe('Aufbau')
+    expect(helferEvent.helfer_event_id).toBe('he-1')
+
+    // Check legacy event details
+    const legacyEvent = result.find((e) => e.typ === 'helfereinsatz_legacy')!
+    expect(legacyEvent.id).toBe('hs-hs-1')
+    expect(legacyEvent.helfer_rolle).toBe('Service')
+    expect(legacyEvent.helfereinsatz_id).toBe('hei-1')
+  })
+
+  it('requires mitglieder:read when personId provided', async () => {
+    mockRequirePermission.mockResolvedValueOnce(undefined)
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'personen') {
+        return setupPersonLookup('person-2', null)
+      }
+      return createEmptyChain()
+    })
+
+    await getPersonalEvents(undefined, undefined, 'person-2')
+
+    expect(mockRequirePermission).toHaveBeenCalledWith('mitglieder:read')
+  })
+
+  it('skips helfer_anmeldungen when person has no profile_id', async () => {
+    mockRequirePermission.mockResolvedValueOnce(undefined)
+
+    const fromCalls: string[] = []
+    mockSupabase.from.mockImplementation((table: string) => {
+      fromCalls.push(table)
+      if (table === 'personen') {
+        return setupPersonLookup('person-2', null)
+      }
+      return createEmptyChain()
+    })
+
+    await getPersonalEvents(undefined, undefined, 'person-2')
+
+    // helfer_anmeldungen should NOT be queried when profileId is null
+    expect(fromCalls).not.toContain('helfer_anmeldungen')
+    // helferschichten should still be queried
+    expect(fromCalls).toContain('helferschichten')
+  })
+})
+
+describe('getPersonVerfuegbarkeiten', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns verfuegbarkeiten for current user', async () => {
+    const verfData = [
+      {
+        id: 'v-1',
+        datum_von: '2026-06-01',
+        datum_bis: '2026-06-15',
+        zeitfenster_von: null,
+        zeitfenster_bis: null,
+        status: 'nicht_verfuegbar',
+        grund: 'Ferien',
+        notiz: null,
+      },
+    ]
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'personen') {
+        return setupPersonLookup('person-1', 'profile-1')
+      }
+      if (table === 'verfuegbarkeiten') {
+        const chain = createEmptyChain()
+        chain.then = (resolve: (r: { data: unknown[]; error: null }) => void) => {
+          resolve({ data: verfData, error: null })
+          return Promise.resolve({ data: verfData, error: null })
+        }
+        return chain
+      }
+      return createEmptyChain()
+    })
+
+    const result = await getPersonVerfuegbarkeiten()
+
+    expect(result).toHaveLength(1)
+    expect(result[0].status).toBe('nicht_verfuegbar')
+    expect(result[0].grund).toBe('Ferien')
+  })
+
+  it('requires mitglieder:read when personId provided', async () => {
+    mockRequirePermission.mockResolvedValueOnce(undefined)
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'personen') {
+        return setupPersonLookup('person-2', null)
+      }
+      return createEmptyChain()
+    })
+
+    await getPersonVerfuegbarkeiten('person-2')
+
+    expect(mockRequirePermission).toHaveBeenCalledWith('mitglieder:read')
+  })
+
+  it('returns empty when person not found', async () => {
+    mockSupabase.from.mockReturnValue(createEmptyChain())
+
+    const result = await getPersonVerfuegbarkeiten()
+    expect(result).toEqual([])
+  })
+})
+
+describe('declinePersonalEvent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('handles ha- prefix for helfer_anmeldungen', async () => {
+    const updateChain = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockResolvedValue({ data: null, error: null }),
+    }
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'helfer_anmeldungen') {
+        return updateChain
+      }
+      return createEmptyChain()
+    })
+
+    const result = await declinePersonalEvent('ha-anm123')
+
+    expect(result.success).toBe(true)
+    expect(mockSupabase.from).toHaveBeenCalledWith('helfer_anmeldungen')
+    expect(updateChain.update).toHaveBeenCalledWith({ status: 'abgelehnt' })
+  })
+
+  it('handles hs- prefix for helferschichten', async () => {
+    const updateChain = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockResolvedValue({ data: null, error: null }),
+    }
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'helferschichten') {
+        return updateChain
+      }
+      return createEmptyChain()
+    })
+
+    const result = await declinePersonalEvent('hs-sch456')
+
+    expect(result.success).toBe(true)
+    expect(mockSupabase.from).toHaveBeenCalledWith('helferschichten')
+    expect(updateChain.update).toHaveBeenCalledWith({ status: 'abgesagt' })
+  })
+})


### PR DESCRIPTION
## Summary
- Extends `PersonalCalendar` with 2 new event sources: **Helfer-Anmeldungen** (new Helferliste system) and **Helferschichten** (legacy system), bringing the total to 5 sources
- Adds **Verfügbarkeiten** as a background color layer (green/yellow/red) on the calendar
- Adds optional `personId` parameter to `getPersonalEvents` and new `getPersonVerfuegbarkeiten` for the **management view** on `/mitglieder/[id]` (requires `mitglieder:read` permission)
- Adds `readOnly` prop to `PersonalCalendar` to hide accept/decline buttons in management view
- Updates `declinePersonalEvent` and iCal export to handle the new event types

Closes #346

## Changes
| File | What |
|------|------|
| `lib/actions/persoenlicher-kalender.ts` | Add helfer + legacy sources, verfuegbarkeiten query, personId param, decline/iCal updates |
| `components/mein-bereich/PersonalCalendar.tsx` | New props (verfuegbarkeiten, readOnly), colors, background layer, filter/legend/stats/modal |
| `app/(protected)/mein-bereich/termine/page.tsx` | Fetch verfuegbarkeiten in parallel |
| `app/(protected)/vorstand/termine/page.tsx` | Fetch verfuegbarkeiten in parallel |
| `app/(protected)/mitglieder/[id]/page.tsx` | Add calendar section with readOnly, widen layout to max-w-5xl |
| `lib/actions/persoenlicher-kalender.test.ts` | 9 unit tests (all 5 sources, permission checks, verfuegbarkeiten, decline) |

## Test plan
- [ ] Verify `/mein-bereich/termine` shows all 5 event sources for a user with data in each
- [ ] Verify Verfügbarkeiten appear as colored background bands on the calendar
- [ ] Verify `/mitglieder/[id]` shows the Einsatzübersicht section (readOnly, no accept/decline buttons)
- [ ] Verify filter dropdown includes Helfereinsätze and Helfereinsätze (alt) options
- [ ] Verify clicking a helfer event links to `/helferliste/{id}` or `/helfereinsaetze/{id}`
- [ ] Verify iCal export includes helfer events with correct categories
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm run test:run` — 130/130 tests pass
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)