### PR TITLE
feat: prominente Cross-System-Konfliktwarnung in Proben-UI (#487)

### DIFF
--- a/apps/web/app/(protected)/proben/[id]/page.tsx
+++ b/apps/web/app/(protected)/proben/[id]/page.tsx
@@ -7,13 +7,20 @@ import {
   getProbe,
   getProbeSzenen,
   getProbeTeilnehmer,
+  checkProbeKonflikteFull,
 } from '@/lib/actions/proben'
 import {
   getProbenProtokoll,
   getProtokollTemplates,
 } from '@/lib/actions/proben-protokoll'
 import { canEdit as checkCanEdit } from '@/lib/supabase/auth-helpers'
-import { ProbeStatusBadge, TeilnehmerList, ProbenProtokoll, DownloadProbenSzenenButton } from '@/components/proben'
+import {
+  ProbeStatusBadge,
+  TeilnehmerList,
+  ProbenProtokoll,
+  DownloadProbenSzenenButton,
+  ProbeKonfliktBanner,
+} from '@/components/proben'
 import type { ProbeSzene, Szene, Person } from '@/lib/supabase/types'
 
 interface ProbeDetailPageProps {
@@ -63,6 +70,23 @@ export default async function ProbeDetailPage({
     .select('id, stueck_id, nummer, titel, beschreibung, text, dauer_minuten, created_at, updated_at')
     .eq('stueck_id', probe.stueck_id)
     .order('nummer')
+
+  // Cross-System-Konflikt-Check (Issue #487)
+  // Sammelt Konflikte für alle eingeladenen Teilnehmer + Cast aus den Szenen.
+  const szenenIds = probeSzenen
+    .map((ps) => ps.szene_id)
+    .filter((sid): sid is string => Boolean(sid))
+  const teilnehmerPersonIds = teilnehmer.map((t) => t.person_id)
+  const konflikte = await checkProbeKonflikteFull({
+    stueckId: probe.stueck_id,
+    datum: probe.datum,
+    startzeit: probe.startzeit,
+    endzeit: probe.endzeit,
+    szenenIds: szenenIds.length > 0 ? szenenIds : undefined,
+    teilnehmerPersonIds:
+      teilnehmerPersonIds.length > 0 ? teilnehmerPersonIds : undefined,
+    excludeProbeId: id,
+  })
 
   const formatDate = (dateStr: string) => {
     return new Date(dateStr).toLocaleDateString('de-CH', {
@@ -116,6 +140,18 @@ export default async function ProbeDetailPage({
           </Link>
         )}
       </div>
+
+      {/* Cross-System Konflikt-Banner (Issue #487) — prominent oben */}
+      {(konflikte.personenMitKonflikten.length > 0 ||
+        konflikte.totalGeprueft > 0) && (
+        <ProbeKonfliktBanner
+          personenMitKonflikten={konflikte.personenMitKonflikten}
+          totalGeprueft={konflikte.totalGeprueft}
+          totalKonflikte={konflikte.totalKonflikte}
+          zeitfensterUnklar={konflikte.zeitfensterUnklar}
+          variant="prominent"
+        />
+      )}
 
       {/* Info-Karten */}
       <div className="grid grid-cols-1 gap-6 md:grid-cols-3">

--- a/apps/web/components/proben/ProbeForm.tsx
+++ b/apps/web/components/proben/ProbeForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import type { Route } from 'next'
 import type {
@@ -14,8 +14,11 @@ import {
   updateProbe,
   updateProbeSzenen,
   checkProbeVerfuegbarkeit,
+  checkProbeKonflikteFull,
   autoInviteProbeTeilnehmer,
+  type ProbeKonflikteFullResult,
 } from '@/lib/actions/proben'
+import { ProbeKonfliktBanner } from './ProbeKonfliktBanner'
 
 interface ProbeFormProps {
   mode: 'create' | 'edit'
@@ -58,11 +61,17 @@ export function ProbeForm({
 
   const [szenenIds, setSzenenIds] = useState<string[]>(selectedSzenenIds)
 
-  // Availability warnings
+  // Availability warnings (legacy: cast-only availability check)
   const [verfuegbarkeitWarnings, setVerfuegbarkeitWarnings] = useState<
     { personId: string; personName: string; status: string; grund: string | null }[]
   >([])
   const [loadingVerfuegbarkeit, setLoadingVerfuegbarkeit] = useState(false)
+
+  // Cross-system conflict check (Issue #487)
+  const [konflikte, setKonflikte] = useState<ProbeKonflikteFullResult | null>(
+    null
+  )
+  const [loadingKonflikte, setLoadingKonflikte] = useState(false)
 
   const checkVerfuegbarkeit = useCallback(async () => {
     if (!formData.datum) {
@@ -82,6 +91,66 @@ export function ProbeForm({
   useEffect(() => {
     checkVerfuegbarkeit()
   }, [checkVerfuegbarkeit])
+
+  // Debounced cross-system conflict check. Triggers whenever datum/startzeit/
+  // endzeit/szenenIds change. ~400ms debounce keeps the form responsive while
+  // typing into the time fields.
+  const konflikteDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const konflikteRequestRef = useRef(0)
+
+  useEffect(() => {
+    if (konflikteDebounceRef.current) {
+      clearTimeout(konflikteDebounceRef.current)
+    }
+
+    if (!formData.datum) {
+      setKonflikte(null)
+      setLoadingKonflikte(false)
+      return
+    }
+
+    konflikteDebounceRef.current = setTimeout(async () => {
+      const requestId = ++konflikteRequestRef.current
+      setLoadingKonflikte(true)
+      try {
+        const result = await checkProbeKonflikteFull({
+          stueckId,
+          datum: formData.datum,
+          startzeit: formData.startzeit,
+          endzeit: formData.endzeit,
+          szenenIds: szenenIds.length > 0 ? szenenIds : undefined,
+          excludeProbeId: mode === 'edit' ? probe?.id : undefined,
+        })
+        // Drop stale responses
+        if (requestId === konflikteRequestRef.current) {
+          setKonflikte(result)
+        }
+      } catch (err) {
+        console.error('Konflikt-Prüfung fehlgeschlagen:', err)
+        if (requestId === konflikteRequestRef.current) {
+          setKonflikte(null)
+        }
+      } finally {
+        if (requestId === konflikteRequestRef.current) {
+          setLoadingKonflikte(false)
+        }
+      }
+    }, 400)
+
+    return () => {
+      if (konflikteDebounceRef.current) {
+        clearTimeout(konflikteDebounceRef.current)
+      }
+    }
+  }, [
+    stueckId,
+    formData.datum,
+    formData.startzeit,
+    formData.endzeit,
+    szenenIds,
+    mode,
+    probe?.id,
+  ])
 
   const handleChange = (
     e: React.ChangeEvent<
@@ -385,6 +454,18 @@ export function ProbeForm({
           placeholder="Interne Notizen (nur für Regie sichtbar)..."
         />
       </div>
+
+      {/* Cross-System Konflikt-Banner (Issue #487) */}
+      {formData.datum && (
+        <ProbeKonfliktBanner
+          personenMitKonflikten={konflikte?.personenMitKonflikten ?? []}
+          totalGeprueft={konflikte?.totalGeprueft ?? 0}
+          totalKonflikte={konflikte?.totalKonflikte ?? 0}
+          zeitfensterUnklar={konflikte?.zeitfensterUnklar ?? false}
+          isLoading={loadingKonflikte}
+          variant="compact"
+        />
+      )}
 
       {/* Submit Button */}
       <div className="flex justify-end gap-4">

--- a/apps/web/components/proben/ProbeKonfliktBanner.tsx
+++ b/apps/web/components/proben/ProbeKonfliktBanner.tsx
@@ -1,0 +1,271 @@
+'use client'
+
+import { useState } from 'react'
+import type { ProbePersonKonflikt } from '@/lib/actions/proben'
+import type { PersonConflict, PersonConflictType } from '@/lib/supabase/types'
+
+interface ProbeKonfliktBannerProps {
+  personenMitKonflikten: ProbePersonKonflikt[]
+  totalGeprueft: number
+  totalKonflikte: number
+  zeitfensterUnklar: boolean
+  isLoading?: boolean
+  variant?: 'compact' | 'prominent'
+  /** When the number of conflicting persons exceeds this threshold, the list
+   *  starts collapsed. Default 5. */
+  collapsibleAfter?: number
+}
+
+const TYPE_LABELS: Record<PersonConflictType, string> = {
+  verfuegbarkeit: 'Nicht verfügbar',
+  zuweisung: 'Aufführungs-Schicht',
+  anmeldung: 'Veranstaltung',
+  probe: 'Andere Probe',
+  helfer: 'Helfereinsatz',
+}
+
+const TYPE_SHORT: Record<PersonConflictType, string> = {
+  verfuegbarkeit: 'Verfügbarkeit',
+  zuweisung: 'Aufführung',
+  anmeldung: 'Veranstaltung',
+  probe: 'Probe',
+  helfer: 'Helfer',
+}
+
+function formatTimeRange(start: string, end: string): string {
+  try {
+    const startDate = new Date(start)
+    const endDate = new Date(end)
+    if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) return ''
+
+    const startStr = startDate.toLocaleString('de-CH', {
+      day: '2-digit',
+      month: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+    const endStr = endDate.toLocaleString('de-CH', {
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+    return `${startStr}–${endStr}`
+  } catch {
+    return ''
+  }
+}
+
+function ConflictLine({ conflict }: { conflict: PersonConflict }) {
+  const label = TYPE_SHORT[conflict.type] ?? conflict.type
+  const range = formatTimeRange(conflict.start_time, conflict.end_time)
+  const isUnavailable =
+    conflict.type === 'verfuegbarkeit' && conflict.severity === 'nicht_verfuegbar'
+  return (
+    <span className="block text-sm text-warning-800">
+      <span className="font-medium">{label}:</span>{' '}
+      <span>{conflict.description}</span>
+      {range && <span className="ml-1 text-warning-700">({range})</span>}
+      {isUnavailable && (
+        <span className="ml-1 rounded bg-warning-200 px-1.5 text-xs font-medium text-warning-900">
+          nicht verfügbar
+        </span>
+      )}
+    </span>
+  )
+}
+
+export function ProbeKonfliktBanner({
+  personenMitKonflikten,
+  totalGeprueft,
+  totalKonflikte,
+  zeitfensterUnklar,
+  isLoading,
+  variant = 'compact',
+  collapsibleAfter = 5,
+}: ProbeKonfliktBannerProps) {
+  const personenCount = personenMitKonflikten.length
+  const shouldCollapse = personenCount > collapsibleAfter
+  const [expanded, setExpanded] = useState(!shouldCollapse)
+
+  if (isLoading) {
+    return (
+      <div
+        className="flex items-center gap-2 rounded-lg border border-neutral-200 bg-neutral-50 px-4 py-3 text-sm text-neutral-600"
+        data-testid="probe-konflikt-banner-loading"
+      >
+        <svg className="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
+          <circle
+            className="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="4"
+          />
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+          />
+        </svg>
+        Konflikte werden geprüft…
+      </div>
+    )
+  }
+
+  if (personenCount === 0) {
+    if (totalGeprueft === 0) return null
+    return (
+      <div
+        className="flex items-center gap-2 rounded-lg border border-success-200 bg-success-50 px-4 py-3 text-sm text-success-800"
+        data-testid="probe-konflikt-banner-clean"
+      >
+        <svg
+          className="h-5 w-5 text-success-600"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M5 13l4 4L19 7"
+          />
+        </svg>
+        <span>
+          Keine Konflikte für die {totalGeprueft} betroffene
+          {totalGeprueft === 1 ? '' : 'n'} Person
+          {totalGeprueft === 1 ? '' : 'en'}.
+        </span>
+      </div>
+    )
+  }
+
+  const isProminent = variant === 'prominent'
+  const containerClasses = isProminent
+    ? 'rounded-lg border-2 border-warning-300 bg-warning-50 p-5 shadow-sm'
+    : 'rounded-lg border border-warning-200 bg-warning-50 p-4'
+  const titleClasses = isProminent
+    ? 'text-base font-semibold text-warning-900'
+    : 'text-sm font-semibold text-warning-900'
+
+  return (
+    <section
+      className={containerClasses}
+      data-testid="probe-konflikt-banner"
+      aria-live="polite"
+    >
+      <div className="flex items-start gap-3">
+        <svg
+          className={`mt-0.5 shrink-0 text-warning-600 ${
+            isProminent ? 'h-6 w-6' : 'h-5 w-5'
+          }`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+          />
+        </svg>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-baseline justify-between gap-3">
+            <div>
+              <h3 className={titleClasses}>
+                {personenCount} Person
+                {personenCount === 1 ? '' : 'en'} mit Konflikten
+              </h3>
+              <p className="mt-0.5 text-xs text-warning-700">
+                {totalKonflikte} Konflikt
+                {totalKonflikte === 1 ? '' : 'e'} insgesamt, geprüft gegen{' '}
+                {totalGeprueft} betroffene Person
+                {totalGeprueft === 1 ? '' : 'en'}
+                {zeitfensterUnklar && (
+                  <span className="ml-1 italic">
+                    · Zeit unklar — auf Tagesbasis geprüft
+                  </span>
+                )}
+              </p>
+            </div>
+            {shouldCollapse && (
+              <button
+                type="button"
+                onClick={() => setExpanded((v) => !v)}
+                className="rounded border border-warning-300 bg-white px-2 py-1 text-xs font-medium text-warning-800 hover:bg-warning-100"
+                aria-expanded={expanded}
+              >
+                {expanded ? 'Einklappen' : 'Alle anzeigen'}
+              </button>
+            )}
+          </div>
+
+          {expanded && (
+            <ul className="mt-3 space-y-3" data-testid="probe-konflikt-list">
+              {personenMitKonflikten.map((person) => (
+                <li
+                  key={person.personId}
+                  className="rounded-md border border-warning-200 bg-white/60 p-3"
+                >
+                  <div className="font-medium text-warning-900">
+                    {person.personName}
+                  </div>
+                  <div className="mt-1 space-y-0.5">
+                    {person.conflicts.map((c) => (
+                      <ConflictLine
+                        key={`${c.type}-${c.reference_id}`}
+                        conflict={c}
+                      />
+                    ))}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {!expanded && shouldCollapse && (
+            <p className="mt-2 text-xs italic text-warning-700">
+              {personenCount} Personen — klicke „Alle anzeigen“ für Details.
+            </p>
+          )}
+
+          <p className="mt-3 text-xs text-warning-700">
+            Hinweis: Die Probe kann trotz Konflikten gespeichert werden — die
+            Warnung dient nur der Information.
+          </p>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+/**
+ * Helper: produce a stable type list for tests / parents that want to group
+ * conflicts by type rather than by person. Pure function, no React state.
+ */
+export function groupConflictsByType(
+  personenMitKonflikten: ProbePersonKonflikt[]
+): Record<PersonConflictType, { personName: string; conflict: PersonConflict }[]> {
+  const out = {
+    verfuegbarkeit: [],
+    zuweisung: [],
+    anmeldung: [],
+    probe: [],
+    helfer: [],
+  } as Record<PersonConflictType, { personName: string; conflict: PersonConflict }[]>
+  for (const p of personenMitKonflikten) {
+    for (const c of p.conflicts) {
+      const bucket = out[c.type]
+      if (bucket) {
+        bucket.push({ personName: p.personName, conflict: c })
+      }
+    }
+  }
+  return out
+}
+
+// Re-export TYPE_LABELS for tests/integrations
+export { TYPE_LABELS as KONFLIKT_TYPE_LABELS }

--- a/apps/web/components/proben/index.ts
+++ b/apps/web/components/proben/index.ts
@@ -6,5 +6,10 @@ export { TeilnahmeUebersicht } from './TeilnahmeUebersicht'
 export { ProbeStatusBadge, TeilnehmerStatusBadge } from './ProbeStatusBadge'
 export { ProbenplanGenerator } from './ProbenplanGenerator'
 export { KonfliktAnzeige, KonfliktBadge } from './KonfliktAnzeige'
+export {
+  ProbeKonfliktBanner,
+  groupConflictsByType,
+  KONFLIKT_TYPE_LABELS,
+} from './ProbeKonfliktBanner'
 export { ProbenProtokoll } from './ProbenProtokoll'
 export { DownloadProbenSzenenButton } from './DownloadProbenSzenenButton'

--- a/apps/web/lib/actions/proben-konflikte-full.test.ts
+++ b/apps/web/lib/actions/proben-konflikte-full.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Unit tests for checkProbeKonflikteFull (Issue #487)
+ *
+ * Verifies the aggregation logic: Cast-Set derivation, per-person fanout,
+ * exclude-Probe filter, and result shaping.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createMockClient, mockVorstandProfile } from '@/tests/mocks/supabase'
+import type { PersonConflict } from '@/lib/supabase/types'
+
+const mockSupabase = createMockClient()
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(() => Promise.resolve(mockSupabase)),
+  getUserProfile: vi.fn(() => Promise.resolve(mockVorstandProfile)),
+}))
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}))
+
+const mockCheckPersonConflicts = vi.fn()
+vi.mock('./conflict-check', () => ({
+  checkPersonConflicts: (...args: unknown[]) =>
+    mockCheckPersonConflicts(...args),
+}))
+
+vi.mock('./verfuegbarkeiten', () => ({
+  checkMultipleMembersAvailability: vi.fn(),
+}))
+
+import { checkProbeKonflikteFull } from './proben'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function chainResolving(data: unknown, error: unknown = null) {
+  const chain: Record<string, unknown> = {}
+  chain.select = vi.fn().mockReturnValue(chain)
+  chain.eq = vi.fn().mockReturnValue(chain)
+  chain.in = vi.fn().mockReturnValue(chain)
+  chain.not = vi.fn().mockReturnValue(chain)
+  chain.lte = vi.fn().mockReturnValue(chain)
+  chain.gte = vi.fn().mockReturnValue(chain)
+  chain.order = vi.fn().mockReturnValue(chain)
+  chain.single = vi.fn().mockResolvedValue({ data, error })
+  chain.then = (resolve: (v: unknown) => void) => {
+    resolve({ data, error })
+    return Promise.resolve({ data, error })
+  }
+  return chain
+}
+
+function makeConflict(overrides: Partial<PersonConflict> = {}): PersonConflict {
+  return {
+    type: 'anmeldung',
+    description: 'Vereinsabend',
+    start_time: '2026-06-25T18:00:00+02:00',
+    end_time: '2026-06-25T22:00:00+02:00',
+    reference_id: 'anm-1',
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('checkProbeKonflikteFull (Issue #487)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns empty result when datum is missing', async () => {
+    const result = await checkProbeKonflikteFull({
+      stueckId: 'st-1',
+      datum: '',
+    })
+    expect(result.personenMitKonflikten).toEqual([])
+    expect(result.totalGeprueft).toBe(0)
+    expect(result.totalKonflikte).toBe(0)
+    expect(result.zeitfensterUnklar).toBe(true)
+  })
+
+  it('returns empty when no cast members are found', async () => {
+    ;(mockSupabase.from as ReturnType<typeof vi.fn>).mockImplementation(
+      (table: string) => {
+        if (table === 'besetzungen') return chainResolving([])
+        return chainResolving([])
+      }
+    )
+
+    const result = await checkProbeKonflikteFull({
+      stueckId: 'st-1',
+      datum: '2026-06-25',
+      startzeit: '18:00',
+      endzeit: '21:00',
+    })
+
+    expect(result.personenMitKonflikten).toEqual([])
+    expect(result.totalGeprueft).toBe(0)
+    expect(result.totalKonflikte).toBe(0)
+  })
+
+  it('returns clean result when cast exists but no conflicts', async () => {
+    ;(mockSupabase.from as ReturnType<typeof vi.fn>).mockImplementation(
+      (table: string) => {
+        if (table === 'besetzungen')
+          return chainResolving([
+            { person_id: 'p-1', rolle: { stueck_id: 'st-1' } },
+            { person_id: 'p-2', rolle: { stueck_id: 'st-1' } },
+          ])
+        if (table === 'personen')
+          return chainResolving([
+            { id: 'p-1', vorname: 'Anna', nachname: 'Schmidt' },
+            { id: 'p-2', vorname: 'Bert', nachname: 'Maier' },
+          ])
+        return chainResolving([])
+      }
+    )
+
+    mockCheckPersonConflicts.mockResolvedValue({
+      has_conflicts: false,
+      conflicts: [],
+    })
+
+    const result = await checkProbeKonflikteFull({
+      stueckId: 'st-1',
+      datum: '2026-06-25',
+      startzeit: '18:00',
+      endzeit: '21:00',
+    })
+
+    expect(result.totalGeprueft).toBe(2)
+    expect(result.personenMitKonflikten).toEqual([])
+    expect(result.totalKonflikte).toBe(0)
+    expect(result.zeitfensterUnklar).toBe(false)
+    expect(mockCheckPersonConflicts).toHaveBeenCalledTimes(2)
+  })
+
+  it('aggregates conflicts grouped by person, sorted by name', async () => {
+    ;(mockSupabase.from as ReturnType<typeof vi.fn>).mockImplementation(
+      (table: string) => {
+        if (table === 'besetzungen')
+          return chainResolving([
+            { person_id: 'p-1', rolle: { stueck_id: 'st-1' } },
+            { person_id: 'p-2', rolle: { stueck_id: 'st-1' } },
+            { person_id: 'p-3', rolle: { stueck_id: 'st-1' } },
+            // Cast from another play -> filtered out
+            { person_id: 'p-4', rolle: { stueck_id: 'st-OTHER' } },
+          ])
+        if (table === 'personen')
+          return chainResolving([
+            { id: 'p-1', vorname: 'Zorro', nachname: 'Z' },
+            { id: 'p-3', vorname: 'Anna', nachname: 'Schmidt' },
+          ])
+        return chainResolving([])
+      }
+    )
+
+    mockCheckPersonConflicts.mockImplementation(async (personId: string) => {
+      if (personId === 'p-1') {
+        return {
+          has_conflicts: true,
+          conflicts: [
+            makeConflict({ reference_id: 'c1a' }),
+            makeConflict({
+              type: 'verfuegbarkeit',
+              description: 'Ferien',
+              reference_id: 'c1b',
+              severity: 'nicht_verfuegbar',
+            }),
+          ],
+        }
+      }
+      if (personId === 'p-2') {
+        return { has_conflicts: false, conflicts: [] }
+      }
+      if (personId === 'p-3') {
+        return {
+          has_conflicts: true,
+          conflicts: [
+            makeConflict({ type: 'zuweisung', reference_id: 'c3a' }),
+          ],
+        }
+      }
+      return { has_conflicts: false, conflicts: [] }
+    })
+
+    const result = await checkProbeKonflikteFull({
+      stueckId: 'st-1',
+      datum: '2026-06-25',
+      startzeit: '18:00',
+      endzeit: '21:00',
+    })
+
+    expect(result.totalGeprueft).toBe(3)
+    expect(result.totalKonflikte).toBe(3)
+    expect(result.personenMitKonflikten).toHaveLength(2)
+    // sorted alphabetically by name
+    expect(result.personenMitKonflikten[0].personName).toBe('Anna Schmidt')
+    expect(result.personenMitKonflikten[1].personName).toBe('Zorro Z')
+    expect(result.personenMitKonflikten[0].conflicts).toHaveLength(1)
+    expect(result.personenMitKonflikten[1].conflicts).toHaveLength(2)
+  })
+
+  it('filters out the same-probe conflict when excludeProbeId is set', async () => {
+    ;(mockSupabase.from as ReturnType<typeof vi.fn>).mockImplementation(
+      (table: string) => {
+        if (table === 'besetzungen')
+          return chainResolving([
+            { person_id: 'p-1', rolle: { stueck_id: 'st-1' } },
+          ])
+        if (table === 'personen')
+          return chainResolving([
+            { id: 'p-1', vorname: 'Anna', nachname: 'Schmidt' },
+          ])
+        return chainResolving([])
+      }
+    )
+
+    mockCheckPersonConflicts.mockResolvedValue({
+      has_conflicts: true,
+      conflicts: [
+        makeConflict({
+          type: 'probe',
+          reference_id: 'probe-self',
+          description: 'Die aktuelle Probe',
+        }),
+        makeConflict({
+          type: 'probe',
+          reference_id: 'probe-other',
+          description: 'Andere Probe',
+        }),
+      ],
+    })
+
+    const result = await checkProbeKonflikteFull({
+      stueckId: 'st-1',
+      datum: '2026-06-25',
+      startzeit: '18:00',
+      endzeit: '21:00',
+      excludeProbeId: 'probe-self',
+    })
+
+    expect(result.totalKonflikte).toBe(1)
+    expect(result.personenMitKonflikten[0].conflicts[0].reference_id).toBe(
+      'probe-other'
+    )
+  })
+
+  it('unions explicit teilnehmerPersonIds with cast set', async () => {
+    ;(mockSupabase.from as ReturnType<typeof vi.fn>).mockImplementation(
+      (table: string) => {
+        if (table === 'besetzungen')
+          return chainResolving([
+            { person_id: 'p-cast', rolle: { stueck_id: 'st-1' } },
+          ])
+        if (table === 'personen')
+          return chainResolving([
+            { id: 'p-cast', vorname: 'Cast', nachname: 'Person' },
+            { id: 'p-extra', vorname: 'Extra', nachname: 'Helfer' },
+          ])
+        return chainResolving([])
+      }
+    )
+
+    mockCheckPersonConflicts.mockImplementation(async (personId: string) => {
+      return {
+        has_conflicts: true,
+        conflicts: [makeConflict({ reference_id: `c-${personId}` })],
+      }
+    })
+
+    const result = await checkProbeKonflikteFull({
+      stueckId: 'st-1',
+      datum: '2026-06-25',
+      startzeit: '18:00',
+      endzeit: '21:00',
+      teilnehmerPersonIds: ['p-extra'],
+    })
+
+    expect(result.totalGeprueft).toBe(2)
+    expect(result.personenMitKonflikten).toHaveLength(2)
+  })
+
+  it('reports zeitfensterUnklar when startzeit/endzeit missing', async () => {
+    ;(mockSupabase.from as ReturnType<typeof vi.fn>).mockImplementation(
+      (table: string) => {
+        if (table === 'besetzungen')
+          return chainResolving([
+            { person_id: 'p-1', rolle: { stueck_id: 'st-1' } },
+          ])
+        if (table === 'personen')
+          return chainResolving([
+            { id: 'p-1', vorname: 'Anna', nachname: 'Schmidt' },
+          ])
+        return chainResolving([])
+      }
+    )
+
+    mockCheckPersonConflicts.mockResolvedValue({
+      has_conflicts: false,
+      conflicts: [],
+    })
+
+    const result = await checkProbeKonflikteFull({
+      stueckId: 'st-1',
+      datum: '2026-06-25',
+    })
+
+    expect(result.zeitfensterUnklar).toBe(true)
+    // Still calls the conflict check with day-wide window
+    expect(mockCheckPersonConflicts).toHaveBeenCalledTimes(1)
+    const callArgs = mockCheckPersonConflicts.mock.calls[0]
+    expect(callArgs[1]).toMatch(/^2026-06-25T00:00:00[+-]/)
+    expect(callArgs[2]).toMatch(/^2026-06-25T23:59:00[+-]/)
+  })
+})

--- a/apps/web/lib/actions/proben.ts
+++ b/apps/web/lib/actions/proben.ts
@@ -21,9 +21,11 @@ import type {
   TeilnehmerVorschlag,
   VerfuegbarkeitStatus,
   OptimalProbeTermin,
+  PersonConflict,
 } from '../supabase/types'
 import { checkPersonConflicts } from './conflict-check'
 import { checkMultipleMembersAvailability } from './verfuegbarkeiten'
+import { toZurichTimestamp } from '../utils/zurich-time'
 
 // =============================================================================
 // Proben CRUD
@@ -1122,4 +1124,174 @@ export async function suggestOptimalProbeTermin(
   return termine
     .sort((a, b) => b.verfuegbarkeitsProzent - a.verfuegbarkeitsProzent)
     .slice(0, 10)
+}
+
+// =============================================================================
+// Cross-System Konflikt-Check für Probe (Issue #487)
+// =============================================================================
+
+export type ProbePersonKonflikt = {
+  personId: string
+  personName: string
+  conflicts: PersonConflict[]
+}
+
+export type ProbeKonflikteFullResult = {
+  /** Personen mit mindestens einem Konflikt */
+  personenMitKonflikten: ProbePersonKonflikt[]
+  /** Gesamtzahl der geprüften Personen */
+  totalGeprueft: number
+  /** Aggregierte Anzahl von Konflikten über alle Personen */
+  totalKonflikte: number
+  /** True wenn das Zeitfenster unklar war (kein startzeit/endzeit) — Genauigkeit eingeschränkt */
+  zeitfensterUnklar: boolean
+}
+
+/**
+ * Aggregate per-person Konflikte für eine geplante/bestehende Probe.
+ *
+ * Für jede betroffene Person (Cast-Mitglieder über Besetzungen oder explizit
+ * eingeladene Teilnehmer) wird `check_person_conflicts` gegen das geplante
+ * Zeitfenster aufgerufen. So werden Konflikte aus allen Subsystemen erfasst:
+ *
+ *  - Verfügbarkeits-Blöcke (verfuegbarkeiten)
+ *  - Aufführungs-Zuweisungen (auffuehrung_zuweisungen, System B)
+ *  - Veranstaltungs-Anmeldungen (anmeldungen)
+ *  - Andere Proben (proben_teilnehmer)
+ */
+export async function checkProbeKonflikteFull(input: {
+  stueckId: string
+  datum: string
+  startzeit?: string | null
+  endzeit?: string | null
+  szenenIds?: string[]
+  teilnehmerPersonIds?: string[]
+  excludeProbeId?: string
+}): Promise<ProbeKonflikteFullResult> {
+  const supabase = await createClient()
+
+  const {
+    stueckId,
+    datum,
+    startzeit,
+    endzeit,
+    szenenIds,
+    teilnehmerPersonIds,
+    excludeProbeId,
+  } = input
+
+  if (!datum) {
+    return {
+      personenMitKonflikten: [],
+      totalGeprueft: 0,
+      totalKonflikte: 0,
+      zeitfensterUnklar: true,
+    }
+  }
+
+  // Build the Cast-Person-Set from besetzungen (filtered by szenen if provided)
+  let besetzungenQuery = supabase
+    .from('besetzungen')
+    .select('person_id, rolle:rollen(stueck_id)')
+    .not('person_id', 'is', null)
+
+  if (szenenIds && szenenIds.length > 0) {
+    const { data: szenenRollen } = await supabase
+      .from('szenen_rollen')
+      .select('rolle_id')
+      .in('szene_id', szenenIds)
+    if (szenenRollen && szenenRollen.length > 0) {
+      const rolleIds = szenenRollen.map((sr) => sr.rolle_id)
+      besetzungenQuery = besetzungenQuery.in('rolle_id', rolleIds)
+    }
+  }
+
+  const { data: besetzungen } = await besetzungenQuery
+
+  const castPersonIds = new Set<string>(
+    (besetzungen || [])
+      .filter((b) => {
+        const rolle = b.rolle as unknown as Record<string, unknown> | null
+        return rolle?.stueck_id === stueckId
+      })
+      .map((b) => b.person_id as string)
+  )
+
+  // Union with explicit teilnehmerPersonIds (e.g. for already-saved Probe)
+  for (const pid of teilnehmerPersonIds || []) {
+    castPersonIds.add(pid)
+  }
+
+  const personIds = Array.from(castPersonIds)
+  if (personIds.length === 0) {
+    return {
+      personenMitKonflikten: [],
+      totalGeprueft: 0,
+      totalKonflikte: 0,
+      zeitfensterUnklar: !startzeit || !endzeit,
+    }
+  }
+
+  // Fallback: if start/end missing, use the full day so the check still catches
+  // hard "nicht_verfuegbar" blocks and other proben on the same date.
+  const effectiveStartzeit = startzeit && startzeit.length >= 5 ? startzeit : '00:00'
+  const effectiveEndzeit = endzeit && endzeit.length >= 5 ? endzeit : '23:59'
+  const zeitfensterUnklar = !startzeit || !endzeit
+
+  const startTs = toZurichTimestamp(datum, effectiveStartzeit)
+  const endTs = toZurichTimestamp(datum, effectiveEndzeit)
+
+  // Run per-person conflict checks in parallel
+  const results = await Promise.all(
+    personIds.map(async (personId) => {
+      const result = await checkPersonConflicts(personId, startTs, endTs)
+      // Filter out conflicts that point back to the same Probe (Edit-Modus)
+      const filtered = excludeProbeId
+        ? result.conflicts.filter(
+            (c) => !(c.type === 'probe' && c.reference_id === excludeProbeId)
+          )
+        : result.conflicts
+      return { personId, conflicts: filtered }
+    })
+  )
+
+  const personenWithConflicts = results.filter((r) => r.conflicts.length > 0)
+  if (personenWithConflicts.length === 0) {
+    return {
+      personenMitKonflikten: [],
+      totalGeprueft: personIds.length,
+      totalKonflikte: 0,
+      zeitfensterUnklar,
+    }
+  }
+
+  // Get names for the persons with conflicts
+  const conflictPersonIds = personenWithConflicts.map((r) => r.personId)
+  const { data: personen } = await supabase
+    .from('personen')
+    .select('id, vorname, nachname')
+    .in('id', conflictPersonIds)
+  const nameMap = new Map(
+    (personen || []).map((p) => [p.id, `${p.vorname} ${p.nachname}`])
+  )
+
+  const personenMitKonflikten: ProbePersonKonflikt[] = personenWithConflicts
+    .map((r) => ({
+      personId: r.personId,
+      personName: nameMap.get(r.personId) ?? 'Unbekannt',
+      conflicts: r.conflicts,
+    }))
+    .sort((a, b) => a.personName.localeCompare(b.personName, 'de'))
+
+  const totalKonflikte = personenMitKonflikten.reduce(
+    (sum, p) => sum + p.conflicts.length,
+    0
+  )
+
+  return {
+    personenMitKonflikten,
+    totalGeprueft: personIds.length,
+    totalKonflikte,
+    zeitfensterUnklar,
+  }
 }

--- a/apps/web/lib/utils/zurich-time.ts
+++ b/apps/web/lib/utils/zurich-time.ts
@@ -1,0 +1,44 @@
+/**
+ * Helpers for working with Europe/Zurich local times.
+ *
+ * The application's domain is exclusively Switzerland. Database functions like
+ * `check_person_conflicts` interpret `TIMESTAMPTZ` inputs by converting them
+ * `AT TIME ZONE 'Europe/Zurich'`. If we send a naïve `YYYY-MM-DDTHH:MM` string
+ * Supabase will parse it as UTC and the DB will then strip ~1-2h back to Zurich
+ * time, leading to off-by-offset errors. To avoid that, we serialize values
+ * with an explicit Zurich UTC offset (`+01:00` winter / `+02:00` summer).
+ */
+
+/**
+ * Determine the UTC offset for a given Zurich wall-clock date.
+ * Returns `+01:00` (CET) or `+02:00` (CEST).
+ *
+ * Implementation uses `Intl.DateTimeFormat` with `timeZoneName: 'shortOffset'`
+ * which Node 18+ supports.
+ */
+export function getZurichOffset(date: string): '+01:00' | '+02:00' {
+  // Use noon on the given day to be safely past any DST transition that happens at 02:00
+  const probe = new Date(`${date}T12:00:00Z`)
+  const fmt = new Intl.DateTimeFormat('en-GB', {
+    timeZone: 'Europe/Zurich',
+    timeZoneName: 'shortOffset',
+  })
+  const parts = fmt.formatToParts(probe)
+  const tzPart = parts.find((p) => p.type === 'timeZoneName')?.value ?? 'GMT+1'
+  // tzPart looks like "GMT+1" or "GMT+2"
+  if (tzPart.includes('+2')) return '+02:00'
+  return '+01:00'
+}
+
+/**
+ * Build an ISO-8601 timestamp string anchored in Europe/Zurich for the given
+ * date and time. Result e.g. `2026-06-25T14:00:00+02:00`.
+ *
+ * @param date YYYY-MM-DD
+ * @param time HH:MM or HH:MM:SS
+ */
+export function toZurichTimestamp(date: string, time: string): string {
+  const normalizedTime = time.length === 5 ? `${time}:00` : time
+  const offset = getZurichOffset(date)
+  return `${date}T${normalizedTime}${offset}`
+}


### PR DESCRIPTION
## Summary

Implementiert prominente, cross-system Konfliktwarnungen im Proben-Planungs-UI (Issue #487, Milestone #36, Epic A3).

- **Neue Server Action** `checkProbeKonflikteFull` aggregiert Konflikte pro betroffener Person über alle Subsysteme (Verfügbarkeits-Blöcke, Aufführungs-Schichten, Veranstaltungs-Anmeldungen, andere Proben) via parallelem `check_person_conflicts`-RPC.
- **Neue Komponente** `ProbeKonfliktBanner` mit zwei Varianten: `compact` (Form) und `prominent` (Detail-Seite). Liste klappt automatisch zu, sobald mehr als 5 Personen Konflikte haben.
- **ProbeForm** prüft jetzt live mit 400 ms Debounce bei jeder Änderung von Datum/Startzeit/Endzeit/Szenen-Auswahl — Banner erscheint **über dem Submit-Button**, nicht-blockierend.
- **Probe-Detailseite** zeigt prominenten Top-Banner mit voller Konflikt-Liste pro Person (Server-seitig gerendert).
- **Helper** `toZurichTimestamp` (lib/utils/zurich-time.ts) stellt sicher, dass die TIMESTAMPTZ-Inputs für `check_person_conflicts` mit dem korrekten Europe/Zurich-Offset gesendet werden (vermeidet 1–2h Drift durch UTC-Parsing).

## Akzeptanzkriterien aus #487

- [x] `checkProbeVerfuegbarkeit()` / `checkProbeKonflikte()` vorhanden (bereits da, jetzt erweitert um `checkProbeKonflikteFull` für Cross-System)
- [x] Live-Warnung im ProbeForm (debounced, ohne Page-Reload)
- [x] Konflikt-/Verfügbarkeitswarnung visuell prominent auf Detailseite (Top-Banner, `variant=prominent`)
- [x] Cross-System-Konflikte deutlich ausgewiesen (Aufführungs-Schicht / Veranstaltung / Verfügbarkeit / Andere Probe — gruppiert pro Person mit Typ-Label und Zeitfenster)
- [x] Nicht blockierend (Hinweistext: „Die Probe kann trotz Konflikten gespeichert werden")

## Design-Entscheidungen

- **Warning-Yellow statt Error-Red** — der Regisseur entscheidet bewusst, ob die Probe trotzdem stattfindet.
- **Aggregation pro Person**, nicht pro Konflikt — der Regisseur denkt in Cast-Mitgliedern.
- **`excludeProbeId` Filter** — verhindert, dass die aktuelle Probe sich selbst als Konflikt meldet (Edit-Modus + Detail-Seite).
- **Cast-Set aus Besetzungen** (gefiltert auf Szenen-Auswahl, falls vorhanden) plus optional explizite `teilnehmerPersonIds` — auf der Detail-Seite werden eingeladene Teilnehmer berücksichtigt, auch wenn sie nicht in der Besetzung sind.
- **Bestehende `checkProbeVerfuegbarkeit`** bleibt parallel im Form (zeigt die vom Cast eingegrenzte Cast-Verfügbarkeit) — bewusst nicht ersetzt, weil sie eine andere semantische Information liefert (Verfügbarkeit ohne Konflikt-Cross-Check).

## Geänderte Dateien

| Datei | Änderung |
| --- | --- |
| `apps/web/lib/actions/proben.ts` | + `checkProbeKonflikteFull` + Types `ProbePersonKonflikt`, `ProbeKonflikteFullResult` |
| `apps/web/lib/utils/zurich-time.ts` | NEU — `toZurichTimestamp`, `getZurichOffset` |
| `apps/web/components/proben/ProbeKonfliktBanner.tsx` | NEU — Banner-Component + `groupConflictsByType` Helper |
| `apps/web/components/proben/ProbeForm.tsx` | + Debounced Live-Check + Banner |
| `apps/web/components/proben/index.ts` | + Export der neuen Komponente |
| `apps/web/app/(protected)/proben/[id]/page.tsx` | + Server-side Konflikt-Check + prominent Banner |
| `apps/web/lib/actions/proben-konflikte-full.test.ts` | NEU — 7 Unit-Tests |

## Quality Gates

- [x] `npm run typecheck` — sauber
- [x] `npm run lint` — keine Warnungen/Fehler
- [x] `npm run test:run` — 139 Tests grün (7 neue Tests für `checkProbeKonflikteFull`)
- [x] `npm run build` — produziert vollständigen Build

## Browser-Test (manuell zu prüfen)

Hinweis: Der lokale Dev-Server konnte aus diesem Sub-Agent-Kontext nicht gestartet werden. Bitte folgenden manuellen Test durchführen:

1. `cd apps/web && rm -rf .next && npm run dev`
2. Login als Vorstand/Admin
3. Navigiere zu einer bestehenden Probe-Detailseite (`/proben/[id]`) — der prominente Banner sollte erscheinen, sofern Konflikte existieren (oder die „Keine Konflikte"-Success-Variante).
4. Bearbeite eine Probe (`/proben/[id]/bearbeiten`):
   - Ändere Datum/Startzeit/Endzeit — Banner aktualisiert sich nach 400ms.
   - Während des Tippens: kein Banner-Flackern, nur eine finale Anfrage.
5. Künstlicher Konflikt: Lege eine zweite Probe am selben Datum mit überlappender Zeit an, dem ein Cast-Mitglied der ersten Probe eingeladen ist — beide Detail-Seiten sollten den Konflikt anzeigen (kreuzweise referenzierend).
6. Veranstaltung-Konflikt: Trage einen Cast-Member zu einer Veranstaltung mit überlappender Zeit ein, prüfe ob die Probe-Detailseite den `Veranstaltung`-Konflikt anzeigt.
7. Mehr als 5 Konflikte: Banner zeigt „Alle anzeigen"-Toggle.

## Hinweise zur Koordination

- **Peter-A arbeitet parallel an Issue #489** (Email-Trigger bei Proben-Änderungen). Beide Branches berühren `apps/web/lib/actions/proben.ts`. Erwarteter Merge-Konflikt: trivial (Peter-A erweitert Imports + `createProbe`/`updateProbe` für Email-Hooks; ich hänge neue Funktion ans Datei-Ende).

Closes #487

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>