### PR TITLE
Add admin password reset functionality for users

### DIFF
--- a/apps/web/app/(protected)/mitglieder/[id]/page.tsx
+++ b/apps/web/app/(protected)/mitglieder/[id]/page.tsx
@@ -7,6 +7,7 @@ import { getUserProfile } from '@/lib/supabase/server'
 import { isManagement } from '@/lib/supabase/permissions'
 import { MitgliedForm } from '@/components/mitglieder/MitgliedForm'
 import { InviteButton } from '@/components/mitglieder/InviteButton'
+import { SetPasswordButton } from '@/components/admin/SetPasswordButton'
 import { PersonalCalendar } from '@/components/mein-bereich/PersonalCalendar'
 import { PersonEngagementHistory } from '@/components/mitglieder/PersonEngagementHistory'
 
@@ -69,6 +70,17 @@ export default async function MitgliedEditPage({ params }: PageProps) {
               invitedAt={person.invited_at}
               invitationAcceptedAt={person.invitation_accepted_at}
             />
+          </div>
+        )}
+
+        {/* Password reset for management (only if person has an account) */}
+        {person.profile_id && profile && isManagement(profile.role) && person.profile_id !== profile.id && (
+          <div className="mb-6 flex items-center gap-3 rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
+            <div className="flex-1">
+              <p className="text-sm font-medium text-neutral-900">Kontoverwaltung</p>
+              <p className="text-sm text-neutral-500">Passwort für dieses Mitglied manuell setzen</p>
+            </div>
+            <SetPasswordButton userId={person.profile_id} userEmail={person.email} />
           </div>
         )}
 

--- a/apps/web/app/actions/profile.ts
+++ b/apps/web/app/actions/profile.ts
@@ -2,7 +2,9 @@
 
 import { revalidatePath } from 'next/cache'
 import { createClient } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
 import { requirePermission } from '@/lib/supabase/auth-helpers'
+import { isManagement } from '@/lib/supabase/permissions'
 import { logAuditEvent } from '@/lib/audit'
 import type { UserRole } from '@/lib/supabase/types'
 
@@ -184,5 +186,60 @@ export async function updateUserRole(userId: string, role: UserRole) {
   })
 
   revalidatePath('/admin/users')
+  return { success: true }
+}
+
+export async function adminSetPassword(userId: string, newPassword: string) {
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return { error: 'Nicht angemeldet' }
+  }
+
+  const { data: currentProfile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+
+  if (!currentProfile || !isManagement(currentProfile.role as UserRole)) {
+    return { error: 'Keine Berechtigung' }
+  }
+
+  if (newPassword.length < 6) {
+    return { error: 'Passwort muss mindestens 6 Zeichen lang sein' }
+  }
+
+  // Prevent setting your own password via this action
+  if (userId === user.id) {
+    return { error: 'Eigenes Passwort bitte über die Profileinstellungen ändern' }
+  }
+
+  // Get target user info for audit log
+  const { data: targetProfile } = await supabase
+    .from('profiles')
+    .select('email')
+    .eq('id', userId)
+    .single()
+
+  // Use admin client to set password (bypasses RLS)
+  const adminClient = createAdminClient()
+  const { error } = await adminClient.auth.admin.updateUserById(userId, {
+    password: newPassword,
+  })
+
+  if (error) {
+    console.error('Failed to set password:', error)
+    return { error: 'Passwort konnte nicht gesetzt werden' }
+  }
+
+  await logAuditEvent('user.password_reset_by_management', 'profile', userId, {
+    target_email: targetProfile?.email,
+    reset_by: user.email,
+  })
+
   return { success: true }
 }

