### PR TITLE
feat: show upcoming proben in active member dashboard

### DIFF
--- a/apps/web/app/(protected)/dashboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/page.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/components/dashboard'
 import { getAktuelleProduktionFuerDashboard } from '@/lib/actions/produktionen'
 import { getAnmeldungenForPerson } from '@/lib/actions/anmeldungen'
+import { getMeineProben } from '@/lib/actions/proben'
 import { getRollenHistorie, getHelfereinsatzHistorie } from '@/lib/actions/historie'
 import { MiniKalender } from '@/components/mein-bereich/MiniKalender'
 import { EditableProfileCard } from '@/components/mein-bereich/EditableProfileCard'
@@ -24,6 +25,7 @@ import { HelfereinsatzHistorie } from '@/components/mein-bereich/HelfereinsatzHi
 import {
   UpcomingEventsWidget,
   HelferEinsaetzeWidget,
+  MeineProbenWidget,
 } from '@/components/mein-bereich/DashboardWidgets'
 import { ProfileCompletionWidget } from '@/components/mein-bereich/ProfileCompletionWidget'
 import type { KalenderTermin } from '@/components/mein-bereich/MiniKalender'
@@ -462,6 +464,7 @@ export default async function DashboardPage({
 
   // Get data if person is linked
   const anmeldungen = person ? await getAnmeldungenForPerson(person.id) : []
+  const meineProben = person && !isPassiveMember ? await getMeineProben(person.id) : []
 
   // Get available helper events (only for active members)
   const { data: verfuegbareEinsaetze } = !isPassiveMember
@@ -493,6 +496,17 @@ export default async function DashboardPage({
       titel: a.veranstaltung.titel,
       typ: 'veranstaltung',
       href: `/veranstaltungen/${a.veranstaltung.id}`,
+    })
+  })
+
+  // Add proben as calendar events
+  meineProben.forEach((p) => {
+    kalenderTermine.push({
+      id: p.id,
+      datum: p.datum,
+      titel: p.stueck_titel ? `${p.stueck_titel}: ${p.titel}` : p.titel,
+      typ: 'probe',
+      href: `/proben/${p.probe_id}`,
     })
   })
 
