### PR TITLE
fix: migrate schichten to helferliste for /mitmachen

### DIFF
--- a/supabase/migrations/20260307120000_migrate_schichten_to_helferliste.sql
+++ b/supabase/migrations/20260307120000_migrate_schichten_to_helferliste.sql
@@ -1,0 +1,75 @@
+-- Migration: Transfer auffuehrung_schichten data to helferliste system
+-- Created: 2026-03-07
+-- Description: Creates helfer_events + helfer_rollen_instanzen from
+--   veranstaltungen + auffuehrung_schichten for all future events.
+--   This enables the /mitmachen page to display available shifts.
+--   Existing helfer_anmeldungen are NOT migrated (old system uses auffuehrung_zuweisungen).
+
+-- =============================================================================
+-- Step 1: Create helfer_events for veranstaltungen that don't have one yet
+-- =============================================================================
+
+INSERT INTO helfer_events (typ, veranstaltung_id, name, datum_start, datum_end, ort)
+SELECT
+  'auffuehrung',
+  v.id,
+  v.titel,
+  (v.datum || ' ' || COALESCE(v.startzeit, '18:00:00'))::timestamptz,
+  (v.datum || ' ' || '23:00:00')::timestamptz,
+  v.ort
+FROM veranstaltungen v
+WHERE v.typ = 'auffuehrung'
+  AND v.datum >= CURRENT_DATE
+  AND NOT EXISTS (
+    SELECT 1 FROM helfer_events he WHERE he.veranstaltung_id = v.id
+  );
+
+-- =============================================================================
+-- Step 2: Create helfer_rollen_templates for unique role names that don't exist
+-- =============================================================================
+
+INSERT INTO helfer_rollen_templates (name, default_anzahl)
+SELECT DISTINCT
+  s.rolle,
+  s.anzahl_benoetigt
+FROM auffuehrung_schichten s
+JOIN veranstaltungen v ON v.id = s.veranstaltung_id
+WHERE v.typ = 'auffuehrung'
+  AND v.datum >= CURRENT_DATE
+  AND NOT EXISTS (
+    SELECT 1 FROM helfer_rollen_templates t WHERE t.name = s.rolle
+  )
+ON CONFLICT DO NOTHING;
+
+-- =============================================================================
+-- Step 3: Create helfer_rollen_instanzen from auffuehrung_schichten
+-- =============================================================================
+
+INSERT INTO helfer_rollen_instanzen (
+  helfer_event_id,
+  template_id,
+  zeitblock_start,
+  zeitblock_end,
+  anzahl_benoetigt,
+  sichtbarkeit
+)
+SELECT
+  he.id,
+  t.id,
+  (v.datum || ' ' || COALESCE(zb.startzeit, v.startzeit, '18:00:00'))::timestamptz,
+  (v.datum || ' ' || COALESCE(zb.endzeit, '23:00:00'))::timestamptz,
+  s.anzahl_benoetigt,
+  'public'
+FROM auffuehrung_schichten s
+JOIN veranstaltungen v ON v.id = s.veranstaltung_id
+JOIN helfer_events he ON he.veranstaltung_id = v.id
+JOIN helfer_rollen_templates t ON t.name = s.rolle
+LEFT JOIN zeitbloecke zb ON zb.id = s.zeitblock_id
+WHERE v.typ = 'auffuehrung'
+  AND v.datum >= CURRENT_DATE
+  AND NOT EXISTS (
+    SELECT 1 FROM helfer_rollen_instanzen ri
+    WHERE ri.helfer_event_id = he.id
+      AND ri.template_id = t.id
+      AND ri.zeitblock_start = (v.datum || ' ' || COALESCE(zb.startzeit, v.startzeit, '18:00:00'))::timestamptz
+  );


### PR DESCRIPTION
## Summary
- `/mitmachen` page shows no shifts because data lives in old system (`auffuehrung_schichten`) but page reads from new system (`helfer_rollen_instanzen`)
- SQL migration transfers all future events from old → new system

## What it does
1. Creates `helfer_events` for each future `veranstaltung` (type=auffuehrung) that doesn't have one
2. Creates `helfer_rollen_templates` for role names not yet in templates (Essensservice, Abwasch, etc.)
3. Creates `helfer_rollen_instanzen` with `sichtbarkeit='public'` from each `auffuehrung_schicht` + zeitblock times

## Data affected
- 4 new `helfer_events` (Samstag, Donnerstag, Freitag, Dernière — Premiere already exists)
- 25 new `helfer_rollen_instanzen` (5 roles × 5 events), all public
- Idempotent: safe to run multiple times (skips existing records)

## Test plan
- [ ] Run migration via Supabase dashboard or `supabase db push`
- [ ] Visit `/mitmachen` → all 5 events with shifts visible
- [ ] Register as external helper → confirmation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)