### PR TITLE
fix: Probenplan-Generator Status-Mismatch (#359, #360)

### DIFF
--- a/apps/web/app/(protected)/proben/generator/page.tsx
+++ b/apps/web/app/(protected)/proben/generator/page.tsx
@@ -19,7 +19,7 @@ export default async function ProbenGeneratorPage() {
       status,
       szenen(id, nummer, titel, dauer_minuten)
     `)
-    .in('status', ['in_produktion', 'in_vorbereitung'])
+    .in('status', ['in_proben', 'in_planung'])
     .order('titel')
 
   // Fetch saved templates
@@ -78,8 +78,8 @@ export default async function ProbenGeneratorPage() {
             Keine aktiven Stücke
           </h3>
           <p className="mt-2 text-gray-500">
-            Um den Probenplan-Generator zu nutzen, muss mindestens ein Stück in
-            Produktion oder Vorbereitung sein.
+            Um den Probenplan-Generator zu nutzen, muss mindestens ein Stück den
+            Status «In Proben» oder «In Planung» haben.
           </p>
           <Link
             href={'/stuecke' as Route}

--- a/apps/web/lib/actions/probenplan.ts
+++ b/apps/web/lib/actions/probenplan.ts
@@ -556,7 +556,7 @@ export async function getStueckeMitSzenen(): Promise<
       titel,
       szenen(*)
     `)
-    .eq('status', 'in_produktion')
+    .in('status', ['in_proben', 'in_planung'])
     .order('titel')
 
   if (error) {


### PR DESCRIPTION
## Summary
- **#359**: Generator filterte nach `in_produktion`/`in_vorbereitung` — diese Werte existieren nicht im `stueck_status` ENUM. Korrigiert zu `in_proben`/`in_planung`.
- **#360**: Fehlermeldung referenzierte "Produktion oder Vorbereitung" statt die tatsächlichen Status-Labels «In Proben»/«In Planung».

## Changes
- `app/(protected)/proben/generator/page.tsx`: Status-Filter und Error-Message korrigiert
- `lib/actions/probenplan.ts`: `getStueckeMitSzenen()` filtert jetzt nach `in_proben`/`in_planung` statt `in_produktion`

## Test plan
- [ ] Generator zeigt Stücke mit Status `in_proben`
- [ ] Generator zeigt Stücke mit Status `in_planung`
- [ ] Stücke mit `aktiv`/`abgeschlossen`/`archiviert` erscheinen nicht
- [ ] Fehlermeldung zeigt korrekte Status-Labels wenn keine Stücke vorhanden

Closes #359, closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)