### PR TITLE
security: Fix open redirect + RLS self-escalation (#368, #369)

### DIFF
--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -4,7 +4,10 @@ import { createServerClient, type CookieOptions } from '@supabase/ssr'
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url)
   const code = searchParams.get('code')
-  const next = searchParams.get('next') ?? '/dashboard'
+  let next = searchParams.get('next') ?? '/dashboard'
+  if (!next.startsWith('/') || next.startsWith('//')) {
+    next = '/dashboard'
+  }
 
   if (code) {
     const response = NextResponse.redirect(`${origin}${next}`)

--- a/apps/web/app/auth/confirm/route.ts
+++ b/apps/web/app/auth/confirm/route.ts
@@ -6,7 +6,10 @@ export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url)
   const token_hash = searchParams.get('token_hash')
   const type = searchParams.get('type') as EmailOtpType | null
-  const next = searchParams.get('next') ?? '/dashboard'
+  let next = searchParams.get('next') ?? '/dashboard'
+  if (!next.startsWith('/') || next.startsWith('//')) {
+    next = '/dashboard'
+  }
 
   if (token_hash && type) {
     const supabase = await createClient()

--- a/supabase/migrations/20260309000000_fix_profiles_update_own_policy.sql
+++ b/supabase/migrations/20260309000000_fix_profiles_update_own_policy.sql
@@ -1,0 +1,15 @@
+-- Fix profiles_update_own RLS policy to prevent self-role-escalation
+-- Issue #369: Users could change their own role (incl. to ADMIN) via direct Supabase client
+
+-- Drop the existing policy
+DROP POLICY IF EXISTS "profiles_update_own" ON profiles;
+
+-- Recreate with role-change prevention:
+-- Users can update their own profile, but the role must stay unchanged
+CREATE POLICY "profiles_update_own"
+  ON profiles FOR UPDATE
+  USING (auth.uid() = id)
+  WITH CHECK (
+    auth.uid() = id
+    AND role = (SELECT p.role FROM profiles p WHERE p.id = auth.uid())
+  );


### PR DESCRIPTION
## Summary
- **#368 Open Redirect:** `next` query param in `auth/callback` and `auth/confirm` was used without validation — attacker could redirect users to external sites after login. Now validates that `next` starts with `/` and rejects `//` (protocol-relative URLs).
- **#369 RLS Self-Escalation:** `profiles_update_own` RLS policy allowed users to change their own `role` column (incl. to ADMIN) via direct Supabase client. Added `WITH CHECK` constraint ensuring `role` stays unchanged on self-updates.

## Changes
- `app/auth/callback/route.ts` — validate `next` param
- `app/auth/confirm/route.ts` — validate `next` param
- New migration `20260309000000_fix_profiles_update_own_policy.sql` — restrict RLS policy

## Test plan
- [ ] `?next=//evil.com` → redirects to `/dashboard`
- [ ] `?next=https://evil.com` → redirects to `/dashboard`
- [ ] `?next=/proben` → redirects correctly to `/proben`
- [ ] Normal login flow still works
- [ ] User can update own `display_name` (not blocked by RLS)
- [ ] User cannot update own `role` via Supabase client (blocked by RLS)
- [ ] Admin can still change other users' roles via `updateUserRole()`
- [ ] Run migration on staging and verify

Closes #368, closes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)