### PR TITLE
fix: invitation links point to correct URL with password setup page

### DIFF
--- a/apps/web/.env
+++ b/apps/web/.env
@@ -11,6 +11,9 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY="sb_publishable_H1OXl6dX8GvZQNhSxp5xeg_h1pfRLfn"
 # GITHUB_TOKEN=your-github-personal-access-token
 # GITHUB_REPO=trismus/BackstagePass
 
+# Site URL (für Einladungslinks, E-Mail-Links etc.)
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+
 # Email (SMTP) - z.B. Gmail mit App-Password
 # SMTP_HOST=smtp.gmail.com
 # SMTP_PORT=587

--- a/apps/web/app/(auth)/passwort-setzen/page.tsx
+++ b/apps/web/app/(auth)/passwort-setzen/page.tsx
@@ -1,0 +1,28 @@
+import { ResetPasswordForm } from '@/components/auth/ResetPasswordForm'
+
+export const metadata = {
+  title: 'Passwort festlegen',
+  description: 'Lege ein Passwort für deinen BackstagePass Account fest',
+}
+
+export default function PasswortSetzenPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-neutral-50">
+      <div className="w-full max-w-md rounded-2xl border border-neutral-200 bg-white p-8 shadow-sm">
+        <div className="mb-6">
+          <p className="text-xs font-semibold uppercase tracking-[0.35em] text-neutral-500">
+            BackstagePass
+          </p>
+          <h1 className="mt-2 text-2xl font-semibold text-neutral-900">
+            Passwort festlegen
+          </h1>
+          <p className="mt-1 text-sm text-neutral-600">
+            Willkommen bei BackstagePass! Lege ein Passwort für deinen Account fest.
+          </p>
+        </div>
+
+        <ResetPasswordForm />
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/auth/confirm/route.ts
+++ b/apps/web/app/auth/confirm/route.ts
@@ -11,6 +11,11 @@ export async function GET(request: NextRequest) {
     next = '/dashboard'
   }
 
