### PR TITLE
feat: TGW slogan and contact email in email templates

### DIFF
--- a/apps/web/lib/actions/email-sender.ts
+++ b/apps/web/lib/actions/email-sender.ts
@@ -79,7 +79,7 @@ export async function getKoordinatorInfo(koordinatorId: string | null): Promise<
   if (!koordinatorId) {
     return {
       name: 'TGW Koordination',
-      email: 'helfer@tgw.ch',
+      email: 'theatergruppewiden@gmail.com',
       telefon: '',
     }
   }
@@ -95,14 +95,14 @@ export async function getKoordinatorInfo(koordinatorId: string | null): Promise<
   if (!data) {
     return {
       name: 'TGW Koordination',
-      email: 'helfer@tgw.ch',
+      email: 'theatergruppewiden@gmail.com',
       telefon: '',
     }
   }
 
   return {
     name: `${data.vorname} ${data.nachname}`,
-    email: data.email || 'helfer@tgw.ch',
+    email: data.email || 'theatergruppewiden@gmail.com',
     telefon: data.telefon || '',
   }
 }

--- a/apps/web/lib/actions/email-templates.ts
+++ b/apps/web/lib/actions/email-templates.ts
@@ -262,7 +262,8 @@ export async function resetEmailTemplateToDefault(
   {{koordinator_telefon}}</p>
 
   <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 30px 0;">
-  <p style="color: #6b7280; font-size: 14px;">Diese E-Mail wurde automatisch von BackstagePass gesendet.</p>
+  <p style="color: #6b7280; font-size: 14px;">Theatergruppe Widen — s'Theater uf em Mutschelle<br>
+  <a href="mailto:theatergruppewiden@gmail.com" style="color: #7c3aed;">theatergruppewiden@gmail.com</a></p>
 </div>`,
       body_text: `Vielen Dank für deine Anmeldung!
 
@@ -297,7 +298,8 @@ Bei Fragen wende dich an:
 {{koordinator_telefon}}
 
 ---
-Diese E-Mail wurde automatisch von BackstagePass gesendet.`,
+Theatergruppe Widen — s'Theater uf em Mutschelle
+theatergruppewiden@gmail.com`,
       placeholders: [
         'vorname',
         'nachname',
@@ -346,7 +348,8 @@ Diese E-Mail wurde automatisch von BackstagePass gesendet.`,
   {{koordinator_telefon}}</p>
 
   <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 30px 0;">
-  <p style="color: #6b7280; font-size: 14px;">Diese E-Mail wurde automatisch von BackstagePass gesendet.</p>
+  <p style="color: #6b7280; font-size: 14px;">Theatergruppe Widen — s'Theater uf em Mutschelle<br>
+  <a href="mailto:theatergruppewiden@gmail.com" style="color: #7c3aed;">theatergruppewiden@gmail.com</a></p>
 </div>`,
       body_text: `Nicht vergessen: Morgen ist es soweit!
 
@@ -372,7 +375,8 @@ Bei Fragen oder wenn du doch absagen musst:
 {{koordinator_telefon}}
 
 ---
-Diese E-Mail wurde automatisch von BackstagePass gesendet.`,
+Theatergruppe Widen — s'Theater uf em Mutschelle
+theatergruppewiden@gmail.com`,
       placeholders: [
         'vorname',
         'nachname',
@@ -410,7 +414,8 @@ Diese E-Mail wurde automatisch von BackstagePass gesendet.`,
   {{koordinator_telefon}}</p>
 
   <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 30px 0;">
-  <p style="color: #6b7280; font-size: 14px;">Diese E-Mail wurde automatisch von BackstagePass gesendet.</p>
+  <p style="color: #6b7280; font-size: 14px;">Theatergruppe Widen — s'Theater uf em Mutschelle<br>
+  <a href="mailto:theatergruppewiden@gmail.com" style="color: #7c3aed;">theatergruppewiden@gmail.com</a></p>
 </div>`,
       body_text: `Heute ist es soweit!
 
@@ -429,7 +434,8 @@ Bis gleich!
 Notfall-Kontakt: {{koordinator_telefon}}
 
 ---
-Diese E-Mail wurde automatisch von BackstagePass gesendet.`,
+Theatergruppe Widen — s'Theater uf em Mutschelle
+theatergruppewiden@gmail.com`,
       placeholders: [
         'vorname',
         'nachname',
@@ -460,7 +466,8 @@ Diese E-Mail wurde automatisch von BackstagePass gesendet.`,
   <p><a href="{{public_link}}" style="display: inline-block; background: #7c3aed; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px;">Zur Anmeldung</a></p>
 
   <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 30px 0;">
-  <p style="color: #6b7280; font-size: 14px;">Diese E-Mail wurde automatisch von BackstagePass gesendet.</p>
+  <p style="color: #6b7280; font-size: 14px;">Theatergruppe Widen — s'Theater uf em Mutschelle<br>
+  <a href="mailto:theatergruppewiden@gmail.com" style="color: #7c3aed;">theatergruppewiden@gmail.com</a></p>
 </div>`,
       body_text: `Deine Abmeldung wurde bestätigt
 
@@ -478,7 +485,8 @@ Du kannst dich jederzeit wieder für andere Schichten anmelden:
 {{public_link}}
 
 ---
-Diese E-Mail wurde automatisch von BackstagePass gesendet.`,
+Theatergruppe Widen — s'Theater uf em Mutschelle
+theatergruppewiden@gmail.com`,
       placeholders: [
         'vorname',
         'nachname',
@@ -515,7 +523,8 @@ Diese E-Mail wurde automatisch von BackstagePass gesendet.`,
   </p>
 
   <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 30px 0;">
-  <p style="color: #6b7280; font-size: 14px;">Diese E-Mail wurde automatisch von BackstagePass gesendet.</p>
+  <p style="color: #6b7280; font-size: 14px;">Theatergruppe Widen — s'Theater uf em Mutschelle<br>
+  <a href="mailto:theatergruppewiden@gmail.com" style="color: #7c3aed;">theatergruppewiden@gmail.com</a></p>
 </div>`,
       body_text: `Gute Nachricht!
 
@@ -535,7 +544,8 @@ Bestätige hier: {{absage_link}}
 Wenn du nicht kannst, lass es uns bitte wissen.
 
 ---
-Diese E-Mail wurde automatisch von BackstagePass gesendet.`,
+Theatergruppe Widen — s'Theater uf em Mutschelle
+theatergruppewiden@gmail.com`,
       placeholders: [
         'vorname',
         'nachname',
@@ -560,7 +570,8 @@ Diese E-Mail wurde automatisch von BackstagePass gesendet.`,
   <p><a href="{{public_link}}" style="display: inline-block; background: #7c3aed; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px;">Zur Anmeldung</a></p>
 
   <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 30px 0;">
-  <p style="color: #6b7280; font-size: 14px;">Diese E-Mail wurde automatisch von BackstagePass gesendet.</p>
+  <p style="color: #6b7280; font-size: 14px;">Theatergruppe Widen — s'Theater uf em Mutschelle<br>
+  <a href="mailto:theatergruppewiden@gmail.com" style="color: #7c3aed;">theatergruppewiden@gmail.com</a></p>
 </div>`,
       body_text: `Platz wurde weitergegeben
 
@@ -574,7 +585,8 @@ Du kannst dich aber gerne für andere Schichten anmelden:
 {{public_link}}
 
 ---
-Diese E-Mail wurde automatisch von BackstagePass gesendet.`,
+Theatergruppe Widen — s'Theater uf em Mutschelle
+theatergruppewiden@gmail.com`,
       placeholders: [
         'vorname',
         'nachname',
@@ -600,7 +612,8 @@ Diese E-Mail wurde automatisch von BackstagePass gesendet.`,
   Das TGW-Team</p>
 
   <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 30px 0;">
-  <p style="color: #6b7280; font-size: 14px;">Diese E-Mail wurde automatisch von BackstagePass gesendet.</p>
+  <p style="color: #6b7280; font-size: 14px;">Theatergruppe Widen — s'Theater uf em Mutschelle<br>
+  <a href="mailto:theatergruppewiden@gmail.com" style="color: #7c3aed;">theatergruppewiden@gmail.com</a></p>
 </div>`,
       body_text: `Vielen herzlichen Dank!
 
@@ -616,7 +629,8 @@ Herzliche Grüsse
 Das TGW-Team
 
 ---
-Diese E-Mail wurde automatisch von BackstagePass gesendet.`,
+Theatergruppe Widen — s'Theater uf em Mutschelle
+theatergruppewiden@gmail.com`,
       placeholders: ['vorname', 'nachname', 'veranstaltung', 'rolle'],
     },
     member_invitation: {
@@ -644,8 +658,8 @@ Diese E-Mail wurde automatisch von BackstagePass gesendet.`,
   <p style="color: #6b7280; font-size: 14px;">Der Link ist 24 Stunden gültig. Falls er abgelaufen ist, wende dich an den Vorstand für eine neue Einladung.</p>
 
   <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 30px 0;">
-  <p style="color: #6b7280; font-size: 14px;">Diese E-Mail wurde automatisch von BackstagePass gesendet.<br>
-  Theatergruppe Widen | <a href="https://www.theatergruppe-widen.ch" style="color: #7c3aed;">www.theatergruppe-widen.ch</a></p>
+  <p style="color: #6b7280; font-size: 14px;">Theatergruppe Widen — s'Theater uf em Mutschelle<br>
+  <a href="mailto:theatergruppewiden@gmail.com" style="color: #7c3aed;">theatergruppewiden@gmail.com</a> | <a href="https://www.theatergruppe-widen.ch" style="color: #7c3aed;">www.theatergruppe-widen.ch</a></p>
 </div>`,
       body_text: `Willkommen bei BackstagePass!
 
@@ -666,8 +680,8 @@ Jetzt anmelden: {{magic_link}}
 Der Link ist 24 Stunden gültig. Falls er abgelaufen ist, wende dich an den Vorstand für eine neue Einladung.
 
 ---
-Diese E-Mail wurde automatisch von BackstagePass gesendet.
-Theatergruppe Widen | www.theatergruppe-widen.ch`,
+Theatergruppe Widen — s'Theater uf em Mutschelle
+theatergruppewiden@gmail.com | www.theatergruppe-widen.ch`,
       placeholders: ['vorname', 'magic_link'],
     },
   }

--- a/apps/web/lib/actions/reminder-sender.ts
+++ b/apps/web/lib/actions/reminder-sender.ts
@@ -51,7 +51,7 @@ async function getKoordinatorInfo(koordinatorId: string | null): Promise<{
   if (!koordinatorId) {
     return {
       name: 'TGW Koordination',
-      email: 'helfer@tgw.ch',
+      email: 'theatergruppewiden@gmail.com',
       telefon: '',
     }
   }
@@ -67,14 +67,14 @@ async function getKoordinatorInfo(koordinatorId: string | null): Promise<{
   if (!data) {
     return {
       name: 'TGW Koordination',
-      email: 'helfer@tgw.ch',
+      email: 'theatergruppewiden@gmail.com',
       telefon: '',
     }
   }
 
   return {
     name: `${data.vorname} ${data.nachname}`,
-    email: data.email || 'helfer@tgw.ch',
+    email: data.email || 'theatergruppewiden@gmail.com',
     telefon: data.telefon || '',
   }
 }

--- a/apps/web/lib/email/templates/helferliste.ts
+++ b/apps/web/lib/email/templates/helferliste.ts
@@ -62,8 +62,8 @@ export function eventPublishedEmail(
           </p>
         </div>
         <div class="footer">
-          <p>Diese E-Mail wurde automatisch von BackstagePass gesendet.</p>
-          <p>Theatergruppe Widen</p>
+          <p>Theatergruppe Widen — s'Theater uf em Mutschelle</p>
+          <p><a href="mailto:theatergruppewiden@gmail.com" style="color: #3b82f6;">theatergruppewiden@gmail.com</a></p>
         </div>
       </div>
     </body>
@@ -81,7 +81,8 @@ ${event.ort ? `Ort: ${event.ort}` : ''}
 Schau dir die offenen Rollen an: ${publicLink || 'Siehe BackstagePass'}
 
 --
-BackstagePass - Theatergruppe Widen
+Theatergruppe Widen — s'Theater uf em Mutschelle
+theatergruppewiden@gmail.com
   `
 
   return { subject, html, text }
@@ -131,8 +132,8 @@ export function registrationConfirmationEmail(
           }
         </div>
         <div class="footer">
-          <p>Diese E-Mail wurde automatisch von BackstagePass gesendet.</p>
-          <p>Theatergruppe Widen</p>
+          <p>Theatergruppe Widen — s'Theater uf em Mutschelle</p>
+          <p><a href="mailto:theatergruppewiden@gmail.com" style="color: #3b82f6;">theatergruppewiden@gmail.com</a></p>
         </div>
       </div>
     </body>
@@ -154,7 +155,8 @@ Status: ${isWaitlist ? 'Warteliste' : 'Angemeldet'}
 ${isWaitlist ? 'Du stehst auf der Warteliste. Wir melden uns, sobald ein Platz frei wird.' : 'Wir freuen uns auf dich!'}
 
 --
-BackstagePass - Theatergruppe Widen
+Theatergruppe Widen — s'Theater uf em Mutschelle
+theatergruppewiden@gmail.com
   `
 
   return { subject, html, text }
@@ -267,8 +269,8 @@ export function multiRegistrationConfirmationEmail(
           ${koordinatorHtml}
         </div>
         <div class="footer">
-          <p>Diese E-Mail wurde automatisch von BackstagePass gesendet.</p>
-          <p>Theatergruppe Widen</p>
+          <p>Theatergruppe Widen — s'Theater uf em Mutschelle</p>
+          <p><a href="mailto:theatergruppewiden@gmail.com" style="color: #3b82f6;">theatergruppewiden@gmail.com</a></p>
         </div>
       </div>
     </body>
@@ -300,7 +302,8 @@ Meine Einsätze: ${dashboardLink}
 ${koordinator ? `\nKoordination: ${koordinator.name}, ${koordinator.email}${koordinator.telefon ? `, ${koordinator.telefon}` : ''}` : ''}
 
 --
-BackstagePass - Theatergruppe Widen
+Theatergruppe Widen — s'Theater uf em Mutschelle
+theatergruppewiden@gmail.com
   `
 
   return { subject, html, text }
@@ -359,8 +362,8 @@ export function statusUpdateEmail(
           <p>${message || statusMessages[newStatus]}</p>
         </div>
         <div class="footer">
-          <p>Diese E-Mail wurde automatisch von BackstagePass gesendet.</p>
-          <p>Theatergruppe Widen</p>
+          <p>Theatergruppe Widen — s'Theater uf em Mutschelle</p>
+          <p><a href="mailto:theatergruppewiden@gmail.com" style="color: #3b82f6;">theatergruppewiden@gmail.com</a></p>
         </div>
       </div>
     </body>
@@ -380,7 +383,8 @@ Neuer Status: ${statusLabels[newStatus]}
 ${message || statusMessages[newStatus]}
 
 --
-BackstagePass - Theatergruppe Widen
+Theatergruppe Widen — s'Theater uf em Mutschelle
+theatergruppewiden@gmail.com
   `
 
   return { subject, html, text }
@@ -420,8 +424,8 @@ export function cancellationConfirmationEmail(
           <p>Danke, dass du uns rechtzeitig Bescheid gegeben hast. So können wir den Platz an jemand anderen vergeben.</p>
         </div>
         <div class="footer">
-          <p>Diese E-Mail wurde automatisch von BackstagePass gesendet.</p>
-          <p>Theatergruppe Widen</p>
+          <p>Theatergruppe Widen — s'Theater uf em Mutschelle</p>
+          <p><a href="mailto:theatergruppewiden@gmail.com" style="color: #3b82f6;">theatergruppewiden@gmail.com</a></p>
         </div>
       </div>
     </body>
@@ -442,7 +446,8 @@ ${event.zeitblock ? `Zeit: ${event.zeitblock}` : ''}
 Danke, dass du uns rechtzeitig Bescheid gegeben hast.
 
 --
-BackstagePass - Theatergruppe Widen
+Theatergruppe Widen — s'Theater uf em Mutschelle
+theatergruppewiden@gmail.com
   `
 
   return { subject, html, text }
@@ -495,8 +500,8 @@ export function waitlistPromotionEmail(
           ` : ''}
         </div>
         <div class="footer">
-          <p>Diese E-Mail wurde automatisch von BackstagePass gesendet.</p>
-          <p>Theatergruppe Widen</p>
+          <p>Theatergruppe Widen — s'Theater uf em Mutschelle</p>
+          <p><a href="mailto:theatergruppewiden@gmail.com" style="color: #3b82f6;">theatergruppewiden@gmail.com</a></p>
         </div>
       </div>
     </body>
@@ -519,7 +524,8 @@ Wir freuen uns auf dich!
 ${abmeldungLink ? `\nFalls du doch nicht teilnehmen kannst: ${abmeldungLink}` : ''}
 
 --
-BackstagePass - Theatergruppe Widen
+Theatergruppe Widen — s'Theater uf em Mutschelle
+theatergruppewiden@gmail.com
   `
 
   return { subject, html, text }


### PR DESCRIPTION
## Summary
- Add slogan **"s'Theater uf em Mutschelle"** to all email footers (HTML + plaintext)
- Replace default contact email `helfer@tgw.ch` → `theatergruppewiden@gmail.com` (6 occurrences)
- Covers all 13 email templates (7 DB-stored + 6 code-based helferliste templates)

## Changes
- `email-sender.ts` — default coordinator email
- `reminder-sender.ts` — default coordinator email
- `email-templates.ts` — all 7 template footers (HTML + plaintext)
- `lib/email/templates/helferliste.ts` — all 6 template footers (HTML + plaintext)

## Test plan
- [ ] Trigger a confirmation email → footer shows slogan + correct email
- [ ] Check all template previews in admin → footers updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)