@@ -583,6 +597,10 @@ export default async function DashboardPage({
                   <span className="font-semibold text-neutral-900">{upcomingAnmeldungen.length}</span>
                 </div>
                 <div className="flex items-center justify-between">
+                  <span className="text-sm text-neutral-600">Anstehende Proben</span>
+                  <span className="font-semibold text-purple-600">{meineProben.length}</span>
+                </div>
+                <div className="flex items-center justify-between">
                   <span className="text-sm text-neutral-600">Offene Einsätze</span>
                   <span className="font-semibold text-blue-600">{verfuegbareEinsaetze?.length ?? 0}</span>
                 </div>
@@ -656,8 +674,9 @@ export default async function DashboardPage({
             </div>
 
             {/* Content Widgets */}
-            <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+            <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
               <UpcomingEventsWidget anmeldungen={upcomingAnmeldungen} />
+              <MeineProbenWidget proben={meineProben} />
               <HelferEinsaetzeWidget einsaetze={verfuegbareEinsaetze ?? []} />
             </div>
 

--- a/apps/web/components/mein-bereich/DashboardWidgets.tsx
+++ b/apps/web/components/mein-bereich/DashboardWidgets.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import type {
   AnmeldungMitVeranstaltung,
+  MeineProbe,
 } from '@/lib/supabase/types'
 
 interface UpcomingEventsWidgetProps {
@@ -150,6 +151,84 @@ export function HelferEinsaetzeWidget({
           className="text-sm text-amber-600 hover:text-amber-800"
         >
           Alle Einsätze &rarr;
+        </Link>
+      </div>
+    </div>
+  )
+}
+
+interface MeineProbenWidgetProps {
+  proben: MeineProbe[]
+}
+
+export function MeineProbenWidget({ proben }: MeineProbenWidgetProps) {
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleDateString('de-CH', {
+      weekday: 'short',
+      day: '2-digit',
+      month: '2-digit',
+    })
+  }
+
+  const formatTime = (start: string | null, end: string | null) => {
+    if (!start) return null
+    const s = start.slice(0, 5)
+    const e = end ? end.slice(0, 5) : null
+    return e ? `${s}–${e}` : s
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-neutral-200 bg-white">
+      <div className="border-b border-purple-100 bg-purple-50 px-4 py-3">
+        <h3 className="font-medium text-purple-900">Meine Proben</h3>
+      </div>
+      {proben.length > 0 ? (
+        <div className="divide-y divide-neutral-100">
+          {proben.map((p) => (
+            <Link
+              key={p.id}
+              href={`/proben/${p.probe_id}` as never}
+              className="block p-3 transition-colors hover:bg-neutral-50"
+            >
+              <div className="flex items-start justify-between">
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-medium text-neutral-900">
+                    {p.stueck_titel ? `${p.stueck_titel}: ` : ''}{p.titel}
+                  </p>
+                  <p className="text-xs text-neutral-500">
+                    {p.ort || 'Kein Ort'}
+                    {formatTime(p.startzeit, p.endzeit) && ` • ${formatTime(p.startzeit, p.endzeit)}`}
+                  </p>
+                </div>
+                <div className="ml-2 flex flex-col items-end gap-1">
+                  <span className="text-xs text-neutral-500">
+                    {formatDate(p.datum)}
+                  </span>
+                  <span
+                    className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${
+                      p.status === 'zugesagt'
+                        ? 'bg-green-100 text-green-700'
+                        : 'bg-yellow-100 text-yellow-700'
+                    }`}
+                  >
+                    {p.status === 'zugesagt' ? 'Zugesagt' : 'Eingeladen'}
+                  </span>
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      ) : (
+        <div className="p-4 text-center text-sm text-neutral-500">
+          Keine anstehenden Proben
+        </div>
+      )}
+      <div className="border-t border-neutral-100 bg-neutral-50 px-4 py-2">
+        <Link
+          href="/proben"
+          className="text-sm text-purple-600 hover:text-purple-800"
+        >
+          Alle Proben &rarr;
         </Link>
       </div>
     </div>

--- a/apps/web/lib/supabase/types.ts
+++ b/apps/web/lib/supabase/types.ts
@@ -1492,6 +1492,18 @@ export type KommendeProbe = Probe & {
   zusagen_count: number
 }
 
+export type MeineProbe = {
+  id: string // proben_teilnehmer.id
+  probe_id: string
+  titel: string
+  stueck_titel: string | null
+  datum: string
+  startzeit: string | null
+  endzeit: string | null
+  ort: string | null
+  status: TeilnehmerStatus
+}
+
 // =============================================================================
 // Externe Helfer Profile (Issue #208)
 // =============================================================================


### PR DESCRIPTION
## Summary
- Add `MeineProbenWidget` to the active member dashboard showing upcoming rehearsals where the member is invited or confirmed
- New `getMeineProben()` server action with lightweight query (proben_teilnehmer → proben → stuecke)
- Proben appear as purple dots in MiniKalender and as count in Quick Stats
- Widget grid upgraded to 3-column layout (Veranstaltungen, Proben, Helfereinsätze)

Closes #388

## Test plan
- [ ] Login as MITGLIED_AKTIV with proben_teilnehmer entries → "Meine Proben" widget visible with correct data
- [ ] Verify purple dots appear in MiniKalender for probe dates
- [ ] Verify "Anstehende Proben" count in Quick Stats sidebar
- [ ] Verify empty state ("Keine anstehenden Proben") when no upcoming proben
- [ ] Verify links navigate to `/proben/{id}` detail page
- [ ] Verify passive members do NOT see the proben widget
- [ ] `npm run typecheck && npm run lint && npm run test:run && npm run build` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)