### PR TITLE
fix: mitmachen confirmation email links to dashboard instead of /mitmachen

### DIFF
--- a/apps/web/lib/actions/public-overview.ts
+++ b/apps/web/lib/actions/public-overview.ts
@@ -456,7 +456,7 @@ async function sendConfirmationEmail(
 
   const dashboardLink = dashboardToken
     ? `${baseUrl}/helfer/meine-einsaetze/${dashboardToken}`
-    : `${baseUrl}/mitmachen`
+    : `${baseUrl}/meine-einsaetze`
 
   const { subject, html, text } = multiRegistrationConfirmationEmail(
     `${helperData.vorname} ${helperData.nachname}`,


### PR DESCRIPTION
## Summary
- Die Bestätigungsmail nach Registrierung über `/mitmachen` verlinkte im Fallback auf `/mitmachen` statt auf das Dashboard
- Fallback geändert von `/mitmachen` zu `/meine-einsaetze`
- Der erste PR (#412) hat den Template-basierten Flow (`email-sender.ts`) gefixt, dieser PR fixt den hardcoded Flow (`public-overview.ts`) der bei `/mitmachen`-Registrierungen verwendet wird

Closes #411

## Geänderte Datei
- `lib/actions/public-overview.ts` — Fallback-Link von `/mitmachen` zu `/meine-einsaetze` geändert (Zeile 459)

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no warnings
- [x] `npm run test:run` — 153/153 passed
- [x] `npm run build` — successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)