### PR TITLE
feat: offene schichten widget über volle breite

### DIFF
--- a/apps/web/app/(protected)/dashboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/page.tsx
@@ -697,8 +697,10 @@ export default async function DashboardPage({
               <UpcomingEventsWidget anmeldungen={upcomingAnmeldungen} produktionsAuffuehrungen={meineAuffuehrungen} />
               <MeineProbenWidget proben={meineProben} />
               <HelferEinsaetzeWidget einsaetze={verfuegbareEinsaetze ?? []} />
-              <OffeneSchichtenWidget schichten={offeneSchichten} />
             </div>
+
+            {/* Offene Schichten - full width */}
+            <OffeneSchichtenWidget schichten={offeneSchichten} />
 
             {/* History Section */}
             <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">


### PR DESCRIPTION
## Summary
- Move "Offene Schichten" widget out of the 3-column grid into its own full-width row for better visibility

## Test plan
- [ ] Dashboard als MITGLIED_AKTIV öffnen
- [ ] Widget "Offene Schichten" erstreckt sich über die volle Breite unterhalb der drei Widgets

🤖 Generated with [Claude Code](https://claude.com/claude-code)