+  // For invite-type confirmations, redirect to password setup instead of dashboard
+  if (type === 'invite' && next === '/dashboard') {
+    next = '/passwort-setzen'
+  }
+
   if (token_hash && type) {
     const supabase = await createClient()
     const { error } = await supabase.auth.verifyOtp({ type, token_hash })

--- a/apps/web/components/admin/helferliste/HelferStatusControl.tsx
+++ b/apps/web/components/admin/helferliste/HelferStatusControl.tsx
@@ -35,7 +35,7 @@ export function HelferStatusControl({
 
   const baseUrl = typeof window !== 'undefined'
     ? window.location.origin
-    : process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
+    : process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
 
   const publicLink = publicToken ? `${baseUrl}/helfer/anmeldung/${publicToken}` : null
 

--- a/apps/web/lib/actions/email-sender.ts
+++ b/apps/web/lib/actions/email-sender.ts
@@ -148,7 +148,7 @@ async function getInfoBlockTimes(veranstaltungId: string): Promise<{
  * Build the cancellation link URL
  */
 function buildCancellationLink(token: string): string {
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
   return `${baseUrl}/helfer/abmeldung/${token}`
 }
 
@@ -156,7 +156,7 @@ function buildCancellationLink(token: string): string {
  * Build the public registration link URL
  */
 function buildPublicLink(token: string): string {
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
   return `${baseUrl}/helfer/anmeldung/${token}`
 }
 
@@ -500,7 +500,7 @@ export async function sendWaitlistAssignedEmail(
 
   const confirmToken = (entry as unknown as { confirmation_token?: string }).confirmation_token
   const confirmLink = confirmToken
-    ? `${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/helfer/warteliste/bestaetigen/${confirmToken}`
+    ? `${process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'}/helfer/warteliste/bestaetigen/${confirmToken}`
     : ''
 
   return sendTemplatedEmail('waitlist_assigned', profile.email, {

--- a/apps/web/lib/actions/external-registration.ts
+++ b/apps/web/lib/actions/external-registration.ts
@@ -372,7 +372,7 @@ async function sendExternalRegistrationEmail(
   helperData: { email: string; vorname: string; nachname: string },
   isWaitlist: boolean
 ): Promise<void> {
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
 
   // Get dashboard token
   const { data: dashboardToken } = await supabase.rpc(

--- a/apps/web/lib/actions/helfer-status.ts
+++ b/apps/web/lib/actions/helfer-status.ts
@@ -221,7 +221,7 @@ export async function getPublicHelferLink(
   }
 
   // Build URL based on environment
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
   const url = `${baseUrl}/helfer/anmeldung/${data.public_helfer_token}`
 
   return { url, status: data.helfer_status }

--- a/apps/web/lib/actions/helferliste-notifications.ts
+++ b/apps/web/lib/actions/helferliste-notifications.ts
@@ -85,7 +85,7 @@ export async function notifyEventPublished(
     return { success: true, sent: 0, errors: 0 }
   }
 
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://backstagepass.app'
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://backstagepass.app'
   const publicLink = event.public_token
     ? `${baseUrl}/public/helfer/${event.public_token}`
     : `${baseUrl}/helferliste/${event.id}`
@@ -331,7 +331,7 @@ export async function notifyStatusChange(
  */
 function buildAbmeldungLink(token: string | null): string {
   if (!token) return ''
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
   return `${baseUrl}/helfer/helferliste/abmeldung/${token}`
 }
 
@@ -436,7 +436,7 @@ export async function notifyMultiRegistrationConfirmed(
   })
 
   // Build dashboard link
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
   const dashboardLink = `${baseUrl}/helfer/meine-einsaetze/${dashboardToken}`
 
   // Fetch coordinator info (if event is linked to a veranstaltung)

--- a/apps/web/lib/actions/personen.ts
+++ b/apps/web/lib/actions/personen.ts
@@ -136,12 +136,17 @@ async function performInvite(
   vorname: string,
   nachname: string
 ): Promise<{ user: User | null; error?: string }> {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
+
   if (isEmailServiceConfigured()) {
     // Custom branded email path: generate link without sending Supabase email
     const { data, error } = await adminClient.auth.admin.generateLink({
       type: 'invite',
       email,
-      options: { data: { display_name: `${vorname} ${nachname}` } },
+      options: {
+        data: { display_name: `${vorname} ${nachname}` },
+        redirectTo: `${siteUrl}/passwort-setzen`,
+      },
     })
 
     if (error) return { user: null, error: error.message }
@@ -157,7 +162,10 @@ async function performInvite(
     // Fallback: Supabase default invitation email
     const { data, error } = await adminClient.auth.admin.inviteUserByEmail(
       email,
-      { data: { display_name: `${vorname} ${nachname}` } }
+      {
+        data: { display_name: `${vorname} ${nachname}` },
+        redirectTo: `${siteUrl}/passwort-setzen`,
+      }
     )
 
     if (error) return { user: null, error: error.message }

--- a/apps/web/lib/actions/public-overview.ts
+++ b/apps/web/lib/actions/public-overview.ts
@@ -426,7 +426,7 @@ async function sendConfirmationEmail(
 
   if (!veranstaltung) return
 
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
 
   // Build shift info for email
   const shifts: ShiftInfo[] = schichten.map((s) => {

--- a/apps/web/lib/actions/thank-you-emails.ts
+++ b/apps/web/lib/actions/thank-you-emails.ts
@@ -47,7 +47,7 @@ export type ThankYouEmailsSendResult = {
  * Build feedback link URL
  */
 function buildFeedbackLink(token: string): string {
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
   return `${baseUrl}/helfer/feedback/${token}`
 }
 

--- a/apps/web/lib/actions/warteliste-notification.ts
+++ b/apps/web/lib/actions/warteliste-notification.ts
@@ -31,7 +31,7 @@ function calculateDeadline(): Date {
  */
 function buildPublicLink(token: string | null): string {
   if (!token) return ''
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
   return `${baseUrl}/helfer/anmeldung/${token}`
 }
 

--- a/apps/web/tests/setup.ts
+++ b/apps/web/tests/setup.ts
@@ -10,7 +10,7 @@ process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'test-anon-key'
 process.env.SMTP_HOST = 'smtp.test.local'
 process.env.SMTP_USER = 'test@test.local'
 process.env.SMTP_PASS = 'test-password'
-process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000'
+process.env.NEXT_PUBLIC_SITE_URL = 'http://localhost:3000'
 
 // Mock next/cache
 vi.mock('next/cache', () => ({


### PR DESCRIPTION
## Summary
- **Consolidate env var**: Replace `NEXT_PUBLIC_APP_URL` → `NEXT_PUBLIC_SITE_URL` across all 9 files that referenced it
- **Fix `performInvite()`**: Add `redirectTo` parameter to both `generateLink` and `inviteUserByEmail` calls so invitation emails link to the correct domain
- **New `/passwort-setzen` page**: Dedicated password setup page for newly invited users (reuses `ResetPasswordForm`)
- **Auth confirm route**: Redirect invite-type OTP confirmations to `/passwort-setzen` instead of `/dashboard`

Closes #385

## Manual steps after merge
- Set `NEXT_PUBLIC_SITE_URL` in Vercel environment variables (Production + Preview)
- Update Supabase Dashboard: Auth → URL Configuration → Site URL to production URL

## Test plan
- [ ] Verify `npm run typecheck`, `npm run lint`, `npm run test:run`, `npm run build` all pass
- [ ] Invite a new user and confirm the email link points to the correct production domain
- [ ] Confirm the invitation link lands on `/passwort-setzen` (not `/dashboard`)
- [ ] Verify existing password reset flow via `/reset-password` still works
- [ ] Check that public helper registration emails use the correct base URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)