### PR TITLE
fix: confirmation email uses dashboard magic link

### DIFF
--- a/apps/web/lib/actions/email-sender.ts
+++ b/apps/web/lib/actions/email-sender.ts
@@ -232,17 +232,23 @@ export async function sendBookingConfirmation(
 
   // Build dashboard link
   const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
-  let dashboardLink = `${baseUrl}/meine-einsaetze`
+  let dashboardLink = ''
 
   const externalHelperId = (zuweisung as unknown as { external_helper_id: string | null }).external_helper_id
   if (externalHelperId) {
-    const { data: dashboardToken } = await supabase.rpc(
+    const { data: dashboardToken, error: tokenError } = await supabase.rpc(
       'get_externe_helfer_dashboard_token',
       { p_helper_id: externalHelperId }
     )
+    if (tokenError) {
+      console.error('[Email] Failed to get dashboard token:', tokenError)
+    }
     if (dashboardToken) {
       dashboardLink = `${baseUrl}/helfer/meine-einsaetze/${dashboardToken}`
     }
+  } else {
+    // Logged-in user: link to protected dashboard
+    dashboardLink = `${baseUrl}/dashboard`
   }
 
   // Get email template

--- a/apps/web/lib/actions/public-overview.ts
+++ b/apps/web/lib/actions/public-overview.ts
@@ -266,10 +266,13 @@ export async function registerForMultipleShifts(
   }
 
   // Get dashboard token
-  const { data: dashboardToken } = await supabase.rpc(
+  const { data: dashboardToken, error: tokenError } = await supabase.rpc(
     'get_externe_helfer_dashboard_token',
     { p_helper_id: helperId }
   )
+  if (tokenError) {
+    console.error('[PublicOverview] Failed to get dashboard token:', tokenError)
+  }
 
   const anySuccess = results.some((r) => r.success)
 
@@ -456,7 +459,7 @@ async function sendConfirmationEmail(
 
   const dashboardLink = dashboardToken
     ? `${baseUrl}/helfer/meine-einsaetze/${dashboardToken}`
-    : `${baseUrl}/meine-einsaetze`
+    : `${baseUrl}/mitmachen`
 
   const { subject, html, text } = multiRegistrationConfirmationEmail(
     `${helperData.vorname} ${helperData.nachname}`,


### PR DESCRIPTION
## Summary
- Fixes confirmation email linking to `/meine-einsaetze` (protected route, unreachable for external helpers) instead of `/helfer/meine-einsaetze/{dashboardToken}` (public magic link)
- Added error logging when `get_externe_helfer_dashboard_token` RPC fails
- Fixed fallbacks: `/dashboard` for logged-in users, `/mitmachen` for external helpers

## Changes
- `email-sender.ts`: Differentiate between external helpers (magic link) and logged-in users (`/dashboard`), add RPC error logging
- `public-overview.ts`: Fallback to `/mitmachen` instead of `/meine-einsaetze`, add RPC error logging

## Related
Closes #411 (follow-up to #412 and #413)

## Test plan
- [ ] Register as external helper via `/mitmachen`
- [ ] Verify confirmation email contains `/helfer/meine-einsaetze/{token}` link
- [ ] Click link → lands on personal dashboard with registered shifts

🤖 Generated with [Claude Code](https://claude.com/claude-code)