--- a/apps/web/components/admin/SetPasswordButton.tsx
+++ b/apps/web/components/admin/SetPasswordButton.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import { useState } from 'react'
+import { Modal } from '@/components/ui'
+import { adminSetPassword } from '@/app/actions/profile'
+
+interface SetPasswordButtonProps {
+  userId: string
+  userEmail?: string | null
+  className?: string
+}
+
+export function SetPasswordButton({
+  userId,
+  userEmail,
+  className = '',
+}: SetPasswordButtonProps) {
+  const [open, setOpen] = useState(false)
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState(false)
+  const [loading, setLoading] = useState(false)
+
+  function resetForm() {
+    setPassword('')
+    setConfirmPassword('')
+    setError('')
+    setSuccess(false)
+  }
+
+  function handleClose() {
+    setOpen(false)
+    resetForm()
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError('')
+
+    if (password.length < 6) {
+      setError('Passwort muss mindestens 6 Zeichen lang sein')
+      return
+    }
+
+    if (password !== confirmPassword) {
+      setError('Passwörter stimmen nicht überein')
+      return
+    }
+
+    setLoading(true)
+    const result = await adminSetPassword(userId, password)
+    setLoading(false)
+
+    if (result.error) {
+      setError(result.error)
+      return
+    }
+
+    setSuccess(true)
+    setTimeout(() => {
+      handleClose()
+    }, 1500)
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className={`text-sm text-primary-600 hover:text-primary-800 ${className}`}
+      >
+        Passwort setzen
+      </button>
+
+      <Modal
+        open={open}
+        onClose={handleClose}
+        title="Passwort setzen"
+        description={
+          userEmail
+            ? `Neues Passwort für ${userEmail} setzen`
+            : 'Neues Passwort für diesen Benutzer setzen'
+        }
+        size="sm"
+        footer={
+          !success ? (
+            <>
+              <button
+                type="button"
+                onClick={handleClose}
+                className="rounded-lg px-4 py-2 text-sm text-neutral-600 hover:bg-neutral-100"
+              >
+                Abbrechen
+              </button>
+              <button
+                type="submit"
+                form="set-password-form"
+                disabled={loading}
+                className="rounded-lg bg-primary-600 px-4 py-2 text-sm text-white hover:bg-primary-700 disabled:opacity-50"
+              >
+                {loading ? 'Wird gesetzt...' : 'Passwort setzen'}
+              </button>
+            </>
+          ) : undefined
+        }
+      >
+        {success ? (
+          <div className="rounded-lg bg-green-50 p-4 text-sm text-green-800">
+            Passwort wurde erfolgreich gesetzt.
+          </div>
+        ) : (
+          <form id="set-password-form" onSubmit={handleSubmit} className="space-y-4">
+            {error && (
+              <div className="rounded-lg bg-red-50 p-3 text-sm text-red-800">
+                {error}
+              </div>
+            )}
+            <div>
+              <label
+                htmlFor="new-password"
+                className="mb-1 block text-sm font-medium text-neutral-700"
+              >
+                Neues Passwort
+              </label>
+              <input
+                id="new-password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                minLength={6}
+                autoComplete="new-password"
+                className="w-full rounded-lg border border-neutral-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="confirm-password"
+                className="mb-1 block text-sm font-medium text-neutral-700"
+              >
+                Passwort bestätigen
+              </label>
+              <input
+                id="confirm-password"
+                type="password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                required
+                minLength={6}
+                autoComplete="new-password"
+                className="w-full rounded-lg border border-neutral-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+              />
+            </div>
+          </form>
+        )}
+      </Modal>
+    </>
+  )
+}

--- a/apps/web/components/admin/UsersTable.tsx
+++ b/apps/web/components/admin/UsersTable.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
 import { UserRoleSelect } from './UserRoleSelect'
+import { SetPasswordButton } from './SetPasswordButton'
 import { toggleUserActive } from '@/app/actions/profile'
 import type { UserRole } from '@/lib/supabase/types'
 
@@ -140,16 +141,19 @@ export function UsersTable({
                 </td>
                 <td className="py-3">
                   {u.id !== currentUserId && (
-                    <button
-                      onClick={() => handleToggleActive(u.id)}
-                      className={`text-sm ${
-                        u.is_active === false
-                          ? 'text-green-600 hover:text-green-800'
-                          : 'text-red-600 hover:text-red-800'
-                      }`}
-                    >
-                      {u.is_active === false ? 'Aktivieren' : 'Deaktivieren'}
-                    </button>
+                    <div className="flex gap-3">
+                      <SetPasswordButton userId={u.id} userEmail={u.email} />
+                      <button
+                        onClick={() => handleToggleActive(u.id)}
+                        className={`text-sm ${
+                          u.is_active === false
+                            ? 'text-green-600 hover:text-green-800'
+                            : 'text-red-600 hover:text-red-800'
+                        }`}
+                      >
+                        {u.is_active === false ? 'Aktivieren' : 'Deaktivieren'}
+                      </button>
+                    </div>
                   )}
                 </td>
               </tr>

--- a/apps/web/lib/audit.ts
+++ b/apps/web/lib/audit.ts
@@ -12,6 +12,7 @@ export type AuditAction =
   | 'role.removed'
   | 'user.disabled'
   | 'user.enabled'
+  | 'user.password_reset_by_management'
 
 export interface AuditLogEntry {
   id: string


### PR DESCRIPTION
# Kontext
Administratoren und Management-Benutzer benötigen die Möglichkeit, Passwörter für andere Benutzer zurückzusetzen. Dies ist notwendig für die Benutzerverwaltung, wenn Benutzer ihr Passwort vergessen haben oder neue Konten eingerichtet werden müssen.

# Änderungen
- Neue `SetPasswordButton` Komponente für Admin-Interface mit Modal-Dialog zur Passwort-Eingabe
- Neue Server-Action `adminSetPassword` mit Berechtigungsprüfung und Audit-Logging
- Integration des Passwort-Reset-Buttons in die Benutzertabelle im Admin-Panel
- Integration des Passwort-Reset-Buttons in die Mitglied-Detailseite für Management-Benutzer
- Validierung: Mindestlänge 6 Zeichen, Passwortbestätigung, Verhinderung von Selbst-Passwort-Änderung
- Audit-Log-Eintrag `user.password_reset_by_management` für Nachverfolgung
- Verwendung des Admin-Clients zum Umgehen von RLS-Richtlinien

# Tests
- [x] Lokal getestet

# Checkliste
- [x] Keine sensiblen Daten enthalten
- [x] Berechtigungsprüfung implementiert (nur Management-Rolle)
- [x] Audit-Logging für Compliance

https://claude.ai/code/session_01NxwTwa1NaKTf2saDkPgEoT