### PR TITLE
feat: offene schichten widget im mitglieder-dashboard

### DIFF
--- a/apps/web/app/(protected)/dashboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/page.tsx
@@ -26,7 +26,9 @@ import {
   UpcomingEventsWidget,
   HelferEinsaetzeWidget,
   MeineProbenWidget,
+  OffeneSchichtenWidget,
 } from '@/components/mein-bereich/DashboardWidgets'
+import { getOffeneSchichtenForDashboard } from '@/lib/actions/auffuehrung-schichten'
 import { ProfileCompletionWidget } from '@/components/mein-bereich/ProfileCompletionWidget'
 import type { KalenderTermin } from '@/components/mein-bereich/MiniKalender'
 
@@ -463,10 +465,11 @@ export default async function DashboardPage({
   const isPassiveMember = profile.role === 'MITGLIED_PASSIV'
 
   // Get data if person is linked
-  const [anmeldungen, meineProben, meineAuffuehrungen] = await Promise.all([
+  const [anmeldungen, meineProben, meineAuffuehrungen, offeneSchichten] = await Promise.all([
     person ? getAnmeldungenForPerson(person.id) : Promise.resolve([]),
     person && !isPassiveMember ? getMeineProben(person.id) : Promise.resolve([]),
     person && !isPassiveMember ? getMeineProduktionsAuffuehrungen(person.id) : Promise.resolve([]),
+    !isPassiveMember ? getOffeneSchichtenForDashboard() : Promise.resolve([]),
   ])
 
   // Get available helper events (only for active members)
@@ -694,6 +697,7 @@ export default async function DashboardPage({
               <UpcomingEventsWidget anmeldungen={upcomingAnmeldungen} produktionsAuffuehrungen={meineAuffuehrungen} />
               <MeineProbenWidget proben={meineProben} />
               <HelferEinsaetzeWidget einsaetze={verfuegbareEinsaetze ?? []} />
+              <OffeneSchichtenWidget schichten={offeneSchichten} />
             </div>
 
             {/* History Section */}

--- a/apps/web/components/mein-bereich/DashboardWidgets.tsx
+++ b/apps/web/components/mein-bereich/DashboardWidgets.tsx
@@ -4,6 +4,7 @@ import type {
   MeineProbe,
 } from '@/lib/supabase/types'
 import type { MeineProduktionsAuffuehrung } from '@/lib/actions/produktionen'
+import type { DashboardSchicht } from '@/lib/actions/auffuehrung-schichten'
 
 type MergedEvent = {
   key: string
@@ -315,6 +316,82 @@ export function QuickLinksWidget({
             </span>
           </Link>
         ))}
+      </div>
+    </div>
+  )
+}
+
+interface OffeneSchichtenWidgetProps {
+  schichten: DashboardSchicht[]
+}
+
+export function OffeneSchichtenWidget({
+  schichten,
+}: OffeneSchichtenWidgetProps) {
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleDateString('de-CH', {
+      weekday: 'short',
+      day: '2-digit',
+      month: '2-digit',
+    })
+  }
+
+  const formatTime = (start: string, end: string) => {
+    return `${start.slice(0, 5)}–${end.slice(0, 5)}`
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-neutral-200 bg-white">
+      <div className="border-b border-orange-100 bg-orange-50 px-4 py-3">
+        <h3 className="font-medium text-orange-900">Offene Schichten</h3>
+      </div>
+      {schichten.length > 0 ? (
+        <div className="divide-y divide-neutral-100">
+          {schichten.map((s) => (
+            <Link
+              key={s.id}
+              href={`/auffuehrungen/${s.veranstaltung.id}/helferliste` as never}
+              className="block p-3 transition-colors hover:bg-neutral-50"
+            >
+              <div className="flex items-start justify-between">
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-medium text-neutral-900">
+                    {s.rolle}
+                    {s.sichtbarkeit === 'intern' && (
+                      <span className="ml-2 inline-block rounded-full bg-neutral-100 px-2 py-0.5 text-xs font-medium text-neutral-600">
+                        Intern
+                      </span>
+                    )}
+                  </p>
+                  <p className="text-xs text-neutral-500">
+                    {s.veranstaltung.titel}
+                    {s.zeitblock && ` • ${formatTime(s.zeitblock.startzeit, s.zeitblock.endzeit)}`}
+                  </p>
+                </div>
+                <div className="ml-2 flex flex-col items-end gap-1">
+                  <span className="text-xs text-neutral-500">
+                    {formatDate(s.veranstaltung.datum)}
+                  </span>
+                  <span className="text-xs text-green-600">
+                    {s.freie_plaetze} frei
+                  </span>
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      ) : (
+        <div className="p-4 text-center text-sm text-neutral-500">
+          Keine offenen Schichten
+        </div>
+      )}
+      <div className="border-t border-neutral-100 bg-neutral-50 px-4 py-2">
+        <Link
+          href="/auffuehrungen"
+          className="text-sm text-orange-600 hover:text-orange-800"
+        >
+          Alle Aufführungen &rarr;
+        </Link>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- New `getOffeneSchichtenForDashboard()` server action that queries open shifts from published performances (both `intern` and `public` sichtbarkeit)
- New `OffeneSchichtenWidget` component with orange color scheme, intern badge, free slot count, and links to helferliste
- Integrated into MITGLIED_AKTIV dashboard alongside existing widgets

## Test plan
- [ ] Open dashboard as MITGLIED_AKTIV user
- [ ] Verify "Offene Schichten" widget appears with shifts from published performances
- [ ] Verify intern shifts show "Intern" badge
- [ ] Verify clicking a shift navigates to `/auffuehrungen/{id}/helferliste`
- [ ] Verify empty state shows "Keine offenen Schichten" when no shifts available
- [ ] Verify passive members do NOT see the widget

🤖 Generated with [Claude Code](https://claude.com/claude-code)