### PR TITLE
feat: Passwort ändern in Einstellungen

### DIFF
--- a/apps/web/app/(protected)/mein-bereich/einstellungen/page.tsx
+++ b/apps/web/app/(protected)/mein-bereich/einstellungen/page.tsx
@@ -1,3 +1,4 @@
+import { ChangePasswordForm } from '@/components/account/ChangePasswordForm'
 import { NotificationSettings } from '@/components/notifications'
 import { getNotificationSettings } from '@/lib/actions/notifications'
 import Link from 'next/link'
@@ -16,7 +17,7 @@ export default async function EinstellungenPage() {
         <div>
           <h1 className="text-2xl font-bold text-gray-900">Einstellungen</h1>
           <p className="mt-1 text-gray-600">
-            Verwalte deine Benachrichtigungseinstellungen
+            Verwalte deine Einstellungen
           </p>
         </div>
         <Link
@@ -28,6 +29,8 @@ export default async function EinstellungenPage() {
       </div>
 
       <NotificationSettings settings={settings} />
+
+      <ChangePasswordForm />
     </div>
   )
 }

--- a/apps/web/components/account/ChangePasswordForm.tsx
+++ b/apps/web/components/account/ChangePasswordForm.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import { useState } from 'react'
+import { changePassword } from '@/app/actions/auth'
+import { Button, Input, Alert } from '@/components/ui'
+
+export function ChangePasswordForm() {
+  const [currentPassword, setCurrentPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState(false)
+  const [loading, setLoading] = useState(false)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setLoading(true)
+    setError('')
+    setSuccess(false)
+
+    if (newPassword.length < 6) {
+      setError('Neues Passwort muss mindestens 6 Zeichen lang sein')
+      setLoading(false)
+      return
+    }
+
+    if (newPassword !== confirmPassword) {
+      setError('Passwörter stimmen nicht überein')
+      setLoading(false)
+      return
+    }
+
+    const result = await changePassword(currentPassword, newPassword)
+
+    if (result?.error) {
+      setError(result.error)
+      setLoading(false)
+      return
+    }
+
+    setSuccess(true)
+    setCurrentPassword('')
+    setNewPassword('')
+    setConfirmPassword('')
+    setLoading(false)
+
+    setTimeout(() => setSuccess(false), 3000)
+  }
+
+  return (
+    <div className="rounded-lg bg-white p-6 shadow">
+      <h3 className="mb-4 text-lg font-semibold text-gray-900">
+        Passwort ändern
+      </h3>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {error && <Alert variant="error">{error}</Alert>}
+        {success && <Alert variant="success">Passwort wurde erfolgreich geändert</Alert>}
+
+        <Input
+          label="Aktuelles Passwort"
+          id="currentPassword"
+          type="password"
+          value={currentPassword}
+          onChange={(e) => setCurrentPassword(e.target.value)}
+          placeholder="••••••••"
+          required
+          autoComplete="current-password"
+        />
+
+        <Input
+          label="Neues Passwort"
+          id="newPassword"
+          type="password"
+          value={newPassword}
+          onChange={(e) => setNewPassword(e.target.value)}
+          placeholder="••••••••"
+          required
+          autoComplete="new-password"
+          helperText="Mindestens 6 Zeichen"
+        />
+
+        <Input
+          label="Neues Passwort bestätigen"
+          id="confirmNewPassword"
+          type="password"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          placeholder="••••••••"
+          required
+          autoComplete="new-password"
+        />
+
+        <Button type="submit" loading={loading}>
+          Passwort ändern
+        </Button>
+      </form>
+    </div>
+  )
+}

--- a/apps/web/lib/audit.ts
+++ b/apps/web/lib/audit.ts
@@ -6,6 +6,7 @@ export type AuditAction =
   | 'auth.login'
   | 'auth.logout'
   | 'auth.signup'
+  | 'auth.password_changed'
   | 'profile.updated'
   | 'role.assigned'
   | 'role.removed'


### PR DESCRIPTION
## Summary
- Neue `changePassword()` Server Action mit Verifizierung des aktuellen Passworts via `signInWithPassword()`
- Neues `ChangePasswordForm` Client-Component (3 Felder, Inline-Erfolgs-/Fehlermeldungen)
- Einstellungsseite um Passwort-Änderung erweitert

Closes #406

## Test plan
- [ ] Einstellungsseite aufrufen → Passwort-Formular wird unterhalb der Benachrichtigungen angezeigt
- [ ] Falsches aktuelles Passwort eingeben → Fehlermeldung "Aktuelles Passwort ist falsch"
- [ ] Neues Passwort < 6 Zeichen → Fehlermeldung
- [ ] Passwörter stimmen nicht überein → Fehlermeldung
- [ ] Korrektes altes + neues Passwort → Erfolgsmeldung, Felder werden geleert
- [ ] Mit neuem Passwort erneut einloggen → funktioniert

🤖 Generated with [Claude Code](https://claude.com/claude-code)