### PR TITLE
refactor: helfer-dashboard.ts — System A Merge-Logik entfernen

### DIFF
--- a/apps/web/components/helfer-dashboard/ShiftCard.tsx
+++ b/apps/web/components/helfer-dashboard/ShiftCard.tsx
@@ -37,27 +37,19 @@ function formatTimeValue(timeStr: string) {
 }
 
 /**
- * Get the cancellation route based on the booking system.
- * System A (helferliste): /helfer/helferliste/abmeldung/[token]
- * System B (auffuehrung): /helfer/abmeldung/[token]
+ * Get the cancellation route. All dashboard entries are now System B
+ * (auffuehrung_zuweisungen).
  */
 function getCancellationHref(anmeldung: HelferDashboardAnmeldung): string {
-  if (anmeldung.system === 'b') {
-    return `/helfer/abmeldung/${anmeldung.abmeldung_token}`
-  }
-  return `/helfer/helferliste/abmeldung/${anmeldung.abmeldung_token}`
+  return `/helfer/abmeldung/${anmeldung.abmeldung_token}`
 }
 
 /**
- * Get the "more shifts" link based on the booking system.
- * System A links to the helferliste event page.
- * System B links to the mitmachen overview page.
+ * Get the "more shifts" link. All dashboard entries are now System B,
+ * which uses the mitmachen overview page.
  */
