### PR TITLE
feat: add preview dialog for rehearsal participant suggestions from cast

### DIFF
--- a/apps/web/components/proben/TeilnehmerPreviewDialog.tsx
+++ b/apps/web/components/proben/TeilnehmerPreviewDialog.tsx
@@ -1,0 +1,189 @@
+'use client'
+
+import { useState, useMemo, useCallback } from 'react'
+import type { TeilnehmerSuggestionResult } from '@/lib/supabase/types'
+import { ConflictWarning } from '@/components/ui/ConflictWarning'
+
+interface TeilnehmerPreviewDialogProps {
+  open: boolean
+  onClose: () => void
+  preview: TeilnehmerSuggestionResult
+  onConfirm: (personIds: string[]) => void
+  isConfirming: boolean
+}
+
+export function TeilnehmerPreviewDialog({
+  open,
+  onClose,
+  preview,
+  onConfirm,
+  isConfirming,
+}: TeilnehmerPreviewDialogProps) {
+  const [selected, setSelected] = useState<Set<string>>(() => {
+    const initial = new Set<string>()
+    for (const v of preview.vorschlaege) {
+      if (!v.bereits_vorhanden) {
+        initial.add(v.person_id)
+      }
+    }
+    return initial
+  })
+
+  const selectableVorschlaege = useMemo(
+    () => preview.vorschlaege.filter((v) => !v.bereits_vorhanden),
+    [preview.vorschlaege]
+  )
+
+  const toggleAll = useCallback(
+    (checked: boolean) => {
+      if (checked) {
+        const all = new Set<string>()
+        for (const v of selectableVorschlaege) {
+          all.add(v.person_id)
+        }
+        setSelected(all)
+      } else {
+        setSelected(new Set())
+      }
+    },
+    [selectableVorschlaege]
+  )
+
+  const toggleOne = useCallback((personId: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(personId)) {
+        next.delete(personId)
+      } else {
+        next.add(personId)
+      }
+      return next
+    })
+  }, [])
+
+  const handleConfirm = () => {
+    onConfirm([...selected])
+  }
+
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="mx-4 flex max-h-[90vh] w-full max-w-2xl flex-col rounded-lg bg-white shadow-xl">
+        {/* Header */}
+        <div className="border-b border-gray-200 px-6 py-4">
+          <h2 className="text-lg font-semibold text-gray-900">
+            Teilnehmer aus Besetzung vorschlagen
+          </h2>
+          <div className="mt-2 flex flex-wrap gap-4 text-sm text-gray-600">
+            <span>{preview.stats.total_vorgeschlagen} Vorschläge</span>
+            {preview.stats.total_bereits_vorhanden > 0 && (
+              <span className="text-gray-400">
+                {preview.stats.total_bereits_vorhanden} bereits vorhanden
+              </span>
+            )}
+            {preview.stats.total_mit_konflikten > 0 && (
+              <span className="text-warning-600">
+                {preview.stats.total_mit_konflikten} mit Konflikten
+              </span>
+            )}
+          </div>
+          <p className="mt-1 text-xs text-gray-400">
+            {preview.quelle === 'szenen'
+              ? 'Basierend auf zugewiesenen Szenen'
+              : 'Basierend auf allen Besetzungen (keine Szenen zugewiesen)'}
+          </p>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto px-6 py-4">
+          {preview.vorschlaege.length === 0 ? (
+            <p className="py-8 text-center text-gray-500">
+              Keine Vorschläge gefunden. Prüfe ob Besetzungen für dieses Stück
+              existieren.
+            </p>
+          ) : (
+            <div className="space-y-3">
+              {/* Select all */}
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={
+                    selectableVorschlaege.length > 0 &&
+                    selected.size === selectableVorschlaege.length
+                  }
+                  onChange={(e) => toggleAll(e.target.checked)}
+                  disabled={selectableVorschlaege.length === 0}
+                  className="h-4 w-4 rounded border-gray-300 text-primary-600"
+                />
+                <span className="text-sm font-medium text-gray-700">
+                  Alle auswählen ({selected.size} / {selectableVorschlaege.length})
+                </span>
+              </label>
+
+              {/* Person list */}
+              <div className="divide-y divide-gray-100 rounded-lg border border-gray-200">
+                {preview.vorschlaege.map((v) => (
+                  <div
+                    key={v.person_id}
+                    className={`flex items-start gap-3 px-4 py-3 ${
+                      v.bereits_vorhanden ? 'opacity-50' : ''
+                    }`}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selected.has(v.person_id)}
+                      disabled={v.bereits_vorhanden}
+                      onChange={() => toggleOne(v.person_id)}
+                      className="mt-0.5 h-4 w-4 rounded border-gray-300 text-primary-600"
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-medium text-gray-900">
+                          {v.person_name}
+                        </span>
+                        <span className="text-xs text-gray-500">
+                          {v.rollen.join(', ')}
+                        </span>
+                        {v.bereits_vorhanden && (
+                          <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-500">
+                            Bereits vorhanden
+                          </span>
+                        )}
+                      </div>
+                      {v.konflikte.length > 0 && (
+                        <div className="mt-1">
+                          <ConflictWarning conflicts={v.konflikte} />
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between border-t border-gray-200 px-6 py-4">
+          <button
+            onClick={onClose}
+            disabled={isConfirming}
+            className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+          >
+            Abbrechen
+          </button>
+          <button
+            onClick={handleConfirm}
+            disabled={isConfirming || selected.size === 0}
+            className="rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-700 disabled:bg-gray-400"
+          >
+            {isConfirming
+              ? 'Einladen...'
+              : `Einladen (${selected.size})`}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/proben/index.ts
+++ b/apps/web/components/proben/index.ts
@@ -1,6 +1,7 @@
 export { ProbenList } from './ProbenList'
 export { ProbeForm } from './ProbeForm'
 export { TeilnehmerList } from './TeilnehmerList'
+export { TeilnehmerPreviewDialog } from './TeilnehmerPreviewDialog'
 export { TeilnahmeUebersicht } from './TeilnahmeUebersicht'
 export { ProbeStatusBadge, TeilnehmerStatusBadge } from './ProbeStatusBadge'
 export { ProbenplanGenerator } from './ProbenplanGenerator'

--- a/apps/web/lib/actions/proben-teilnehmer-suggest.test.ts
+++ b/apps/web/lib/actions/proben-teilnehmer-suggest.test.ts
@@ -1,0 +1,462 @@
+/**
+ * Unit Tests for Proben-Teilnehmer Suggestion (Issue #345)
+ * Tests for suggestProbenTeilnehmer and confirmProbenTeilnehmer
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  createMockClient,
+  mockVorstandProfile,
+  mockProfile,
+} from '@/tests/mocks/supabase'
+
+// Mock the Supabase client
+const mockSupabase = createMockClient()
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(() => Promise.resolve(mockSupabase)),
+  getUserProfile: vi.fn(() => Promise.resolve(mockVorstandProfile)),
+}))
+
+vi.mock('./conflict-check', () => ({
+  checkPersonConflicts: vi.fn().mockResolvedValue({
+    has_conflicts: false,
+    conflicts: [],
+  }),
+}))
+
+// Import after mocking
+import { suggestProbenTeilnehmer, confirmProbenTeilnehmer } from './proben'
+import { checkPersonConflicts } from './conflict-check'
+
+describe('Proben-Teilnehmer Suggestion (Issue #345)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // =============================================================================
+  // suggestProbenTeilnehmer
+  // =============================================================================
+
+  describe('suggestProbenTeilnehmer', () => {
+    it('rejects without management permission', async () => {
+      const { getUserProfile } = await import('@/lib/supabase/server')
+      vi.mocked(getUserProfile).mockResolvedValueOnce(mockProfile)
+
+      const result = await suggestProbenTeilnehmer('probe-1')
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('Keine Berechtigung')
+    })
+
+    it('returns error when probe not found', async () => {
+      mockSupabase.from.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: null, error: { message: 'not found' } }),
+      })
+
+      const result = await suggestProbenTeilnehmer('nonexistent')
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Probe nicht gefunden.')
+    })
+
+    it('suggests from szenen when scenes are assigned', async () => {
+      const fromMock = vi.fn()
+
+      // 1. proben - load probe
+      fromMock.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({
+          data: { id: 'probe-1', stueck_id: 'stueck-1', datum: '2026-03-15', startzeit: '19:00:00', endzeit: '22:00:00' },
+          error: null,
+        }),
+      })
+
+      // 2. proben_szenen - has scenes
+      fromMock.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        then: (resolve: (r: { data: unknown[]; error: null }) => void) => {
+          resolve({ data: [{ szene_id: 'szene-1' }], error: null })
+          return Promise.resolve({ data: [{ szene_id: 'szene-1' }], error: null })
+        },
+      })
+
+      // 3. szenen_rollen
+      fromMock.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        in: vi.fn().mockReturnThis(),
+        then: (resolve: (r: { data: unknown[]; error: null }) => void) => {
+          resolve({ data: [{ rolle_id: 'rolle-1' }], error: null })
+          return Promise.resolve({ data: [{ rolle_id: 'rolle-1' }], error: null })
+        },
+      })
+
+      // 4. besetzungen
+      fromMock.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        in: vi.fn().mockReturnThis(),
+        or: vi.fn().mockReturnThis(),
+        then: (resolve: (r: { data: unknown[]; error: null }) => void) => {
+          resolve({ data: [{ person_id: 'person-1', rolle_id: 'rolle-1' }], error: null })
+          return Promise.resolve({ data: [{ person_id: 'person-1', rolle_id: 'rolle-1' }], error: null })
+        },
+      })
+
+      // 5. personen (names)
+      fromMock.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        in: vi.fn().mockReturnThis(),
+        then: (resolve: (r: { data: unknown[]; error: null }) => void) => {
+          resolve({ data: [{ id: 'person-1', vorname: 'Max', nachname: 'Mustermann' }], error: null })
+          return Promise.resolve({ data: [{ id: 'person-1', vorname: 'Max', nachname: 'Mustermann' }], error: null })
+        },
+      })
+
+      // 6. rollen (names)
+      fromMock.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        in: vi.fn().mockReturnThis(),
+        then: (resolve: (r: { data: unknown[]; error: null }) => void) => {
+          resolve({ data: [{ id: 'rolle-1', name: 'Hamlet' }], error: null })
+          return Promise.resolve({ data: [{ id: 'rolle-1', name: 'Hamlet' }], error: null })
+        },
+      })
+
+      // 7. proben_teilnehmer (existing)
+      fromMock.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        then: (resolve: (r: { data: unknown[]; error: null }) => void) => {
+          resolve({ data: [], error: null })
+          return Promise.resolve({ data: [], error: null })
+        },
+      })
+
+      mockSupabase.from = fromMock
+
+      const result = await suggestProbenTeilnehmer('probe-1')
+      expect(result.success).toBe(true)
+      expect(result.data?.quelle).toBe('szenen')
+      expect(result.data?.vorschlaege).toHaveLength(1)
+      expect(result.data?.vorschlaege[0].person_name).toBe('Max Mustermann')
+      expect(result.data?.vorschlaege[0].rollen).toEqual(['Hamlet'])
+      expect(result.data?.vorschlaege[0].bereits_vorhanden).toBe(false)
+    })
+
+    it('falls back to all cast when no scenes assigned', async () => {
+      const fromMock = vi.fn()
+
+      // 1. proben - load probe
+      fromMock.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({
+          data: { id: 'probe-1', stueck_id: 'stueck-1', datum: '2026-03-15', startzeit: '19:00:00', endzeit: '22:00:00' },
+          error: null,
+        }),
+      })
+
+      // 2. proben_szenen - empty (no scenes)
+      fromMock.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        then: (resolve: (r: { data: unknown[]; error: null }) => void) => {
+          resolve({ data: [], error: null })
+          return Promise.resolve({ data: [], error: null })
+        },
+      })
+
+      // 3. rollen (all for stueck - fallback)
+      fromMock.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        then: (resolve: (r: { data: unknown[]; error: null }) => void) => {
+          resolve({ data: [{ id: 'rolle-1' }, { id: 'rolle-2' }], error: null })
+          return Promise.resolve({ data: [{ id: 'rolle-1' }, { id: 'rolle-2' }], error: null })
+        },
+      })
+
+      // 4. besetzungen
+      fromMock.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        in: vi.fn().mockReturnThis(),
+        or: vi.fn().mockReturnThis(),
+        then: (resolve: (r: { data: unknown[]; error: null }) => void) => {
+          resolve({ data: [
+            { person_id: 'person-1', rolle_id: 'rolle-1' },
+            { person_id: 'person-2', rolle_id: 'rolle-2' },
+          ], error: null })
+          return Promise.resolve({ data: [
+            { person_id: 'person-1', rolle_id: 'rolle-1' },
+            { person_id: 'person-2', rolle_id: 'rolle-2' },
+          ], error: null })
+        },
+      })
+
+      // 5. personen (names)
+      fromMock.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        in: vi.fn().mockReturnThis(),
+        then: (resolve: (r: { data: unknown[]; error: null }) => void) => {
+          resolve({ data: [
+            { id: 'person-1', vorname: 'Max', nachname: 'Mustermann' },
+            { id: 'person-2', vorname: 'Anna', nachname: 'Schmidt' },
+          ], error: null })
+          return Promise.resolve({ data: [
+            { id: 'person-1', vorname: 'Max', nachname: 'Mustermann' },
+            { id: 'person-2', vorname: 'Anna', nachname: 'Schmidt' },
+          ], error: null })
+        },
+      })
+
+      // 6. rollen (names)
+      fromMock.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        in: vi.fn().mockReturnThis(),
+        then: (resolve: (r: { data: unknown[]; error: null }) => void) => {
+          resolve({ data: [{ id: 'rolle-1', name: 'Hamlet' }, { id: 'rolle-2', name: 'Ophelia' }], error: null })
+          return Promise.resolve({ data: [{ id: 'rolle-1', name: 'Hamlet' }, { id: 'rolle-2', name: 'Ophelia' }], error: null })
+        },
+      })
+
+      // 7. proben_teilnehmer (existing)
+      fromMock.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        then: (resolve: (r: { data: unknown[]; error: null }) => void) => {
+          resolve({ data: [], error: null })
+          return Promise.resolve({ data: [], error: null })
+        },
+      })
+
+      mockSupabase.from = fromMock
+
+      const result = await suggestProbenTeilnehmer('probe-1')
+      expect(result.success).toBe(true)
+      expect(result.data?.quelle).toBe('alle_besetzungen')
+      expect(result.data?.vorschlaege).toHaveLength(2)
+      expect(result.data?.stats.total_vorgeschlagen).toBe(2)
+    })
+
+    it('marks already existing teilnehmer correctly', async () => {
+      const fromMock = vi.fn()
+
+      // 1. proben
+      fromMock.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({
+          data: { id: 'probe-1', stueck_id: 'stueck-1', datum: '2026-03-15', startzeit: null, endzeit: null },
+          error: null,
+        }),
+      })
+
+      // 2. proben_szenen
+      fromMock.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        then: (resolve: (r: { data: unknown[]; error: null }) => void) => {
+          resolve({ data: [{ szene_id: 'szene-1' }], error: null })
+          return Promise.resolve({ data: [{ szene_id: 'szene-1' }], error: null })
+        },
+      })
+
+      // 3. szenen_rollen
+      fromMock.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        in: vi.fn().mockReturnThis(),
+        then: (resolve: (r: { data: unknown[]; error: null }) => void) => {
+          resolve({ data: [{ rolle_id: 'rolle-1' }], error: null })
+          return Promise.resolve({ data: [{ rolle_id: 'rolle-1' }], error: null })
+        },
+      })
+
+      // 4. besetzungen
+      fromMock.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        in: vi.fn().mockReturnThis(),
+        or: vi.fn().mockReturnThis(),
+        then: (resolve: (r: { data: unknown[]; error: null }) => void) => {
+          resolve({ data: [{ person_id: 'person-1', rolle_id: 'rolle-1' }], error: null })
+          return Promise.resolve({ data: [{ person_id: 'person-1', rolle_id: 'rolle-1' }], error: null })
+        },
+      })
+
+      // 5. personen
+      fromMock.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        in: vi.fn().mockReturnThis(),
+        then: (resolve: (r: { data: unknown[]; error: null }) => void) => {
+          resolve({ data: [{ id: 'person-1', vorname: 'Max', nachname: 'Mustermann' }], error: null })
+          return Promise.resolve({ data: [{ id: 'person-1', vorname: 'Max', nachname: 'Mustermann' }], error: null })
+        },
+      })
+
+      // 6. rollen
+      fromMock.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        in: vi.fn().mockReturnThis(),
+        then: (resolve: (r: { data: unknown[]; error: null }) => void) => {
+          resolve({ data: [{ id: 'rolle-1', name: 'Hamlet' }], error: null })
+          return Promise.resolve({ data: [{ id: 'rolle-1', name: 'Hamlet' }], error: null })
+        },
+      })
+
+      // 7. proben_teilnehmer - person-1 already exists
+      fromMock.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        then: (resolve: (r: { data: unknown[]; error: null }) => void) => {
+          resolve({ data: [{ person_id: 'person-1' }], error: null })
+          return Promise.resolve({ data: [{ person_id: 'person-1' }], error: null })
+        },
+      })
+
+      mockSupabase.from = fromMock
+
+      const result = await suggestProbenTeilnehmer('probe-1')
+      expect(result.success).toBe(true)
+      expect(result.data?.vorschlaege[0].bereits_vorhanden).toBe(true)
+      expect(result.data?.stats.total_bereits_vorhanden).toBe(1)
+      expect(result.data?.stats.total_vorgeschlagen).toBe(0)
+    })
+
+    it('includes conflicts per person when time info available', async () => {
+      vi.mocked(checkPersonConflicts).mockResolvedValueOnce({
+        has_conflicts: true,
+        conflicts: [{
+          type: 'probe',
+          description: 'Andere Probe',
+          start_time: '2026-03-15T19:00:00',
+          end_time: '2026-03-15T21:00:00',
+          reference_id: 'probe-2',
+        }],
+      })
+
+      const fromMock = vi.fn()
+
+      // 1. proben
+      fromMock.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({
+          data: { id: 'probe-1', stueck_id: 'stueck-1', datum: '2026-03-15', startzeit: '19:00:00', endzeit: '22:00:00' },
+          error: null,
+        }),
+      })
+
+      // 2. proben_szenen
+      fromMock.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        then: (resolve: (r: { data: unknown[]; error: null }) => void) => {
+          resolve({ data: [{ szene_id: 'szene-1' }], error: null })
+          return Promise.resolve({ data: [{ szene_id: 'szene-1' }], error: null })
+        },
+      })
+
+      // 3. szenen_rollen
+      fromMock.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        in: vi.fn().mockReturnThis(),
+        then: (resolve: (r: { data: unknown[]; error: null }) => void) => {
+          resolve({ data: [{ rolle_id: 'rolle-1' }], error: null })
+          return Promise.resolve({ data: [{ rolle_id: 'rolle-1' }], error: null })
+        },
+      })
+
+      // 4. besetzungen
+      fromMock.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        in: vi.fn().mockReturnThis(),
+        or: vi.fn().mockReturnThis(),
+        then: (resolve: (r: { data: unknown[]; error: null }) => void) => {
+          resolve({ data: [{ person_id: 'person-1', rolle_id: 'rolle-1' }], error: null })
+          return Promise.resolve({ data: [{ person_id: 'person-1', rolle_id: 'rolle-1' }], error: null })
+        },
+      })
+
+      // 5. personen
+      fromMock.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        in: vi.fn().mockReturnThis(),
+        then: (resolve: (r: { data: unknown[]; error: null }) => void) => {
+          resolve({ data: [{ id: 'person-1', vorname: 'Max', nachname: 'Mustermann' }], error: null })
+          return Promise.resolve({ data: [{ id: 'person-1', vorname: 'Max', nachname: 'Mustermann' }], error: null })
+        },
+      })
+
+      // 6. rollen
+      fromMock.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        in: vi.fn().mockReturnThis(),
+        then: (resolve: (r: { data: unknown[]; error: null }) => void) => {
+          resolve({ data: [{ id: 'rolle-1', name: 'Hamlet' }], error: null })
+          return Promise.resolve({ data: [{ id: 'rolle-1', name: 'Hamlet' }], error: null })
+        },
+      })
+
+      // 7. proben_teilnehmer
+      fromMock.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        then: (resolve: (r: { data: unknown[]; error: null }) => void) => {
+          resolve({ data: [], error: null })
+          return Promise.resolve({ data: [], error: null })
+        },
+      })
+
+      mockSupabase.from = fromMock
+
+      const result = await suggestProbenTeilnehmer('probe-1')
+      expect(result.success).toBe(true)
+      expect(result.data?.vorschlaege[0].konflikte).toHaveLength(1)
+      expect(result.data?.vorschlaege[0].konflikte[0].type).toBe('probe')
+      expect(result.data?.stats.total_mit_konflikten).toBe(1)
+    })
+  })
+
+  // =============================================================================
+  // confirmProbenTeilnehmer
+  // =============================================================================
+
+  describe('confirmProbenTeilnehmer', () => {
+    it('rejects without management permission', async () => {
+      const { getUserProfile } = await import('@/lib/supabase/server')
+      vi.mocked(getUserProfile).mockResolvedValueOnce(mockProfile)
+
+      const result = await confirmProbenTeilnehmer('probe-1', ['person-1'])
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('Keine Berechtigung')
+    })
+
+    it('rejects empty selection', async () => {
+      const result = await confirmProbenTeilnehmer('probe-1', [])
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Keine Teilnehmer ausgewählt.')
+    })
+
+    it('inserts teilnehmer with status eingeladen', async () => {
+      mockSupabase.from.mockReturnValueOnce({
+        upsert: vi.fn().mockResolvedValue({ error: null }),
+      })
+
+      const result = await confirmProbenTeilnehmer('probe-1', ['person-1', 'person-2'])
+      expect(result.success).toBe(true)
+      expect(result.count).toBe(2)
+      expect(mockSupabase.from).toHaveBeenCalledWith('proben_teilnehmer')
+    })
+
+    it('returns error on database failure', async () => {
+      mockSupabase.from.mockReturnValueOnce({
+        upsert: vi.fn().mockResolvedValue({ error: { message: 'DB error' } }),
+      })
+
+      const result = await confirmProbenTeilnehmer('probe-1', ['person-1'])
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('DB error')
+    })
+  })
+})

--- a/apps/web/lib/supabase/types.ts
+++ b/apps/web/lib/supabase/types.ts
@@ -1784,6 +1784,28 @@ export type ZuweisungenPreviewResult = {
 }
 
 // =============================================================================
+// Proben-Teilnehmer Suggestion (Issue #345)
+// =============================================================================
+
+export type TeilnehmerVorschlag = {
+  person_id: string
+  person_name: string
+  rollen: string[]
+  bereits_vorhanden: boolean
+  konflikte: PersonConflict[]
+}
+
+export type TeilnehmerSuggestionResult = {
+  vorschlaege: TeilnehmerVorschlag[]
+  quelle: 'szenen' | 'alle_besetzungen'
+  stats: {
+    total_vorgeschlagen: number
+    total_bereits_vorhanden: number
+    total_mit_konflikten: number
+  }
+}
+
+// =============================================================================
 // Helfer Dashboard (US-9)
 // =============================================================================
 


### PR DESCRIPTION
## Summary
- Replace direct-insert "Aus Besetzungen" button with a preview dialog that shows suggested participants based on cast assignments (Besetzungen)
- When scenes are assigned to the rehearsal, suggest only cast from those scenes; otherwise fall back to all cast members for the Stück
- Preview shows role names, "bereits vorhanden" for duplicates, and conflict warnings per person with select/deselect all
- Add `suggestProbenTeilnehmer()` (read-only preview) and `confirmProbenTeilnehmer()` (batch upsert) server actions
- 10 new unit tests covering permissions, scene-based vs fallback suggestions, duplicate detection, and conflict inclusion

## Test plan
- [ ] `npm run typecheck` — passes
- [ ] `npm run lint` — no warnings
- [ ] `npm run test:run` — 130/130 tests pass (10 new)
- [ ] `npm run build` — production build succeeds
- [ ] Manual: Probe with scenes → "Aus Besetzungen" → preview shows scene-based cast with conflicts → confirm
- [ ] Manual: Probe without scenes → "Aus Besetzungen" → preview shows all cast (fallback) → confirm
- [ ] Manual: Already-invited participants shown as disabled/greyed out in preview

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)