### PR TITLE
feat: backfill auto-invite Teilnehmer für bestehende Proben

### DIFF
--- a/supabase/migrations/20260218011720_backfill_probe_teilnehmer.sql
+++ b/supabase/migrations/20260218011720_backfill_probe_teilnehmer.sql
@@ -1,0 +1,27 @@
+-- Backfill: Auto-invite Teilnehmer for existing Proben that have none
+-- Uses the existing auto_invite_probe_teilnehmer() function to invite
+-- cast members based on assigned scenes (or full cast if no scenes assigned)
+
+DO $$
+DECLARE
+  probe_record RECORD;
+  invited_count INT;
+  total_proben INT := 0;
+  total_invited INT := 0;
+BEGIN
+  FOR probe_record IN
+    SELECT p.id, p.titel
+    FROM proben p
+    LEFT JOIN proben_teilnehmer pt ON pt.probe_id = p.id
+    WHERE p.status NOT IN ('abgesagt', 'abgeschlossen')
+    GROUP BY p.id, p.titel
+    HAVING COUNT(pt.id) = 0
+  LOOP
+    SELECT auto_invite_probe_teilnehmer(probe_record.id) INTO invited_count;
+    total_proben := total_proben + 1;
+    total_invited := total_invited + COALESCE(invited_count, 0);
+    RAISE NOTICE 'Probe "%": % Teilnehmer eingeladen', probe_record.titel, COALESCE(invited_count, 0);
+  END LOOP;
+
+  RAISE NOTICE 'Backfill abgeschlossen: % Proben verarbeitet, % Teilnehmer eingeladen', total_proben, total_invited;
+END $$;


### PR DESCRIPTION
## Summary
- Migration ruft `auto_invite_probe_teilnehmer()` für alle offenen Proben aus, die noch keine Teilnehmer haben
- Ergänzung zu PR #394 — dort wurde Auto-Invite nur für neu erstellte Proben eingebaut
- Bestehende Proben werden damit nachträglich mit Cast-Mitgliedern befüllt

## Test plan
- [ ] Migration lokal oder auf Staging ausführen
- [ ] RAISE NOTICE Logs prüfen: Anzahl verarbeiteter Proben und eingeladener Teilnehmer
- [ ] Proben-Detailseiten stichprobenartig prüfen — Teilnehmer sollten vorhanden sein

🤖 Generated with [Claude Code](https://claude.com/claude-code)