### PR TITLE
fix: confirmation email links to dashboard instead of public page

### DIFF
--- a/apps/web/lib/actions/email-sender.ts
+++ b/apps/web/lib/actions/email-sender.ts
@@ -178,6 +178,7 @@ export async function sendBookingConfirmation(
     .select(`
       id,
       abmeldung_token,
+      external_helper_id,
       person:personen(id, vorname, nachname, email),
       schicht:auffuehrung_schichten(
         id,
@@ -229,6 +230,21 @@ export async function sendBookingConfirmation(
   // Get info blocks (briefing, helferessen)
   const infoTimes = await getInfoBlockTimes(veranstaltung.id)
 
+  // Build dashboard link
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
+  let dashboardLink = `${baseUrl}/meine-einsaetze`
+
+  const externalHelperId = (zuweisung as unknown as { external_helper_id: string | null }).external_helper_id
+  if (externalHelperId) {
+    const { data: dashboardToken } = await supabase.rpc(
+      'get_externe_helfer_dashboard_token',
+      { p_helper_id: externalHelperId }
+    )
+    if (dashboardToken) {
+      dashboardLink = `${baseUrl}/helfer/meine-einsaetze/${dashboardToken}`
+    }
+  }
+
   // Get email template
   const template = await getEmailTemplateInternal('confirmation')
   if (!template) {
@@ -256,6 +272,7 @@ export async function sendBookingConfirmation(
     public_link: veranstaltung.public_helfer_token
       ? buildPublicLink(veranstaltung.public_helfer_token)
       : '',
+    dashboard_link: dashboardLink,
     koordinator_name: koordinator.name,
     koordinator_email: koordinator.email,
     koordinator_telefon: koordinator.telefon,

--- a/apps/web/lib/actions/email-templates.ts
+++ b/apps/web/lib/actions/email-templates.ts
@@ -253,6 +253,9 @@ export async function resetEmailTemplateToDefault(
   <p>Falls du doch nicht kommen kannst, melde dich bitte rechtzeitig ab:</p>
   <p><a href="{{absage_link}}" style="display: inline-block; background: #dc2626; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px;">Anmeldung stornieren</a></p>
 
+  <p style="margin-top: 20px;">Alle deine Einsätze auf einen Blick:</p>
+  <p><a href="{{dashboard_link}}" style="display: inline-block; background: #7c3aed; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px;">Meine Einsätze ansehen</a></p>
+
   <p style="margin-top: 30px;">Bei Fragen wende dich an:</p>
   <p>{{koordinator_name}}<br>
   {{koordinator_email}}<br>
@@ -285,6 +288,9 @@ Helferessen: {{helferessen_zeit}}
 Falls du doch nicht kommen kannst, melde dich bitte rechtzeitig ab:
 {{absage_link}}
 
+Alle deine Einsätze auf einen Blick:
+{{dashboard_link}}
+
 Bei Fragen wende dich an:
 {{koordinator_name}}
 {{koordinator_email}}
@@ -306,6 +312,7 @@ Diese E-Mail wurde automatisch von BackstagePass gesendet.`,
         'briefing_zeit',
         'helferessen_zeit',
         'absage_link',
+        'dashboard_link',
         'koordinator_name',
         'koordinator_email',
         'koordinator_telefon',

--- a/apps/web/lib/supabase/types.ts
+++ b/apps/web/lib/supabase/types.ts
@@ -2493,6 +2493,7 @@ export type EmailPlaceholderData = {
   koordinator_telefon?: string
   frist?: string
   magic_link?: string
+  dashboard_link?: string
 }
 
 // =============================================================================

--- a/apps/web/lib/utils/email-renderer.ts
+++ b/apps/web/lib/utils/email-renderer.ts
@@ -25,6 +25,7 @@ const TRUSTED_PLACEHOLDERS = new Set([
   'absage_link',
   'public_link',
   'magic_link',
+  'dashboard_link',
 ])
 
 /**
@@ -94,6 +95,7 @@ export const SAMPLE_PLACEHOLDER_DATA: EmailPlaceholderData = {
   koordinator_telefon: '+41 79 123 45 67',
   frist: 'Freitag, 14. März 2026, 18:00 Uhr',
   magic_link: 'https://example.com/auth/confirm?token_hash=abc123&type=invite',
+  dashboard_link: 'https://example.com/helfer/meine-einsaetze/abc123',
 }
 
 /**


### PR DESCRIPTION
## Summary
- Bestätigungsmail enthält neu einen "Meine Einsätze ansehen"-Button, der zum persönlichen Dashboard verlinkt statt zur öffentlichen Anmeldeseite
- Externe Helfer erhalten einen Token-basierten Dashboard-Link (`/helfer/meine-einsaetze/{token}`)
- Interne Mitglieder erhalten den authentifizierten Route-Link (`/meine-einsaetze`)
- `public_link` bleibt unverändert (wird korrekt in Abmeldungs- und Warteliste-Mails verwendet)

Closes #411

## Geänderte Dateien
- `lib/supabase/types.ts` — `dashboard_link` zu `EmailPlaceholderData` hinzugefügt
- `lib/utils/email-renderer.ts` — `dashboard_link` in `TRUSTED_PLACEHOLDERS` und `SAMPLE_PLACEHOLDER_DATA`
- `lib/actions/email-sender.ts` — Dashboard-Link-Logik in `sendBookingConfirmation()`
- `lib/actions/email-templates.ts` — Default-Template um Dashboard-Button erweitert

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no warnings
- [x] `npm run test:run` — 153/153 passed
- [x] `npm run build` — successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)