### PR TITLE
refactor: persoenlicher-kalender.ts — helfer_anmeldungen entfernen

### DIFF
--- a/apps/web/components/mein-bereich/PersonalCalendar.tsx
+++ b/apps/web/components/mein-bereich/PersonalCalendar.tsx
@@ -54,18 +54,12 @@ const eventColors: Record<
     border: 'rgb(245 158 11)', // amber-500
     text: 'rgb(146 64 14)', // amber-800
   },
-  helfer: {
-    bg: 'rgb(220 252 231)', // green-100
-    border: 'rgb(34 197 94)', // green-500
-    text: 'rgb(22 101 52)', // green-800
-  },
 }
 
 const typLabels: Record<PersonalEventTyp, string> = {
   veranstaltung: 'Veranstaltung',
   probe: 'Probe',
   schicht: 'Schicht',
-  helfer: 'Helfereinsatz',
 }
 
 const statusLabels: Record<string, string> = {
@@ -249,9 +243,6 @@ export function PersonalCalendar({
 
   // Get link for event detail
   const getEventLink = (event: PersonalEvent): string => {
-    if (event.helfer_event_id) {
-      return `/helferliste/${event.helfer_event_id}`
-    }
     if (event.probe_id) {
       return `/proben/${event.probe_id}`
     }
@@ -261,8 +252,6 @@ export function PersonalCalendar({
     return '#'
   }
 
-  // Check which event types actually exist
-  const hasHelfer = events.some((e) => e.typ === 'helfer')
   const hasVerfuegbarkeiten = verfuegbarkeiten.length > 0
 
   return (
@@ -345,7 +334,6 @@ export function PersonalCalendar({
             <option value="veranstaltung">Veranstaltungen</option>
             <option value="probe">Proben</option>
             <option value="schicht">Schichten</option>
-            <option value="helfer">Helfereinsätze</option>
           </select>
 
           {/* Export Button */}
@@ -464,7 +452,7 @@ export function PersonalCalendar({
       </div>
 
       {/* Stats */}
-      <div className={`grid gap-4 ${hasHelfer ? 'grid-cols-3 sm:grid-cols-4' : 'grid-cols-3'}`}>
+      <div className="grid grid-cols-3 gap-4">
         <div className="rounded-lg bg-white p-4 text-center shadow">
           <div className="text-2xl font-bold text-blue-600">
             {events.filter((e) => e.typ === 'veranstaltung').length}
@@ -483,14 +471,6 @@ export function PersonalCalendar({
           </div>
           <div className="text-sm text-gray-600">Schichten</div>
         </div>
-        {hasHelfer && (
-          <div className="rounded-lg bg-white p-4 text-center shadow">
-            <div className="text-2xl font-bold text-green-600">
-              {events.filter((e) => e.typ === 'helfer').length}
-            </div>
-            <div className="text-sm text-gray-600">Helfereinsätze</div>
-          </div>
-        )}
       </div>
 
       {/* Event Detail Modal */}
@@ -570,12 +550,6 @@ export function PersonalCalendar({
                 </div>
               )}
 
-              {selectedEvent.helfer_rolle && !selectedEvent.rolle && (
-                <div>
-                  <dt className="font-medium text-gray-500">Helfer-Rolle</dt>
-                  <dd className="text-gray-900">{selectedEvent.helfer_rolle}</dd>
-                </div>
-              )}
 
               {selectedEvent.zeitblock && (
                 <div>

--- a/apps/web/lib/actions/persoenlicher-kalender.test.ts
+++ b/apps/web/lib/actions/persoenlicher-kalender.test.ts
@@ -1,7 +1,8 @@
 /**
  * Unit Tests for Persönlicher Kalender (Issue #346)
- * Tests getPersonalEvents (4 sources), getPersonVerfuegbarkeiten,
- * personId management view, and decline actions for new types.
+ * Tests getPersonalEvents (anmeldungen, proben_teilnehmer,
+ * auffuehrung_zuweisungen, produktions_* sources), getPersonVerfuegbarkeiten,
+ * personId management view, and decline actions.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
@@ -95,7 +96,7 @@ describe('getPersonalEvents', () => {
     expect(result).toEqual([])
   })
 
-  it('returns events from all 5 sources', async () => {
+  it('returns events from anmeldungen, proben_teilnehmer and auffuehrung_zuweisungen', async () => {
     mockSupabase.from.mockImplementation((table: string) => {
       if (table === 'personen') {
         return setupPersonLookup('person-1', 'profile-1')
@@ -180,60 +181,23 @@ describe('getPersonalEvents', () => {
         return chain
       }
 
-      if (table === 'helfer_anmeldungen') {
-        const chain = createEmptyChain()
-        const resultData = [
-          {
-            id: 'ha-1',
-            status: 'bestaetigt',
-            helfer_rollen_instanzen: {
-              id: 'ri-1',
-              custom_name: null,
-              zeitblock_start: '08:00:00',
-              zeitblock_end: '12:00:00',
-              helfer_rollen_templates: { name: 'Aufbau' },
-              helfer_events: {
-                id: 'he-1',
-                name: 'Festbetrieb',
-                beschreibung: 'Dorffest',
-                datum_start: '2026-08-01',
-                datum_end: '2026-08-01',
-                ort: 'Festplatz',
-              },
-            },
-          },
-        ]
-        chain.then = (resolve: (r: { data: unknown[]; error: null }) => void) => {
-          resolve({ data: resultData, error: null })
-          return Promise.resolve({ data: resultData, error: null })
-        }
-        return chain
-      }
-
       return createEmptyChain()
     })
 
     const result = await getPersonalEvents()
 
-    expect(result).toHaveLength(4)
+    expect(result).toHaveLength(3)
 
-    // Check all 4 types are present
+    // Check all 3 types are present
     const types = result.map((e) => e.typ)
     expect(types).toContain('veranstaltung')
     expect(types).toContain('probe')
     expect(types).toContain('schicht')
-    expect(types).toContain('helfer')
 
     // Verify sorted by date
     for (let i = 1; i < result.length; i++) {
       expect(result[i].datum >= result[i - 1].datum).toBe(true)
     }
-
-    // Check helfer event details
-    const helferEvent = result.find((e) => e.typ === 'helfer')!
-    expect(helferEvent.id).toBe('ha-ha-1')
-    expect(helferEvent.helfer_rolle).toBe('Aufbau')
-    expect(helferEvent.helfer_event_id).toBe('he-1')
   })
 
   it('requires mitglieder:read when personId provided', async () => {
@@ -251,7 +215,7 @@ describe('getPersonalEvents', () => {
     expect(mockRequirePermission).toHaveBeenCalledWith('mitglieder:read')
   })
 
-  it('skips helfer_anmeldungen when person has no profile_id', async () => {
+  it('does not query helfer_anmeldungen (System A removed)', async () => {
     mockRequirePermission.mockResolvedValueOnce(undefined)
 
     const fromCalls: string[] = []
@@ -265,7 +229,6 @@ describe('getPersonalEvents', () => {
 
     await getPersonalEvents(undefined, undefined, 'person-2')
 
-    // helfer_anmeldungen should NOT be queried when profileId is null
     expect(fromCalls).not.toContain('helfer_anmeldungen')
   })
 })
@@ -339,28 +302,17 @@ describe('declinePersonalEvent', () => {
     vi.clearAllMocks()
   })
 
-  it('handles ha- prefix for helfer_anmeldungen', async () => {
-    const innerEq = vi.fn().mockResolvedValue({ data: null, error: null })
-    const updateChain = {
-      update: vi.fn().mockReturnThis(),
-      eq: vi.fn().mockReturnValue({ eq: innerEq }),
-    }
-
+  it('rejects unsupported ha- prefix (System A removed)', async () => {
     mockSupabase.from.mockImplementation((table: string) => {
       if (table === 'personen') {
         return setupPersonLookup('person-1', 'profile-1')
-      }
-      if (table === 'helfer_anmeldungen') {
-        return updateChain
       }
       return createEmptyChain()
     })
 
     const result = await declinePersonalEvent('ha-anm123')
 
-    expect(result.success).toBe(true)
-    expect(mockSupabase.from).toHaveBeenCalledWith('helfer_anmeldungen')
-    expect(updateChain.update).toHaveBeenCalledWith({ status: 'abgelehnt' })
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('Aktion nicht unterstützt')
   })
-
 })

--- a/apps/web/lib/actions/persoenlicher-kalender.ts
+++ b/apps/web/lib/actions/persoenlicher-kalender.ts
@@ -20,7 +20,6 @@ export type PersonalEventTyp =
   | 'veranstaltung'
   | 'probe'
   | 'schicht'
-  | 'helfer'
 
 export type PersonalEventStatus =
   | 'angemeldet'
@@ -51,9 +50,6 @@ export type PersonalEvent = {
   anmeldung_id?: string | null
   teilnehmer_id?: string | null
   zuweisung_id?: string | null
-  helfer_anmeldung_id?: string | null
-  helfer_event_id?: string | null
-  helfer_rolle?: string | null
   // Extra info
   stueck_titel?: string | null
   rolle?: string | null
@@ -129,7 +125,7 @@ export async function getPersonalEvents(
 
   if (!resolved) return []
 
-  const { resolvedPersonId, profileId } = resolved
+  const { resolvedPersonId } = resolved
   const events: PersonalEvent[] = []
 
   // 1. Get Veranstaltung Anmeldungen
@@ -287,80 +283,7 @@ export async function getPersonalEvents(
     }
   }
 
-  // 4. Get Helfer Anmeldungen (new Helferliste system)
-  if (profileId) {
-    const { data: helferAnmeldungen } = await supabase
-      .from('helfer_anmeldungen')
-      .select(`
-        id,
-        status,
-        helfer_rollen_instanzen!inner (
-          id,
-          custom_name,
-          zeitblock_start,
-          zeitblock_end,
-          helfer_rollen_templates ( name ),
-          helfer_events!inner (
-            id, name, beschreibung, datum_start, datum_end, ort
-          )
-        )
-      `)
-      .eq('profile_id', profileId)
-      .neq('status', 'abgelehnt')
-
-    type HelferAnmeldungWithDetails = {
-      id: string
-      status: string
-      helfer_rollen_instanzen: {
-        id: string
-        custom_name: string | null
-        zeitblock_start: string | null
-        zeitblock_end: string | null
-        helfer_rollen_templates: { name: string } | null
-        helfer_events: {
-          id: string
-          name: string
-          beschreibung: string | null
-          datum_start: string
-          datum_end: string
-          ort: string | null
-        }
-      }
-    }
-
-    if (helferAnmeldungen) {
-      for (const ha of helferAnmeldungen as unknown as HelferAnmeldungWithDetails[]) {
-        const instanz = ha.helfer_rollen_instanzen
-        const event = instanz.helfer_events
-        const rolleName = instanz.helfer_rollen_templates?.name ?? instanz.custom_name ?? 'Helfer'
-
-        // Use datum_start as the date (format: YYYY-MM-DD or datetime)
-        const datum = event.datum_start.split('T')[0]
-
-        if (startDatum && datum < startDatum) continue
-        if (endDatum && datum > endDatum) continue
-
-        events.push({
-          id: `ha-${ha.id}`,
-          titel: `${event.name} - ${rolleName}`,
-          beschreibung: event.beschreibung,
-          datum,
-          startzeit: instanz.zeitblock_start,
-          endzeit: instanz.zeitblock_end,
-          ort: event.ort,
-          typ: 'helfer',
-          status: ha.status as PersonalEventStatus,
-          helfer_anmeldung_id: ha.id,
-          helfer_event_id: event.id,
-          helfer_rolle: rolleName,
-          kann_zusagen: false,
-          kann_absagen: ha.status === 'angemeldet' || ha.status === 'bestaetigt',
-        })
-      }
-    }
-  }
-
-  // 5. Get Produktions-Aufführungen (via Besetzung/Stab → Produktion → Serie → Veranstaltung)
+  // 4. Get Produktions-Aufführungen (via Besetzung/Stab → Produktion → Serie → Veranstaltung)
   // Collect veranstaltung_ids already present to deduplicate
   const existingVeranstaltungIds = new Set(
     events
@@ -601,22 +524,6 @@ export async function declinePersonalEvent(
     return { success: true }
   }
 
-  if (type === 'ha') {
-    // Update Helfer Anmeldung status (new system) — with ownership filter
-    const { error } = await supabase
-      .from('helfer_anmeldungen')
-      .update({ status: 'abgelehnt' } as never)
-      .eq('id', id)
-      .eq('person_id', resolvedPersonId)
-
-    if (error) {
-      console.error('Error declining helfer anmeldung:', error)
-      return { success: false, error: 'Fehler beim Absagen' }
-    }
-
-    return { success: true }
-  }
-
   return { success: false, error: 'Aktion nicht unterstützt' }
 }
 
@@ -657,15 +564,14 @@ export async function generatePersonalICalFeed(): Promise<string> {
     if (event.ort) {
       ical += `LOCATION:${escapeICalText(event.ort)}\r\n`
     }
-    if (event.rolle || event.helfer_rolle) {
-      ical += `X-TGW-ROLLE:${escapeICalText(event.rolle || event.helfer_rolle || '')}\r\n`
+    if (event.rolle) {
+      ical += `X-TGW-ROLLE:${escapeICalText(event.rolle)}\r\n`
     }
 
     const categoryMap: Record<PersonalEventTyp, string> = {
       veranstaltung: 'VERANSTALTUNG',
       probe: 'PROBE',
       schicht: 'SCHICHT',
-      helfer: 'HELFER',
     }
     ical += `CATEGORIES:${categoryMap[event.typ]}\r\n`
 

--- a/apps/web/lib/actions/person-engagements.test.ts
+++ b/apps/web/lib/actions/person-engagements.test.ts
@@ -70,9 +70,7 @@ describe('Person Engagements (Issue #349)', () => {
       expect(result.statistik.totalProduktionen).toBe(0)
     })
 
-    it('fetches all 6 engagement types in parallel', async () => {
-      // First call: personen (for profile_id)
-      // Then 6 parallel calls for each engagement type
+    it('fetches engagement types in parallel and returns empty arrays when no data', async () => {
       let callCount = 0
       mockSupabase.from.mockImplementation((table: string) => {
         callCount++
@@ -85,8 +83,9 @@ describe('Person Engagements (Issue #349)', () => {
 
       const result = await getPersonEngagements('person-1')
 
-      // Should have called `from` for: personen + besetzungen + produktions_besetzungen + produktions_stab + auffuehrung_zuweisungen + proben_teilnehmer + helfer_anmeldungen
-      expect(callCount).toBeGreaterThanOrEqual(7)
+      // Should have called `from` for: personen + at least the
+      // System-B engagement types
+      expect(callCount).toBeGreaterThanOrEqual(6)
       expect(result.stueckBesetzungen).toEqual([])
       expect(result.produktionsBesetzungen).toEqual([])
       expect(result.produktionsStab).toEqual([])
@@ -185,20 +184,6 @@ describe('Person Engagements (Issue #349)', () => {
             },
           ])
         }
-        if (table === 'helfer_anmeldungen') {
-          return chainResolving([
-            {
-              id: 'ha1',
-              status: 'bestaetigt',
-              rollen_instanz: {
-                zeitblock_start: '2026-06-15T17:00:00Z',
-                zeitblock_end: '2026-06-15T19:00:00Z',
-                template: { name: 'Einlass' },
-                helfer_event: { id: 'he1', name: 'Premiere Helfer', datum_start: '2026-06-15' },
-              },
-            },
-          ])
-        }
         return chainResolving([])
       })
 
@@ -222,16 +207,12 @@ describe('Person Engagements (Issue #349)', () => {
       // Proben
       expect(result.probenTeilnahmen).toHaveLength(3)
 
-      // Helfer
-      expect(result.helferAnmeldungen).toHaveLength(1)
-
       // Statistik
       expect(result.statistik.totalProduktionen).toBe(1) // Only 1 unique produktion
       expect(result.statistik.totalStueckBesetzungen).toBe(1)
       expect(result.statistik.totalAuffuehrungen).toBe(1) // Only zugesagt/erschienen
       expect(result.statistik.totalProben).toBe(3)
       expect(result.statistik.probenAnwesenheitsquote).toBe(67) // 2/3 = 67%
-      expect(result.statistik.totalHelferEinsaetze).toBe(1)
     })
 
     it('handles person with no engagements', async () => {
@@ -249,23 +230,8 @@ describe('Person Engagements (Issue #349)', () => {
       expect(result.produktionsStab).toEqual([])
       expect(result.auffuehrungsZuweisungen).toEqual([])
       expect(result.probenTeilnahmen).toEqual([])
-      expect(result.helferAnmeldungen).toEqual([])
       expect(result.statistik.totalProduktionen).toBe(0)
       expect(result.statistik.probenAnwesenheitsquote).toBe(0)
-    })
-
-    it('handles missing profile_id gracefully for helfer_anmeldungen', async () => {
-      mockSupabase.from.mockImplementation((table: string) => {
-        if (table === 'personen') {
-          return chainResolving({ profile_id: null })
-        }
-        return chainResolving([])
-      })
-
-      const result = await getPersonEngagements('person-no-profile')
-
-      // All should be empty — helfer_anmeldungen requires profile_id
-      expect(result.helferAnmeldungen).toEqual([])
     })
   })
 })


### PR DESCRIPTION
## Summary
- Entfernt die System-A-Quelle (`helfer_anmeldungen`) aus `lib/actions/persoenlicher-kalender.ts` — der persönliche Kalender liefert nur noch Veranstaltung-Anmeldungen, Proben-Teilnahmen, Schicht-Zuweisungen (System B) und Produktions-Aufführungen.
- Bereinigt `PersonalEvent`-Typ und das `PersonalCalendar`-UI von allen `helfer_*`-Feldern und der `helfer`-Kategorie.
- Tests werden um System-A-Fälle reduziert.

## Scope
- **Server Action `getPersonalEvents`:** Quelle 4 (helfer_anmeldungen mit Join auf helfer_rollen_instanzen / helfer_events) entfernt. `profileId` wird nicht mehr aus dem Resolver destrukturiert.
- **Server Action `declinePersonalEvent`:** `ha-`-Prefix-Branch entfernt. IDs mit diesem Präfix werden jetzt mit „Aktion nicht unterstützt" abgelehnt.
- **iCal-Feed:** `helfer_rolle`-Fallback und `HELFER`-Kategorie entfernt.
- **Typen:** `PersonalEventTyp` verliert `'helfer'` (das Token wurde ausschliesslich von der entfernten Quelle 4 gesetzt; System B benutzt `'schicht'`); `PersonalEvent` verliert `helfer_anmeldung_id`, `helfer_event_id`, `helfer_rolle`.
- **`PersonalCalendar.tsx`:** `helfer`-Farbschema, `Helfereinsatz`-Filter, `Helfereinsätze`-Stat-Kachel und Helfer-Rolle-Detail entfernt; `getEventLink()` prüft `helfer_event_id` nicht mehr.
- **Tests:**
  - `persoenlicher-kalender.test.ts`: `helfer_anmeldungen`-Mock und System-A-Assertions entfernt; der „handles ha- prefix"-Test prüft jetzt das Reject-Verhalten.
  - `person-engagements.test.ts`: `helfer_anmeldungen`-Mock und System-A-Assertions entfernt (eine Test-Case rausgenommen).

## Out of scope
- `lib/actions/person-engagements.ts` fragt weiterhin `helfer_anmeldungen` ab. Diese Quelle wird gemeinsam mit dem Tabellen-Drop in #475 entfernt — sie ist im Issue-Scope von #472 nicht vorgesehen.
- Die grossen System-A-Typen (`HelferEvent`, `HelferAnmeldung`, etc.) bleiben — fallen in #475.

## Quality Gates
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test:run` (151/151)
- [x] `npm run build`

## Test plan
- [ ] Eingeloggter Aktivmitglied öffnet `/mein-bereich` (Persönlicher Kalender) — Liste enthält Veranstaltungen, Proben und Aufführungs-Schichten, keine alten Helferliste-Einträge.
- [ ] Stats-Leiste zeigt 3 Spalten (keine Helfereinsätze-Kachel mehr).
- [ ] Filter-Dropdown enthält „Alle Typen / Veranstaltungen / Proben / Schichten".
- [ ] iCal-Export liefert weiterhin gültiges VCALENDAR-File, keine HELFER-Kategorie mehr.
- [ ] Vorstand-Sicht auf eine fremde Person via `personId`-Parameter funktioniert weiterhin.

Closes #472