-function getMoreShiftsHref(anmeldung: HelferDashboardAnmeldung): string {
-  if (anmeldung.system === 'b') {
-    return '/mitmachen'
-  }
-  return `/helfer/anmeldung/${anmeldung.event_public_token}`
+function getMoreShiftsHref(_anmeldung: HelferDashboardAnmeldung): string {
+  return '/mitmachen'
 }
 
 export function ShiftCard({ anmeldung, canCancel, isPast }: ShiftCardProps) {

--- a/apps/web/lib/actions/helfer-dashboard.ts
+++ b/apps/web/lib/actions/helfer-dashboard.ts
@@ -15,14 +15,13 @@ const UUID_REGEX =
 
 /**
  * Normalize a raw System B zuweisung into a unified HelferDashboardAnmeldung.
- * The veranstaltung.datum is a date-only string (YYYY-MM-DD), while System A
- * uses full timestamps. We construct a comparable datetime using startzeit.
+ * The veranstaltung.datum is a date-only string (YYYY-MM-DD); we construct a
+ * comparable datetime using startzeit for sorting/filtering.
  */
 async function normalizeZuweisungen(
   zuweisungen: HelferDashboardZuweisung[]
 ): Promise<HelferDashboardAnmeldung[]> {
   return zuweisungen.map((z) => {
-    // Build a datetime string from datum + startzeit for sorting/filtering
     const datumStart = z.veranstaltung_startzeit
       ? `${z.veranstaltung_datum}T${z.veranstaltung_startzeit}`
       : `${z.veranstaltung_datum}T00:00:00`
@@ -43,7 +42,6 @@ async function normalizeZuweisungen(
       event_ort: z.veranstaltung_ort,
       event_public_token: z.veranstaltung_public_helfer_token ?? '',
       event_abmeldung_frist: z.veranstaltung_helfer_buchung_deadline,
-      system: 'b' as const,
     }
   })
 }
@@ -84,7 +82,6 @@ export async function getHelferDashboardData(
   const result = data as unknown as
     | {
         helper: { vorname: string; nachname: string; email: string; telefon: string | null }
-        anmeldungen: HelferDashboardAnmeldung[]
         zuweisungen?: HelferDashboardZuweisung[]
         error?: never
       }
@@ -94,25 +91,11 @@ export async function getHelferDashboardData(
     return null
   }
 
-  // Tag System A entries
-  const systemAEntries: HelferDashboardAnmeldung[] = (
-    result as { anmeldungen: HelferDashboardAnmeldung[] }
-  ).anmeldungen.map((a) => ({
-    ...a,
-    system: 'a' as const,
-  }))
-
-  // Normalize System B entries
   const rawZuweisungen = (
     result as { zuweisungen?: HelferDashboardZuweisung[] }
   ).zuweisungen ?? []
-  const systemBEntries = await normalizeZuweisungen(rawZuweisungen)
-
-  // Merge and sort
-  const allEntries = await sortAnmeldungen([
-    ...systemAEntries,
-    ...systemBEntries,
-  ])
+  const entries = await normalizeZuweisungen(rawZuweisungen)
+  const allEntries = await sortAnmeldungen(entries)
 
   return {
     helper: (result as { helper: { vorname: string; nachname: string; email: string; telefon: string | null } }).helper,
@@ -129,7 +112,7 @@ export async function getAuthenticatedHelferDashboard(): Promise<HelferDashboard
   // Get person info for display name
   const { data: person } = await supabase
     .from('personen')
-    .select('vorname, nachname, email, telefon')
+    .select('id, vorname, nachname, email, telefon')
     .eq('email', profile.email)
     .single()
 
@@ -137,83 +120,10 @@ export async function getAuthenticatedHelferDashboard(): Promise<HelferDashboard
     ? { vorname: person.vorname, nachname: person.nachname, email: person.email ?? profile.email, telefon: person.telefon ?? null }
     : { vorname: profile.display_name ?? profile.email, nachname: '', email: profile.email, telefon: null }
 
-  // System A: Get all non-rejected helfer_anmeldungen for this profile
-  const { data: anmeldungen, error } = await supabase
-    .from('helfer_anmeldungen')
-    .select(`
-      id,
-      status,
-      abmeldung_token,
-      created_at,
-      rollen_instanz_id,
-      helfer_rollen_instanzen!inner (
-        id,
-        custom_name,
-        zeitblock_start,
-        zeitblock_end,
-        template_id,
-        helfer_event_id,
-        helfer_rollen_templates ( name ),
-        helfer_events!inner (
-          id, name, datum_start, datum_end, ort, public_token, abmeldung_frist
-        )
-      )
-    `)
-    .eq('profile_id', profile.id)
-
-  const systemAEntries: HelferDashboardAnmeldung[] = (!error && anmeldungen)
-    ? anmeldungen.map((a) => {
-        const instanz = a.helfer_rollen_instanzen as unknown as {
-          id: string
-          custom_name: string | null
-          zeitblock_start: string | null
-          zeitblock_end: string | null
-          helfer_rollen_templates: { name: string } | null
-          helfer_events: {
-            id: string
-            name: string
-            datum_start: string
-            datum_end: string
-            ort: string | null
-            public_token: string
-            abmeldung_frist: string | null
-          }
-        }
-
-
-        return {
-          id: a.id,
-          status: a.status,
-          abmeldung_token: a.abmeldung_token,
-          created_at: a.created_at,
-          rolle_name: instanz.helfer_rollen_templates?.name ?? instanz.custom_name ?? 'Helfer',
-          zeitblock_start: instanz.zeitblock_start,
-          zeitblock_end: instanz.zeitblock_end,
-          rollen_instanz_id: instanz.id,
-          event_id: instanz.helfer_events.id,
-          event_name: instanz.helfer_events.name,
-          event_datum_start: instanz.helfer_events.datum_start,
-          event_datum_end: instanz.helfer_events.datum_end,
-          event_ort: instanz.helfer_events.ort,
-          event_public_token: instanz.helfer_events.public_token,
-          event_abmeldung_frist: instanz.helfer_events.abmeldung_frist,
-          system: 'a' as const,
-        }
-      })
-    : []
-
   // System B: Get auffuehrung_zuweisungen for this profile's person
-  // Find the person linked to this profile via email
-  const personId = person
-    ? await supabase
-        .from('personen')
-        .select('id')
-        .eq('email', profile.email)
-        .single()
-        .then(({ data: p }) => p?.id ?? null)
-    : null
+  const personId = person?.id ?? null
 
-  let systemBEntries: HelferDashboardAnmeldung[] = []
+  let entries: HelferDashboardAnmeldung[] = []
 
   if (personId) {
     const { data: zuweisungen } = await supabase
@@ -238,7 +148,7 @@ export async function getAuthenticatedHelferDashboard(): Promise<HelferDashboard
       .not('status', 'in', '("abgesagt","nicht_erschienen")')
 
     if (zuweisungen) {
-      systemBEntries = zuweisungen.map((z) => {
+      entries = zuweisungen.map((z) => {
         const schicht = z.schicht as unknown as {
           id: string
           rolle: string
@@ -280,17 +190,12 @@ export async function getAuthenticatedHelferDashboard(): Promise<HelferDashboard
           event_ort: v.ort,
           event_public_token: v.public_helfer_token ?? '',
           event_abmeldung_frist: v.helfer_buchung_deadline,
-          system: 'b' as const,
         }
       })
     }
   }
 
-  // Merge and sort
-  const allEntries = await sortAnmeldungen([
-    ...systemAEntries,
-    ...systemBEntries,
-  ])
+  const allEntries = await sortAnmeldungen(entries)
 
   return { helper, anmeldungen: allEntries }
 }

--- a/apps/web/lib/supabase/types.ts
+++ b/apps/web/lib/supabase/types.ts
@@ -2049,8 +2049,6 @@ export type HelferDashboardAnmeldung = {
   event_ort: string | null
   event_public_token: string
   event_abmeldung_frist: string | null
-  /** Which booking system this entry comes from */
-  system: 'a' | 'b'
 }
 
 /** Raw System B zuweisung as returned by the RPC */

--- a/supabase/migrations/20260625210135_simplify_get_helfer_dashboard_data.sql
+++ b/supabase/migrations/20260625210135_simplify_get_helfer_dashboard_data.sql
@@ -1,0 +1,70 @@
+-- =============================================================================
+-- Migration: Simplify get_helfer_dashboard_data — remove System A merge
+-- Created: 2026-06-25
+-- Issue: #471
+-- Description:
+--   System A (helferliste) is frozen and contains no active future entries.
+--   This migration removes the System-A query (helfer_anmeldungen) from the
+--   get_helfer_dashboard_data RPC. Only System-B zuweisungen are returned.
+--   The 'anmeldungen' key is retained in the JSON response as an empty array
+--   for backward compatibility with any consumer that still reads it; it will
+--   be removed completely together with the System-A tables in #475.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION get_helfer_dashboard_data(p_dashboard_token UUID)
+RETURNS JSONB AS $$
+DECLARE
+  v_helper RECORD;
+  v_zuweisungen JSONB;
+BEGIN
+  -- Validate token and get helper info
+  SELECT id, vorname, nachname, email, telefon
+  INTO v_helper
+  FROM externe_helfer_profile
+  WHERE dashboard_token = p_dashboard_token;
+
+  IF v_helper IS NULL THEN
+    RETURN jsonb_build_object('error', 'invalid');
+  END IF;
+
+  -- System B: Get all non-cancelled auffuehrung_zuweisungen
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object(
+      'id', az.id,
+      'status', az.status,
+      'abmeldung_token', az.abmeldung_token,
+      'created_at', az.created_at,
+      'rolle', asc2.rolle,
+      'schicht_id', asc2.id,
+      'zeitblock_id', zb.id,
+      'zeitblock_name', zb.name,
+      'zeitblock_start', zb.startzeit,
+      'zeitblock_end', zb.endzeit,
+      'veranstaltung_id', v.id,
+      'veranstaltung_titel', v.titel,
+      'veranstaltung_datum', v.datum,
+      'veranstaltung_startzeit', v.startzeit,
+      'veranstaltung_ort', v.ort,
+      'veranstaltung_public_helfer_token', v.public_helfer_token,
+      'veranstaltung_helfer_buchung_deadline', v.helfer_buchung_deadline
+    ) ORDER BY v.datum ASC, zb.startzeit ASC NULLS LAST
+  ), '[]'::jsonb)
+  INTO v_zuweisungen
+  FROM auffuehrung_zuweisungen az
+  JOIN auffuehrung_schichten asc2 ON asc2.id = az.schicht_id
+  JOIN veranstaltungen v ON v.id = asc2.veranstaltung_id
+  LEFT JOIN zeitbloecke zb ON zb.id = asc2.zeitblock_id
+  WHERE az.external_helper_id = v_helper.id
+    AND az.status NOT IN ('abgesagt', 'nicht_erschienen');
+
+  RETURN jsonb_build_object(
+    'helper', jsonb_build_object(
+      'vorname', v_helper.vorname,
+      'nachname', v_helper.nachname,
+      'email', v_helper.email,
+      'telefon', v_helper.telefon
+    ),
+    'zuweisungen', v_zuweisungen
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
## Summary
- Entfernt die System-A-Merge-Logik aus `lib/actions/helfer-dashboard.ts` und der zugehörigen DB-Funktion `get_helfer_dashboard_data` — System A ist nach Phase 0 leer und eingefroren.
- Dashboard liefert jetzt ausschliesslich System-B-Zuweisungen (`auffuehrung_zuweisungen`).
- Vereinfacht `ShiftCard`: Abmelde- und „Weitere Schichten"-Routen sind nur noch die System-B-Pfade.
- Typ `HelferDashboardAnmeldung.system: 'a' | 'b'` entfernt.

## Scope
- **Server Action:** `getHelferDashboardData()` — `systemAEntries`-Block (Mapping aus RPC `anmeldungen`) entfernt; `getAuthenticatedHelferDashboard()` — direkter Supabase-Query auf `helfer_anmeldungen` (~40 Zeilen) entfernt, `systemAEntries`-Array und Merge-Logik entfernt; personId aus dem bestehenden `personen`-Lookup wiederverwendet.
- **DB-Migration:** `supabase/migrations/20260625210135_simplify_get_helfer_dashboard_data.sql` — `CREATE OR REPLACE FUNCTION` ohne System-A-Teil; Response liefert nur noch `helper` und `zuweisungen`.
- **Typen:** `HelferDashboardAnmeldung.system` Feld entfernt. Die grossen System-A-Typen (`HelferEvent`, `HelferAnmeldung`, etc.) bleiben — die fliegen zusammen mit den Tabellen in #475 raus.
- **Komponente:** `ShiftCard.getCancellationHref()` und `getMoreShiftsHref()` — die Verzweigung nach `system` ist weg, beide Routen sind System-B-Defaults.

## Quality Gates
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test:run` (152/152)
- [x] `npm run build`

## Test plan
- [ ] Externer Helfer öffnet sein Token-Dashboard (`/helfer/meine-einsaetze/[token]`) — Liste zeigt nur noch System-B-Schichten, Abmelde-Link führt auf `/helfer/abmeldung/[token]`.
- [ ] Eingeloggter Helfer öffnet `/helfer/meine-einsaetze` — gleiches Verhalten wie oben.
- [ ] „Weitere Schichten"-Link führt auf `/mitmachen`.
- [ ] Vorstand `/vorstand/einsaetze` — Auth-Dashboard rendert ohne Fehler.

## Hinweis
DB-Migration ist mit `CREATE OR REPLACE FUNCTION` sicher anwendbar — keine Datenbankobjekte werden gedroppt, nur die Funktion vereinfacht.

Closes #471