### PR TITLE
feat: auto-invite Teilnehmer beim Erstellen einer Probe

### DIFF
--- a/apps/web/components/proben/ProbeForm.tsx
+++ b/apps/web/components/proben/ProbeForm.tsx
@@ -14,6 +14,7 @@ import {
   updateProbe,
   updateProbeSzenen,
   checkProbeVerfuegbarkeit,
+  autoInviteProbeTeilnehmer,
 } from '@/lib/actions/proben'
 
 interface ProbeFormProps {
@@ -119,6 +120,7 @@ export function ProbeForm({
           if (szenenIds.length > 0) {
             await updateProbeSzenen(result.id, szenenIds)
           }
+          await autoInviteProbeTeilnehmer(result.id)
           router.push(`/proben/${result.id}` as Route)
         } else {
           setError(result.error || 'Fehler beim Erstellen')


### PR DESCRIPTION
## Summary
- Ruft `autoInviteProbeTeilnehmer(probeId)` nach Probe-Erstellung und Szenen-Zuweisung auf
- Cast-Mitglieder werden automatisch mit Status `eingeladen` eingetragen (basierend auf zugewiesenen Szenen oder dem gesamten Stück-Cast)
- Kein manuelles "Aus Besetzungen"-Klicken auf der Detailseite mehr nötig

## Test plan
- [ ] Probe mit Szenen erstellen → Detailseite zeigt automatisch eingeladene Teilnehmer
- [ ] Probe ohne Szenen erstellen → gesamter Stück-Cast wird eingeladen
- [ ] Dashboard-Widget "Meine Proben" zeigt neu erstellte Probe sofort an

🤖 Generated with [Claude Code](https://claude.com/claude-code)