### PR TITLE
feat: Dashboard CTA 'Weitere Schichten buchen' + Link zu /mitmachen

### DIFF
--- a/apps/web/components/helfer-dashboard/HelferDashboardView.tsx
+++ b/apps/web/components/helfer-dashboard/HelferDashboardView.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import Link from 'next/link'
 import { Card, CardContent } from '@/components/ui'
 import { ShiftCard } from './ShiftCard'
 import type {
@@ -62,6 +63,34 @@ export function HelferDashboardView({ data, showHeader = true }: HelferDashboard
               <p className="text-sm text-neutral-500">{data.helper.email}</p>
             </CardContent>
           </Card>
+
+          {/* CTA: Weitere Schichten buchen */}
+          <Link
+            href="/mitmachen"
+            className="flex items-center justify-between rounded-lg border border-primary-200 bg-primary-50 px-5 py-4 transition-colors hover:bg-primary-100"
+          >
+            <div>
+              <p className="font-semibold text-primary-900">
+                Weitere Schichten buchen
+              </p>
+              <p className="text-sm text-primary-700">
+                Alle offenen Helfer-Einsätze ansehen und dich anmelden
+              </p>
+            </div>
+            <svg
+              className="h-5 w-5 flex-shrink-0 text-primary-600"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 5l7 7-7 7"
+              />
+            </svg>
+          </Link>
         </>
       )}
 
@@ -81,6 +110,12 @@ export function HelferDashboardView({ data, showHeader = true }: HelferDashboard
               <p className="text-neutral-500">
                 Du hast keine kommenden Einsätze.
               </p>
+              <Link
+                href="/mitmachen"
+                className="mt-3 inline-block text-sm font-medium text-primary-600 hover:text-primary-700"
+              >
+                Offene Einsätze ansehen
+              </Link>
             </CardContent>
           </Card>
         ) : (
@@ -151,6 +186,25 @@ export function HelferDashboardView({ data, showHeader = true }: HelferDashboard
               Sobald du dich für einen Helfer-Einsatz anmeldest, siehst du hier
               deine Übersicht.
             </p>
+            <Link
+              href="/mitmachen"
+              className="mt-4 inline-flex items-center gap-2 rounded-lg bg-primary-600 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-primary-700"
+            >
+              Jetzt Schichten buchen
+              <svg
+                className="h-4 w-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9 5l7 7-7 7"
+                />
+              </svg>
+            </Link>
           </CardContent>
         </Card>
       )}

--- a/apps/web/components/helfer-dashboard/ShiftCard.tsx
+++ b/apps/web/components/helfer-dashboard/ShiftCard.tsx
@@ -65,7 +65,7 @@ export function ShiftCard({ anmeldung, canCancel, isPast }: ShiftCardProps) {
         {!isPast && (
           <div className="mt-3 flex flex-wrap gap-2 border-t border-neutral-100 pt-3">
             <Link
-              href={`/helfer/anmeldung/${anmeldung.event_public_token}` as never}
+              href="/mitmachen"
               className="text-sm font-medium text-primary-600 hover:text-primary-700"
             >
               Weitere Schichten


### PR DESCRIPTION
## Summary

- Prominenter "Weitere Schichten buchen"-CTA-Banner im Helfer-Dashboard mit Link zu `/mitmachen`
- Empty-State-Links zu `/mitmachen` (kommende Einsätze leer + globaler Empty State)
- `ShiftCard` "Weitere Schichten"-Link von altem System B Route (`/helfer/anmeldung/...`) auf `/mitmachen` geändert

Closes #415

## Test plan

- [ ] `npm run typecheck` — bestanden
- [ ] `npm run lint` — bestanden
- [ ] `npm run test:run` — 153/153 Tests bestanden
- [ ] `npm run build` — bestanden
- [ ] Manuell: Dashboard zeigt CTA-Banner mit Link zu `/mitmachen`
- [ ] Manuell: Empty States zeigen Links zu `/mitmachen`
- [ ] Manuell: ShiftCard "Weitere Schichten" führt zu `/mitmachen`

🤖 Generated with [Claude Code](https://claude.com/claude-code)