### PR TITLE
feat: Sofort-Mail bei Proben-Einladung/-Änderung/-Absage (Issue #489)

### DIFF
--- a/apps/web/lib/actions/proben-emails.test.ts
+++ b/apps/web/lib/actions/proben-emails.test.ts
@@ -1,0 +1,404 @@
+/**
+ * Unit tests for Proben Sofort-Mail helpers (Issue #489)
+ *
+ * Verifies that:
+ *  - invitation / change / cancellation emails are dispatched via the SMTP layer
+ *  - opt-out flags in `benachrichtigungs_einstellungen` are honored
+ *  - persons without email or without profile are handled gracefully
+ *
+ * The SMTP layer (`sendEmailWithRetry`) is mocked at the module boundary so
+ * no real email is sent.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// -----------------------------------------------------------------------------
+// Mock SMTP layer — must be hoisted BEFORE importing the SUT
+// -----------------------------------------------------------------------------
+
+const { sendEmailWithRetryMock } = vi.hoisted(() => ({
+  sendEmailWithRetryMock: vi.fn(async () => ({ success: true, messageId: 'mock-1' })),
+}))
+
+vi.mock('../email/client', () => ({
+  sendEmailWithRetry: sendEmailWithRetryMock,
+  sendEmail: vi.fn(async () => ({ success: true, messageId: 'mock-1' })),
+}))
+
+// -----------------------------------------------------------------------------
+// Mock the admin Supabase client — chainable `from(...).select().eq()...` builder
+// -----------------------------------------------------------------------------
+
+type Row = Record<string, unknown>
+
+const { tableState, mockAdminClient } = vi.hoisted(() => {
+  const tableState: Record<string, { rows: Record<string, unknown>[]; error: { message: string } | null }> = {}
+
+  function makeBuilder(table: string) {
+    const filters: Array<(r: Record<string, unknown>) => boolean> = []
+
+    const exec = () => {
+      const t = tableState[table]
+      if (!t) return { data: [], error: null }
+      if (t.error) return { data: null, error: t.error }
+      const rows = t.rows.filter((r) => filters.every((f) => f(r)))
+      return { data: rows, error: null }
+    }
+
+    const builder: Record<string, unknown> = {
+      select: vi.fn(() => builder),
+      eq: vi.fn((col: string, value: unknown) => {
+        filters.push((r) => r[col] === value)
+        return builder
+      }),
+      in: vi.fn((col: string, values: unknown[]) => {
+        filters.push((r) => values.includes(r[col]))
+        return builder
+      }),
+      insert: vi.fn(async () => ({ error: null })),
+      update: vi.fn(() => builder),
+      delete: vi.fn(() => builder),
+      single: vi.fn(async () => {
+        const r = exec()
+        if (r.error) return { data: null, error: r.error }
+        return { data: r.data?.[0] ?? null, error: null }
+      }),
+      maybeSingle: vi.fn(async () => {
+        const r = exec()
+        if (r.error) return { data: null, error: r.error }
+        return { data: r.data?.[0] ?? null, error: null }
+      }),
+      then: (resolve: (result: { data: unknown[]; error: unknown }) => void) => {
+        const r = exec()
+        resolve({ data: r.data ?? [], error: r.error })
+        return Promise.resolve(r)
+      },
+    }
+    return builder
+  }
+
+  const mockAdminClient = {
+    from: vi.fn((table: string) => makeBuilder(table)),
+  }
+
+  return { tableState, mockAdminClient }
+})
+
+function setTable(table: string, rows: Row[], error: { message: string } | null = null) {
+  tableState[table] = { rows, error }
+}
+
+function resetTables() {
+  for (const key of Object.keys(tableState)) delete tableState[key]
+}
+
+vi.mock('../supabase/admin', () => ({
+  createAdminClient: vi.fn(() => mockAdminClient),
+}))
+
+// -----------------------------------------------------------------------------
+// Import the SUT after the mocks are wired up
+// -----------------------------------------------------------------------------
+
+import {
+  sendProbeEinladungEmails,
+  sendProbeAenderungEmails,
+  sendProbeAbsageEmails,
+  getExistingTeilnehmerPersonIds,
+} from './proben-emails'
+
+// -----------------------------------------------------------------------------
+// Fixtures
+// -----------------------------------------------------------------------------
+
+const PROBE_ID = 'probe-123'
+const STUECK_ID = 'stueck-1'
+
+function seedProbe(overrides: Partial<Row> = {}) {
+  setTable('proben', [
+    {
+      id: PROBE_ID,
+      titel: 'Durchlaufprobe Akt 1',
+      datum: '2026-07-15',
+      startzeit: '19:30:00',
+      endzeit: '22:00:00',
+      ort: 'Probebühne',
+      stueck_id: STUECK_ID,
+      status: 'geplant',
+      notizen: null,
+      stueck: { titel: 'Hamlet' },
+      ...overrides,
+    },
+  ])
+}
+
+function seedPerson(
+  id: string,
+  email: string | null,
+  opts: { profileId?: string | null; vorname?: string; nachname?: string } = {}
+) {
+  const existing = tableState['personen']?.rows ?? []
+  setTable('personen', [
+    ...existing,
+    {
+      id,
+      vorname: opts.vorname ?? 'Anna',
+      nachname: opts.nachname ?? 'Beispiel',
+      email,
+    },
+  ])
+
+  const existingProfiles = tableState['profiles']?.rows ?? []
+  if (opts.profileId !== undefined && opts.profileId !== null && email) {
+    setTable('profiles', [
+      ...existingProfiles,
+      { id: opts.profileId, email },
+    ])
+  } else {
+    setTable('profiles', existingProfiles)
+  }
+}
+
+function seedSettings(profileId: string, settings: Record<string, boolean>) {
+  const existing = tableState['benachrichtigungs_einstellungen']?.rows ?? []
+  setTable('benachrichtigungs_einstellungen', [
+    ...existing,
+    { profile_id: profileId, ...settings },
+  ])
+}
+
+function seedTeilnehmer(personIds: string[], status = 'eingeladen') {
+  setTable(
+    'proben_teilnehmer',
+    personIds.map((pid) => ({ probe_id: PROBE_ID, person_id: pid, status }))
+  )
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+describe('proben-emails (Issue #489)', () => {
+  beforeEach(() => {
+    sendEmailWithRetryMock.mockClear()
+    sendEmailWithRetryMock.mockImplementation(async () => ({ success: true, messageId: 'mock-1' }))
+    resetTables()
+  })
+
+  // -----------------------------
+  // sendProbeEinladungEmails
+  // -----------------------------
+
+  describe('sendProbeEinladungEmails', () => {
+    it('sends an invitation to a teilnehmer with email and no opt-out', async () => {
+      seedProbe()
+      seedPerson('person-1', 'anna@example.com', { profileId: 'profile-1' })
+
+      const result = await sendProbeEinladungEmails(PROBE_ID, ['person-1'])
+
+      expect(result.sent).toBe(1)
+      expect(result.failed).toBe(0)
+      expect(result.skipped).toBe(0)
+      expect(sendEmailWithRetryMock).toHaveBeenCalledTimes(1)
+
+      const call = sendEmailWithRetryMock.mock.calls[0][0] as { to: string; subject: string }
+      expect(call.to).toBe('anna@example.com')
+      expect(call.subject).toContain('Probeneinladung')
+      expect(call.subject).toContain('Hamlet')
+    })
+
+    it('skips a teilnehmer who has opted out (email_neue_einladung = false)', async () => {
+      seedProbe()
+      seedPerson('person-1', 'opt-out@example.com', { profileId: 'profile-1' })
+      seedSettings('profile-1', { email_neue_einladung: false })
+
+      const result = await sendProbeEinladungEmails(PROBE_ID, ['person-1'])
+
+      expect(result.sent).toBe(0)
+      expect(result.skipped).toBe(1)
+      expect(sendEmailWithRetryMock).not.toHaveBeenCalled()
+    })
+
+    it('still sends to a teilnehmer with a settings row but the flag set to true', async () => {
+      seedProbe()
+      seedPerson('person-1', 'opt-in@example.com', { profileId: 'profile-1' })
+      seedSettings('profile-1', { email_neue_einladung: true })
+
+      const result = await sendProbeEinladungEmails(PROBE_ID, ['person-1'])
+
+      expect(result.sent).toBe(1)
+      expect(result.skipped).toBe(0)
+    })
+
+    it('skips persons without an email address', async () => {
+      seedProbe()
+      seedPerson('person-1', null)
+
+      const result = await sendProbeEinladungEmails(PROBE_ID, ['person-1'])
+
+      expect(result.sent).toBe(0)
+      expect(result.skipped).toBe(1)
+      expect(sendEmailWithRetryMock).not.toHaveBeenCalled()
+    })
+
+    it('treats a person without a linked profile as "no opt-out" and sends', async () => {
+      seedProbe()
+      seedPerson('person-1', 'no-profile@example.com') // no profileId
+
+      const result = await sendProbeEinladungEmails(PROBE_ID, ['person-1'])
+
+      expect(result.sent).toBe(1)
+      expect(result.skipped).toBe(0)
+    })
+
+    it('returns zeros when personIds is empty', async () => {
+      seedProbe()
+
+      const result = await sendProbeEinladungEmails(PROBE_ID, [])
+
+      expect(result).toEqual({ sent: 0, skipped: 0, failed: 0 })
+      expect(sendEmailWithRetryMock).not.toHaveBeenCalled()
+    })
+
+    it('counts a failed send as failed (not sent)', async () => {
+      seedProbe()
+      seedPerson('person-1', 'fail@example.com', { profileId: 'profile-1' })
+      sendEmailWithRetryMock.mockImplementationOnce(async () => ({ success: false, error: 'SMTP down' }))
+
+      const result = await sendProbeEinladungEmails(PROBE_ID, ['person-1'])
+
+      expect(result.sent).toBe(0)
+      expect(result.failed).toBe(1)
+    })
+
+    it('returns zeros if the probe does not exist', async () => {
+      // no seedProbe()
+
+      const result = await sendProbeEinladungEmails('non-existent', ['person-1'])
+
+      expect(result).toEqual({ sent: 0, skipped: 0, failed: 0 })
+      expect(sendEmailWithRetryMock).not.toHaveBeenCalled()
+    })
+  })
+
+  // -----------------------------
+  // sendProbeAenderungEmails
+  // -----------------------------
+
+  describe('sendProbeAenderungEmails', () => {
+    it('mails all current teilnehmer (eingeladen / zugesagt / vielleicht)', async () => {
+      seedProbe()
+      seedPerson('person-1', 'a@example.com', { profileId: 'profile-a' })
+      seedPerson('person-2', 'b@example.com', { profileId: 'profile-b' })
+      seedTeilnehmer(['person-1', 'person-2'])
+
+      const result = await sendProbeAenderungEmails(PROBE_ID, [
+        { field: 'datum', vorher: '15.07.2026', nachher: '22.07.2026' },
+      ])
+
+      expect(result.sent).toBe(2)
+      expect(sendEmailWithRetryMock).toHaveBeenCalledTimes(2)
+      const subjects = sendEmailWithRetryMock.mock.calls.map((c) => (c[0] as { subject: string }).subject)
+      expect(subjects.every((s) => s.includes('Probe geändert'))).toBe(true)
+    })
+
+    it('respects the Änderungsbenachrichtigung opt-out flag', async () => {
+      seedProbe()
+      seedPerson('person-1', 'opt-out@example.com', { profileId: 'profile-1' })
+      seedSettings('profile-1', { email_aenderungsbenachrichtigung: false })
+      seedTeilnehmer(['person-1'])
+
+      const result = await sendProbeAenderungEmails(PROBE_ID, [
+        { field: 'ort', vorher: 'A', nachher: 'B' },
+      ])
+
+      expect(result.sent).toBe(0)
+      expect(result.skipped).toBe(1)
+    })
+
+    it('returns zero when there are no changes', async () => {
+      seedProbe()
+      seedTeilnehmer(['person-1'])
+
+      const result = await sendProbeAenderungEmails(PROBE_ID, [])
+
+      expect(result).toEqual({ sent: 0, skipped: 0, failed: 0 })
+      expect(sendEmailWithRetryMock).not.toHaveBeenCalled()
+    })
+
+    it('returns zero when no teilnehmer exist', async () => {
+      seedProbe()
+      // no teilnehmer rows
+
+      const result = await sendProbeAenderungEmails(PROBE_ID, [
+        { field: 'datum', vorher: 'A', nachher: 'B' },
+      ])
+
+      expect(result).toEqual({ sent: 0, skipped: 0, failed: 0 })
+    })
+  })
+
+  // -----------------------------
+  // sendProbeAbsageEmails
+  // -----------------------------
+
+  describe('sendProbeAbsageEmails', () => {
+    it('sends an Absage to all teilnehmer including the Grund text', async () => {
+      seedProbe()
+      seedPerson('person-1', 'a@example.com', { profileId: 'profile-a' })
+      seedTeilnehmer(['person-1'])
+
+      const result = await sendProbeAbsageEmails(PROBE_ID, 'Krankheit Regie')
+
+      expect(result.sent).toBe(1)
+      const call = sendEmailWithRetryMock.mock.calls[0][0] as {
+        subject: string
+        text: string
+        html: string
+      }
+      expect(call.subject).toContain('Probe abgesagt')
+      expect(call.text).toContain('Krankheit Regie')
+    })
+
+    it('respects the Änderungsbenachrichtigung opt-out flag (same flag as Änderung)', async () => {
+      seedProbe()
+      seedPerson('person-1', 'opt-out@example.com', { profileId: 'profile-1' })
+      seedSettings('profile-1', { email_aenderungsbenachrichtigung: false })
+      seedTeilnehmer(['person-1'])
+
+      const result = await sendProbeAbsageEmails(PROBE_ID)
+
+      expect(result.sent).toBe(0)
+      expect(result.skipped).toBe(1)
+    })
+
+    it('skips when there are no teilnehmer', async () => {
+      seedProbe()
+
+      const result = await sendProbeAbsageEmails(PROBE_ID)
+
+      expect(result).toEqual({ sent: 0, skipped: 0, failed: 0 })
+    })
+  })
+
+  // -----------------------------
+  // getExistingTeilnehmerPersonIds
+  // -----------------------------
+
+  describe('getExistingTeilnehmerPersonIds', () => {
+    it('returns the set of person_ids currently in proben_teilnehmer', async () => {
+      seedTeilnehmer(['person-1', 'person-2'])
+
+      const ids = await getExistingTeilnehmerPersonIds(PROBE_ID)
+
+      expect(ids.has('person-1')).toBe(true)
+      expect(ids.has('person-2')).toBe(true)
+      expect(ids.size).toBe(2)
+    })
+
+    it('returns an empty set when no teilnehmer exist', async () => {
+      const ids = await getExistingTeilnehmerPersonIds(PROBE_ID)
+      expect(ids.size).toBe(0)
+    })
+  })
+})

--- a/apps/web/lib/actions/proben-emails.ts
+++ b/apps/web/lib/actions/proben-emails.ts
@@ -1,0 +1,434 @@
+'use server'
+
+/**
+ * Proben Sofort-Mail Helper (Issue #489)
+ *
+ * Best-effort email dispatch for probe invitation / change / cancellation.
+ * Triggered from `proben.ts` after the underlying mutation has succeeded.
+ * Errors are logged but NEVER re-thrown — the probe action must succeed even
+ * if email sending fails (SMTP outage, missing config, etc.).
+ */
+
+import { createAdminClient } from '../supabase/admin'
+import { sendEmailWithRetry } from '../email/client'
+import {
+  probeEinladungEmail,
+  probeAenderungEmail,
+  probeAbsageEmail,
+  type ProbeAenderungChange,
+} from '../email/templates/proben'
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface ProbeEmailResult {
+  sent: number
+  skipped: number
+  failed: number
+}
+
+interface ProbeBasic {
+  id: string
+  titel: string
+  datum: string
+  startzeit: string | null
+  endzeit: string | null
+  ort: string | null
+  stueck_id: string
+  status: string
+  stueck_titel: string | null
+}
+
+interface PersonInfo {
+  id: string
+  vorname: string
+  nachname: string
+  email: string | null
+  profile_id: string | null
+}
+
+type OptOutFlag = 'email_neue_einladung' | 'email_aenderungsbenachrichtigung'
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function buildProbeLink(probeId: string): string {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
+  return `${baseUrl}/proben/${probeId}`
+}
+
+async function fetchProbe(probeId: string): Promise<ProbeBasic | null> {
+  const admin = createAdminClient()
+  const { data, error } = await admin
+    .from('proben')
+    .select('id, titel, datum, startzeit, endzeit, ort, stueck_id, status, stueck:stuecke(titel)')
+    .eq('id', probeId)
+    .single()
+
+  if (error || !data) {
+    if (error) console.error('[Proben Email] Failed to fetch probe:', error.message)
+    return null
+  }
+
+  const stueck = (data as unknown as { stueck: { titel: string } | null }).stueck
+  return {
+    id: data.id as string,
+    titel: data.titel as string,
+    datum: data.datum as string,
+    startzeit: (data.startzeit as string | null) ?? null,
+    endzeit: (data.endzeit as string | null) ?? null,
+    ort: (data.ort as string | null) ?? null,
+    stueck_id: data.stueck_id as string,
+    status: data.status as string,
+    stueck_titel: stueck?.titel ?? null,
+  }
+}
+
+async function fetchPersonsWithProfiles(personIds: string[]): Promise<PersonInfo[]> {
+  if (personIds.length === 0) return []
+
+  const admin = createAdminClient()
+
+  const { data: personen, error } = await admin
+    .from('personen')
+    .select('id, vorname, nachname, email')
+    .in('id', personIds)
+
+  if (error || !personen) {
+    if (error) console.error('[Proben Email] Failed to fetch personen:', error.message)
+    return []
+  }
+
+  const withEmail = personen.filter(
+    (p): p is { id: string; vorname: string; nachname: string; email: string } =>
+      typeof p.email === 'string' && p.email.length > 0
+  )
+
+  if (withEmail.length === 0) return []
+
+  const emails = withEmail.map((p) => p.email)
+  const { data: profiles } = await admin
+    .from('profiles')
+    .select('id, email')
+    .in('email', emails)
+
+  const profileMap = new Map<string, string>()
+  for (const p of profiles || []) {
+    if (typeof p.email === 'string') profileMap.set(p.email.toLowerCase(), p.id as string)
+  }
+
+  return withEmail.map((p) => ({
+    id: p.id,
+    vorname: p.vorname,
+    nachname: p.nachname,
+    email: p.email,
+    profile_id: profileMap.get(p.email.toLowerCase()) ?? null,
+  }))
+}
+
+async function isOptedOut(profileId: string | null, flag: OptOutFlag): Promise<boolean> {
+  if (!profileId) return false
+
+  const admin = createAdminClient()
+  const { data } = await admin
+    .from('benachrichtigungs_einstellungen')
+    .select(flag)
+    .eq('profile_id', profileId)
+    .maybeSingle()
+
+  if (!data) return false
+  return (data as Record<string, boolean | null>)[flag] === false
+}
+
+async function logEmailFailure(
+  templateTyp: string,
+  recipientEmail: string,
+  recipientName: string,
+  errorMessage: string
+): Promise<void> {
+  try {
+    const admin = createAdminClient()
+    await admin.from('email_logs').insert({
+      template_typ: templateTyp,
+      recipient_email: recipientEmail,
+      recipient_name: recipientName,
+      status: 'failed',
+      error_message: errorMessage,
+    } as never)
+  } catch (err) {
+    console.error('[Proben Email] Failed to log email failure:', err)
+  }
+}
+
+/**
+ * Returns the set of person_ids currently in proben_teilnehmer for a given
+ * probe. Used by callers in `proben.ts` to compute the "new IDs" diff.
+ */
+export async function getExistingTeilnehmerPersonIds(probeId: string): Promise<Set<string>> {
+  const admin = createAdminClient()
+  const { data, error } = await admin
+    .from('proben_teilnehmer')
+    .select('person_id')
+    .eq('probe_id', probeId)
+
+  if (error || !data) {
+    if (error) console.error('[Proben Email] Failed to fetch existing teilnehmer:', error.message)
+    return new Set()
+  }
+
+  return new Set(data.map((t: { person_id: string }) => t.person_id))
+}
+
+// =============================================================================
+// Sofort-Einladung
+// =============================================================================
+
+export async function sendProbeEinladungEmails(
+  probeId: string,
+  personIds: string[]
+): Promise<ProbeEmailResult> {
+  const result: ProbeEmailResult = { sent: 0, skipped: 0, failed: 0 }
+
+  if (personIds.length === 0) return result
+
+  const probe = await fetchProbe(probeId)
+  if (!probe) return result
+
+  const persons = await fetchPersonsWithProfiles(personIds)
+
+  for (const person of persons) {
+    try {
+      if (!person.email) {
+        result.skipped++
+        continue
+      }
+
+      const optedOut = await isOptedOut(person.profile_id, 'email_neue_einladung')
+      if (optedOut) {
+        result.skipped++
+        continue
+      }
+
+      const { subject, html, text } = probeEinladungEmail({
+        vorname: person.vorname,
+        probeTitel: probe.titel,
+        stueckTitel: probe.stueck_titel ?? undefined,
+        datum: probe.datum,
+        startzeit: probe.startzeit,
+        endzeit: probe.endzeit,
+        ort: probe.ort,
+        probeLink: buildProbeLink(probe.id),
+      })
+
+      const sendResult = await sendEmailWithRetry({
+        to: person.email,
+        subject,
+        html,
+        text,
+        logging: {
+          templateTyp: 'probe_einladung',
+          recipientName: `${person.vorname} ${person.nachname}`,
+        },
+      })
+
+      if (sendResult.success) {
+        result.sent++
+      } else {
+        result.failed++
+        await logEmailFailure(
+          'probe_einladung',
+          person.email,
+          `${person.vorname} ${person.nachname}`,
+          sendResult.error || 'unknown error'
+        )
+      }
+    } catch (err) {
+      result.failed++
+      console.error('[Proben Email] Unexpected error for', person.email, err)
+    }
+  }
+
+  const handled = result.sent + result.failed + result.skipped
+  const unaccounted = personIds.length - handled
+  if (unaccounted > 0) {
+    result.skipped += unaccounted
+  }
+
+  return result
+}
+
+// =============================================================================
+// Änderungs-Mail
+// =============================================================================
+
+export async function sendProbeAenderungEmails(
+  probeId: string,
+  changes: ProbeAenderungChange[]
+): Promise<ProbeEmailResult> {
+  const result: ProbeEmailResult = { sent: 0, skipped: 0, failed: 0 }
+
+  if (changes.length === 0) return result
+
+  const probe = await fetchProbe(probeId)
+  if (!probe) return result
+
+  const admin = createAdminClient()
+  const { data: teilnehmer, error } = await admin
+    .from('proben_teilnehmer')
+    .select('person_id, status')
+    .eq('probe_id', probeId)
+    .in('status', ['eingeladen', 'zugesagt', 'vielleicht'])
+
+  if (error || !teilnehmer || teilnehmer.length === 0) {
+    if (error) console.error('[Proben Email] Failed to fetch teilnehmer:', error.message)
+    return result
+  }
+
+  const personIds = teilnehmer.map((t: { person_id: string }) => t.person_id)
+  const persons = await fetchPersonsWithProfiles(personIds)
+
+  for (const person of persons) {
+    try {
+      if (!person.email) {
+        result.skipped++
+        continue
+      }
+
+      const optedOut = await isOptedOut(person.profile_id, 'email_aenderungsbenachrichtigung')
+      if (optedOut) {
+        result.skipped++
+        continue
+      }
+
+      const { subject, html, text } = probeAenderungEmail({
+        vorname: person.vorname,
+        probeTitel: probe.titel,
+        stueckTitel: probe.stueck_titel ?? undefined,
+        datum: probe.datum,
+        startzeit: probe.startzeit,
+        endzeit: probe.endzeit,
+        ort: probe.ort,
+        changes,
+        probeLink: buildProbeLink(probe.id),
+      })
+
+      const sendResult = await sendEmailWithRetry({
+        to: person.email,
+        subject,
+        html,
+        text,
+        logging: {
+          templateTyp: 'probe_aenderung',
+          recipientName: `${person.vorname} ${person.nachname}`,
+        },
+      })
+
+      if (sendResult.success) {
+        result.sent++
+      } else {
+        result.failed++
+        await logEmailFailure(
+          'probe_aenderung',
+          person.email,
+          `${person.vorname} ${person.nachname}`,
+          sendResult.error || 'unknown error'
+        )
+      }
+    } catch (err) {
+      result.failed++
+      console.error('[Proben Email] Unexpected error for', person.email, err)
+    }
+  }
+
+  const handled = result.sent + result.failed + result.skipped
+  const unaccounted = personIds.length - handled
+  if (unaccounted > 0) result.skipped += unaccounted
+
+  return result
+}
+
+// =============================================================================
+// Absage-Mail
+// =============================================================================
+
+export async function sendProbeAbsageEmails(
+  probeId: string,
+  grund?: string
+): Promise<ProbeEmailResult> {
+  const result: ProbeEmailResult = { sent: 0, skipped: 0, failed: 0 }
+
+  const probe = await fetchProbe(probeId)
+  if (!probe) return result
+
+  const admin = createAdminClient()
+  const { data: teilnehmer, error } = await admin
+    .from('proben_teilnehmer')
+    .select('person_id, status')
+    .eq('probe_id', probeId)
+    .in('status', ['eingeladen', 'zugesagt', 'vielleicht'])
+
+  if (error || !teilnehmer || teilnehmer.length === 0) {
+    if (error) console.error('[Proben Email] Failed to fetch teilnehmer:', error.message)
+    return result
+  }
+
+  const personIds = teilnehmer.map((t: { person_id: string }) => t.person_id)
+  const persons = await fetchPersonsWithProfiles(personIds)
+
+  for (const person of persons) {
+    try {
+      if (!person.email) {
+        result.skipped++
+        continue
+      }
+
+      const optedOut = await isOptedOut(person.profile_id, 'email_aenderungsbenachrichtigung')
+      if (optedOut) {
+        result.skipped++
+        continue
+      }
+
+      const { subject, html, text } = probeAbsageEmail({
+        vorname: person.vorname,
+        probeTitel: probe.titel,
+        stueckTitel: probe.stueck_titel ?? undefined,
+        datum: probe.datum,
+        grund: grund ?? null,
+      })
+
+      const sendResult = await sendEmailWithRetry({
+        to: person.email,
+        subject,
+        html,
+        text,
+        logging: {
+          templateTyp: 'probe_absage',
+          recipientName: `${person.vorname} ${person.nachname}`,
+        },
+      })
+
+      if (sendResult.success) {
+        result.sent++
+      } else {
+        result.failed++
+        await logEmailFailure(
+          'probe_absage',
+          person.email,
+          `${person.vorname} ${person.nachname}`,
+          sendResult.error || 'unknown error'
+        )
+      }
+    } catch (err) {
+      result.failed++
+      console.error('[Proben Email] Unexpected error for', person.email, err)
+    }
+  }
+
+  const handled = result.sent + result.failed + result.skipped
+  const unaccounted = personIds.length - handled
+  if (unaccounted > 0) result.skipped += unaccounted
+
+  return result
+}

--- a/apps/web/lib/actions/proben-teilnehmer-suggest.test.ts
+++ b/apps/web/lib/actions/proben-teilnehmer-suggest.test.ts
@@ -25,6 +25,16 @@ vi.mock('./conflict-check', () => ({
   }),
 }))
 
+// Issue #489: stub email helpers so confirmProbenTeilnehmer / addTeilnehmer
+// don't reach into the admin Supabase client (no SUPABASE_SERVICE_ROLE_KEY
+// in the unit-test environment).
+vi.mock('./proben-emails', () => ({
+  sendProbeEinladungEmails: vi.fn().mockResolvedValue({ sent: 0, skipped: 0, failed: 0 }),
+  sendProbeAenderungEmails: vi.fn().mockResolvedValue({ sent: 0, skipped: 0, failed: 0 }),
+  sendProbeAbsageEmails: vi.fn().mockResolvedValue({ sent: 0, skipped: 0, failed: 0 }),
+  getExistingTeilnehmerPersonIds: vi.fn().mockResolvedValue(new Set<string>()),
+}))
+
 // Import after mocking
 import { suggestProbenTeilnehmer, confirmProbenTeilnehmer } from './proben'
 import { checkPersonConflicts } from './conflict-check'

--- a/apps/web/lib/actions/proben.test.ts
+++ b/apps/web/lib/actions/proben.test.ts
@@ -19,6 +19,15 @@ vi.mock('@/lib/supabase/server', () => ({
   getUserProfile: vi.fn(() => Promise.resolve(mockVorstandProfile)),
 }))
 
+// Issue #489: stub email helpers so probe actions don't reach into the admin
+// client (no SUPABASE_SERVICE_ROLE_KEY in the unit-test environment).
+vi.mock('./proben-emails', () => ({
+  sendProbeEinladungEmails: vi.fn().mockResolvedValue({ sent: 0, skipped: 0, failed: 0 }),
+  sendProbeAenderungEmails: vi.fn().mockResolvedValue({ sent: 0, skipped: 0, failed: 0 }),
+  sendProbeAbsageEmails: vi.fn().mockResolvedValue({ sent: 0, skipped: 0, failed: 0 }),
+  getExistingTeilnehmerPersonIds: vi.fn().mockResolvedValue(new Set<string>()),
+}))
+
 // Import after mocking
 import {
   getProbenForStueck,

--- a/apps/web/lib/actions/proben.ts
+++ b/apps/web/lib/actions/proben.ts
@@ -24,6 +24,13 @@ import type {
 } from '../supabase/types'
 import { checkPersonConflicts } from './conflict-check'
 import { checkMultipleMembersAvailability } from './verfuegbarkeiten'
+import {
+  sendProbeEinladungEmails,
+  sendProbeAenderungEmails,
+  sendProbeAbsageEmails,
+  getExistingTeilnehmerPersonIds,
+} from './proben-emails'
+import type { ProbeAenderungChange } from '../email/templates/proben'
 
 // =============================================================================
 // Proben CRUD
@@ -152,7 +159,9 @@ export async function updateProbe(
 
   const supabase = await createClient()
 
-  // Get stueck_id for revalidation
+  // Read the OLD probe BEFORE update so we can:
+  //  - revalidate the stueck-page
+  //  - build a field-level diff for the change/cancel email (Issue #489)
   const probe = await getProbeBasic(id)
 
   const { error } = await supabase
@@ -170,7 +179,86 @@ export async function updateProbe(
   }
   revalidatePath(`/proben/${id}`)
   revalidatePath('/proben')
+
+  // Issue #489: dispatch change/cancellation emails (best-effort, no throw)
+  if (probe) {
+    try {
+      const newStatus = data.status ?? probe.status
+      const wasCancelOrPostpone =
+        (newStatus === 'abgesagt' || newStatus === 'verschoben') &&
+        probe.status !== newStatus
+
+      if (wasCancelOrPostpone) {
+        // Status flipped to abgesagt/verschoben — send cancellation mail.
+        // No structured "Grund" field on the probe; use notizen if present.
+        const grund = data.notizen ?? probe.notizen ?? undefined
+        await sendProbeAbsageEmails(id, grund || undefined)
+      } else {
+        const changes = buildProbeAenderungChanges(probe, data)
+        if (changes.length > 0) {
+          await sendProbeAenderungEmails(id, changes)
+        }
+      }
+    } catch (mailErr) {
+      console.error('[Proben] Änderungs-/Absage-Mails failed:', mailErr)
+    }
+  }
+
   return { success: true }
+}
+
+/**
+ * Compute the human-readable diff between the OLD probe row and the partial
+ * update. Only includes fields the recipient cares about (datum, zeit, ort).
+ */
+function buildProbeAenderungChanges(
+  oldProbe: Probe,
+  update: ProbeUpdate
+): ProbeAenderungChange[] {
+  const changes: ProbeAenderungChange[] = []
+
+  const formatDate = (v: string | null | undefined) => {
+    if (!v) return ''
+    const [y, m, d] = v.split('-').map(Number)
+    if (!y || !m || !d) return v
+    return `${String(d).padStart(2, '0')}.${String(m).padStart(2, '0')}.${y}`
+  }
+  const formatTime = (v: string | null | undefined) => {
+    if (!v) return ''
+    const parts = v.split(':')
+    return parts.length >= 2 ? `${parts[0]}:${parts[1]}` : v
+  }
+
+  if (update.datum !== undefined && update.datum !== oldProbe.datum) {
+    changes.push({
+      field: 'datum',
+      vorher: formatDate(oldProbe.datum),
+      nachher: formatDate(update.datum),
+    })
+  }
+  if (update.startzeit !== undefined && update.startzeit !== oldProbe.startzeit) {
+    changes.push({
+      field: 'startzeit',
+      vorher: formatTime(oldProbe.startzeit),
+      nachher: formatTime(update.startzeit),
+    })
+  }
+  if (update.endzeit !== undefined && update.endzeit !== oldProbe.endzeit) {
+    changes.push({
+      field: 'endzeit',
+      vorher: formatTime(oldProbe.endzeit),
+      nachher: formatTime(update.endzeit),
+    })
+  }
+  if (update.ort !== undefined && update.ort !== oldProbe.ort) {
+    changes.push({
+      field: 'ort',
+      vorher: oldProbe.ort ?? '',
+      nachher: update.ort ?? '',
+    })
+  }
+
+  return changes
 }
 
 /**
@@ -433,6 +521,13 @@ export async function addTeilnehmerToProbe(
     return { success: false, error: error.message }
   }
 
+  // Issue #489: send immediate invitation email (best-effort)
+  try {
+    await sendProbeEinladungEmails(data.probe_id, [data.person_id])
+  } catch (mailErr) {
+    console.error('[Proben] Einladungs-Mail failed:', mailErr)
+  }
+
   revalidatePath(`/proben/${data.probe_id}`)
   return { success: true }
 }
@@ -529,6 +624,10 @@ export async function autoInviteProbeTeilnehmer(
 
   const supabase = await createClient()
 
+  // Issue #489: capture existing teilnehmer BEFORE the RPC, so we can diff
+  // afterwards and only mail newly-added persons.
+  const existingBefore = await getExistingTeilnehmerPersonIds(probeId)
+
   // Call the database function
   const { data, error } = await supabase.rpc('auto_invite_probe_teilnehmer', {
     probe_uuid: probeId,
@@ -537,6 +636,17 @@ export async function autoInviteProbeTeilnehmer(
   if (error) {
     console.error('Error auto-inviting teilnehmer:', error)
     return { success: false, error: error.message }
+  }
+
+  // Issue #489: fire-and-forget invitation emails for newly-added persons
+  try {
+    const existingAfter = await getExistingTeilnehmerPersonIds(probeId)
+    const newPersonIds = [...existingAfter].filter((id) => !existingBefore.has(id))
+    if (newPersonIds.length > 0) {
+      await sendProbeEinladungEmails(probeId, newPersonIds)
+    }
+  } catch (mailErr) {
+    console.error('[Proben] Einladungs-Mails (auto) failed:', mailErr)
   }
 
   revalidatePath(`/proben/${probeId}`)
@@ -864,6 +974,11 @@ export async function confirmProbenTeilnehmer(
 
   const supabase = await createClient()
 
+  // Issue #489: figure out which IDs are NEW so we only mail those after the
+  // upsert (existing teilnehmer would otherwise get a stale invitation mail).
+  const existingBefore = await getExistingTeilnehmerPersonIds(probeId)
+  const newPersonIds = personIds.filter((id) => !existingBefore.has(id))
+
   const inserts = personIds.map((personId) => ({
     probe_id: probeId,
     person_id: personId,
@@ -877,6 +992,15 @@ export async function confirmProbenTeilnehmer(
   if (error) {
     console.error('Error confirming teilnehmer:', error)
     return { success: false, error: error.message }
+  }
+
+  // Issue #489: send immediate invitation emails for the newly-added persons
+  if (newPersonIds.length > 0) {
+    try {
+      await sendProbeEinladungEmails(probeId, newPersonIds)
+    } catch (mailErr) {
+      console.error('[Proben] Einladungs-Mails (confirm) failed:', mailErr)
+    }
   }
 
   revalidatePath(`/proben/${probeId}`)

--- a/apps/web/lib/email/templates/proben.ts
+++ b/apps/web/lib/email/templates/proben.ts
@@ -1,0 +1,318 @@
+/**
+ * Email Templates — Proben (Sprint 5 / Issue #489)
+ *
+ * Inline TS templates (HTML + plain text) for immediate invitation / change /
+ * cancellation mails when a Probe-Teilnehmer is added or the Probe itself is
+ * updated. Mirrors the convention used in `helferliste.ts`: no DB round-trip,
+ * German UI text.
+ */
+
+const baseStyles = `
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; }
+  .container { max-width: 600px; margin: 0 auto; padding: 20px; }
+  .header { background: #1a1a2e; color: white; padding: 20px; text-align: center; border-radius: 8px 8px 0 0; }
+  .header h1 { margin: 0; font-size: 24px; }
+  .content { background: #f9f9f9; padding: 20px; border: 1px solid #e0e0e0; }
+  .footer { background: #f0f0f0; padding: 15px; text-align: center; font-size: 12px; color: #666; border-radius: 0 0 8px 8px; }
+  .info-box { background: white; padding: 15px; border-radius: 6px; margin: 15px 0; border-left: 4px solid #3b82f6; }
+  .diff-box { background: #fffbeb; padding: 12px 15px; border-radius: 6px; margin: 15px 0; border-left: 4px solid #f59e0b; }
+  .diff-row { padding: 4px 0; }
+  .diff-old { color: #9ca3af; text-decoration: line-through; }
+  .diff-new { color: #047857; font-weight: 600; }
+  .cancel-box { background: #fef2f2; padding: 15px; border-radius: 6px; margin: 15px 0; border-left: 4px solid #dc2626; }
+`
+
+const footerHtml = `
+  <div class="footer">
+    <p>Diese E-Mail wurde automatisch von BackstagePass gesendet.</p>
+    <p>Theatergruppe Widen</p>
+    <p style="font-style: italic; color: #9ca3af; font-size: 11px; margin: 2px 0 0 0;">s'Theater uf em Mutschelle</p>
+  </div>
+`
+
+const footerText = `
+--
+BackstagePass - Theatergruppe Widen
+s'Theater uf em Mutschelle
+`
+
+// =============================================================================
+// Helpers — German date / time formatting
+// =============================================================================
+
+function formatGermanDate(isoDate: string): string {
+  const [y, m, d] = isoDate.split('-').map(Number)
+  if (!y || !m || !d) return isoDate
+  const date = new Date(Date.UTC(y, m - 1, d))
+  return date.toLocaleDateString('de-CH', {
+    weekday: 'short',
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  })
+}
+
+function formatGermanTime(time: string | null | undefined): string {
+  if (!time) return ''
+  const parts = time.split(':')
+  if (parts.length < 2) return time
+  return `${parts[0]}:${parts[1]}`
+}
+
+function formatTimeRange(start: string | null | undefined, end: string | null | undefined): string {
+  const s = formatGermanTime(start)
+  const e = formatGermanTime(end)
+  if (s && e) return `${s} – ${e} Uhr`
+  if (s) return `${s} Uhr`
+  if (e) return `bis ${e} Uhr`
+  return ''
+}
+
+// =============================================================================
+// Probe Einladung (Sofort-Mail beim Hinzufügen)
+// =============================================================================
+
+export interface ProbeEinladungData {
+  vorname: string
+  probeTitel: string
+  stueckTitel?: string
+  datum: string
+  startzeit?: string | null
+  endzeit?: string | null
+  ort?: string | null
+  beschreibung?: string | null
+  probeLink: string
+}
+
+export function probeEinladungEmail(
+  data: ProbeEinladungData
+): { subject: string; html: string; text: string } {
+  const datum = formatGermanDate(data.datum)
+  const zeitRange = formatTimeRange(data.startzeit, data.endzeit)
+  const titel = data.stueckTitel ? `${data.stueckTitel} — ${data.probeTitel}` : data.probeTitel
+
+  const subject = `Probeneinladung: ${titel} am ${datum}`
+
+  const html = `
+    <!DOCTYPE html>
+    <html>
+    <head><style>${baseStyles}</style></head>
+    <body>
+      <div class="container">
+        <div class="header"><h1>BackstagePass</h1></div>
+        <div class="content">
+          <p>Hallo ${data.vorname},</p>
+          <p>du wurdest zu einer Probe eingeladen:</p>
+          <div class="info-box">
+            <h3 style="margin-top: 0;">${titel}</h3>
+            <p><strong>Datum:</strong> ${datum}</p>
+            ${zeitRange ? `<p><strong>Zeit:</strong> ${zeitRange}</p>` : ''}
+            ${data.ort ? `<p><strong>Ort:</strong> ${data.ort}</p>` : ''}
+            ${data.beschreibung ? `<p style="margin-top: 12px; color: #555;">${data.beschreibung}</p>` : ''}
+          </div>
+          <p>Bitte gib in BackstagePass Bescheid, ob du teilnehmen kannst:</p>
+          <p style="text-align: center; margin: 20px 0;">
+            <a href="${data.probeLink}" style="display: inline-block; background: #3b82f6; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px;">Probe ansehen</a>
+          </p>
+          <p style="font-size: 13px; color: #666;">
+            Diese Einladung kannst du in deinen Benachrichtigungs-Einstellungen abschalten.
+          </p>
+        </div>
+        ${footerHtml}
+      </div>
+    </body>
+    </html>
+  `
+
+  const text = `
+Hallo ${data.vorname},
+
+du wurdest zu einer Probe eingeladen:
+
+${titel}
+Datum: ${datum}
+${zeitRange ? `Zeit: ${zeitRange}` : ''}
+${data.ort ? `Ort: ${data.ort}` : ''}
+${data.beschreibung ? `\n${data.beschreibung}\n` : ''}
+Bitte gib in BackstagePass Bescheid, ob du teilnehmen kannst:
+${data.probeLink}
+
+${footerText}
+  `.trim()
+
+  return { subject, html, text }
+}
+
+// =============================================================================
+// Probe Änderung
+// =============================================================================
+
+export interface ProbeAenderungChange {
+  field: 'datum' | 'startzeit' | 'endzeit' | 'ort'
+  vorher: string
+  nachher: string
+}
+
+export interface ProbeAenderungData {
+  vorname: string
+  probeTitel: string
+  stueckTitel?: string
+  datum: string
+  startzeit?: string | null
+  endzeit?: string | null
+  ort?: string | null
+  changes: ProbeAenderungChange[]
+  probeLink: string
+}
+
+const FIELD_LABELS: Record<ProbeAenderungChange['field'], string> = {
+  datum: 'Datum',
+  startzeit: 'Startzeit',
+  endzeit: 'Endzeit',
+  ort: 'Ort',
+}
+
+export function probeAenderungEmail(
+  data: ProbeAenderungData
+): { subject: string; html: string; text: string } {
+  const datum = formatGermanDate(data.datum)
+  const zeitRange = formatTimeRange(data.startzeit, data.endzeit)
+  const titel = data.stueckTitel ? `${data.stueckTitel} — ${data.probeTitel}` : data.probeTitel
+
+  const subject = `Probe geändert: ${titel}`
+
+  const diffRowsHtml = data.changes
+    .map((c) => {
+      const label = FIELD_LABELS[c.field]
+      return `
+        <div class="diff-row">
+          <strong>${label}:</strong>
+          <span class="diff-old">${c.vorher || '—'}</span>
+          &nbsp;→&nbsp;
+          <span class="diff-new">${c.nachher || '—'}</span>
+        </div>
+      `
+    })
+    .join('')
+
+  const diffRowsText = data.changes
+    .map((c) => `  - ${FIELD_LABELS[c.field]}: ${c.vorher || '—'} → ${c.nachher || '—'}`)
+    .join('\n')
+
+  const html = `
+    <!DOCTYPE html>
+    <html>
+    <head><style>${baseStyles}</style></head>
+    <body>
+      <div class="container">
+        <div class="header"><h1>BackstagePass</h1></div>
+        <div class="content">
+          <p>Hallo ${data.vorname},</p>
+          <p>eine Probe, zu der du eingeladen bist, hat sich geändert:</p>
+          <div class="info-box">
+            <h3 style="margin-top: 0;">${titel}</h3>
+            <p><strong>Datum:</strong> ${datum}</p>
+            ${zeitRange ? `<p><strong>Zeit:</strong> ${zeitRange}</p>` : ''}
+            ${data.ort ? `<p><strong>Ort:</strong> ${data.ort}</p>` : ''}
+          </div>
+          <div class="diff-box">
+            <p style="margin-top: 0; font-weight: 600;">Was hat sich geändert?</p>
+            ${diffRowsHtml}
+          </div>
+          <p>Bitte prüfe die Details und bestätige ggf. neu in BackstagePass:</p>
+          <p style="text-align: center; margin: 20px 0;">
+            <a href="${data.probeLink}" style="display: inline-block; background: #3b82f6; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px;">Probe ansehen</a>
+          </p>
+        </div>
+        ${footerHtml}
+      </div>
+    </body>
+    </html>
+  `
+
+  const text = `
+Hallo ${data.vorname},
+
+eine Probe, zu der du eingeladen bist, hat sich geändert:
+
+${titel}
+Datum: ${datum}
+${zeitRange ? `Zeit: ${zeitRange}` : ''}
+${data.ort ? `Ort: ${data.ort}` : ''}
+
+Was hat sich geändert?
+${diffRowsText}
+
+Bitte prüfe die Details:
+${data.probeLink}
+
+${footerText}
+  `.trim()
+
+  return { subject, html, text }
+}
+
+// =============================================================================
+// Probe Absage
+// =============================================================================
+
+export interface ProbeAbsageData {
+  vorname: string
+  probeTitel: string
+  stueckTitel?: string
+  datum: string
+  grund?: string | null
+}
+
+export function probeAbsageEmail(
+  data: ProbeAbsageData
+): { subject: string; html: string; text: string } {
+  const datum = formatGermanDate(data.datum)
+  const titel = data.stueckTitel ? `${data.stueckTitel} — ${data.probeTitel}` : data.probeTitel
+
+  const subject = `Probe abgesagt: ${titel} am ${datum}`
+
+  const html = `
+    <!DOCTYPE html>
+    <html>
+    <head><style>${baseStyles}</style></head>
+    <body>
+      <div class="container">
+        <div class="header"><h1>BackstagePass</h1></div>
+        <div class="content">
+          <p>Hallo ${data.vorname},</p>
+          <div class="cancel-box">
+            <p style="margin: 0;"><strong>Die folgende Probe wurde abgesagt:</strong></p>
+            <h3 style="margin: 10px 0 0 0;">${titel}</h3>
+            <p style="margin: 4px 0 0 0;"><strong>Datum:</strong> ${datum}</p>
+          </div>
+          ${
+            data.grund
+              ? `<p><strong>Grund:</strong><br>${data.grund}</p>`
+              : '<p>Es wurde kein Grund angegeben.</p>'
+          }
+          <p>Wir melden uns mit einem neuen Termin, sobald er steht.</p>
+        </div>
+        ${footerHtml}
+      </div>
+    </body>
+    </html>
+  `
+
+  const text = `
+Hallo ${data.vorname},
+
+Die folgende Probe wurde abgesagt:
+${titel}
+Datum: ${datum}
+
+${data.grund ? `Grund: ${data.grund}` : 'Es wurde kein Grund angegeben.'}
+
+Wir melden uns mit einem neuen Termin, sobald er steht.
+
+${footerText}
+  `.trim()
+
+  return { subject, html, text }
+}

--- a/supabase/migrations/20260626084805_proben_email_neue_einladung.sql
+++ b/supabase/migrations/20260626084805_proben_email_neue_einladung.sql
@@ -1,0 +1,8 @@
+-- Migration: Add opt-out flag for "Sofort-Einladungs-Mail" on probe invitation (Issue #489)
+-- Sprint 5 - Künstlerische Produktion - A4.2
+
+ALTER TABLE benachrichtigungs_einstellungen
+  ADD COLUMN IF NOT EXISTS email_neue_einladung BOOLEAN NOT NULL DEFAULT true;
+
+COMMENT ON COLUMN benachrichtigungs_einstellungen.email_neue_einladung IS
+  'Opt-out für Sofort-Mail beim Hinzufügen zu einer Probe (Issue #489).';


### PR DESCRIPTION
Closes #489 (Sprint 5 / A4.2 — Künstlerische Produktion)

## Summary

Wenn jemand zu einer Probe eingeladen wird, eine Probe geändert oder abgesagt wird, geht ab sofort **direkt** eine E-Mail an die betroffenen Teilnehmer raus. Bisher gab es nur eine 24h-Erinnerung — wer kurzfristig eingeladen wurde, hat es nur in der In-App-Notification gesehen.

Best-effort Dispatch: Mail-Fehler brechen die Probe-Action **nicht** ab.

## Was wurde geändert?

### 4 Trigger-Punkte in `lib/actions/proben.ts`

| Action | Auslöser |
|---|---|
| `addTeilnehmerToProbe` | Einladung an die hinzugefügte Person |
| `confirmProbenTeilnehmer` | Einladung — nur an **neu** hinzugefügte IDs (existing IDs werden vorher gelesen und ausgefiltert) |
| `autoInviteProbeTeilnehmer` | Einladung — Diff von existing IDs vor/nach RPC |
| `updateProbe` | Bei `status` flip auf `abgesagt`/`verschoben` → Absage-Mail. Sonst bei Diff von `datum`/`startzeit`/`endzeit`/`ort` → Änderungs-Mail |

### Templates (`lib/email/templates/proben.ts`)
- `probeEinladungEmail` — Sofort-Einladung mit Datum/Zeit/Ort + Link zur Probe
- `probeAenderungEmail` — Änderung mit explizitem Vorher/Nachher-Diff
- `probeAbsageEmail` — Absage mit optionalem Grund

Konvention wie `helferliste.ts`: inline HTML+Text, kein DB-Roundtrip, deutsche UI.

### Dispatcher (`lib/actions/proben-emails.ts`)
- Nutzt **Admin-Client** (Settings-Tabelle hat RLS auf `profile_id = auth.uid()`)
- Profile-Lookup über `personen.email` ↔ `profiles.email` (gleiche Konvention wie `notify_probe_change()`)
- Pro-Person Opt-out-Check
- `email_logs.template_typ`: `probe_einladung` / `probe_aenderung` / `probe_absage`
- Counter-Return `{ sent, skipped, failed }`

### Opt-out
- **Neue Spalte** `benachrichtigungs_einstellungen.email_neue_einladung BOOLEAN DEFAULT true` für Einladungen
- **Bestehende** `email_aenderungsbenachrichtigung` deckt Änderung + Absage ab

### Migration
`supabase/migrations/20260626084805_proben_email_neue_einladung.sql`

⚠️ **Migration NICHT angewendet** — bitte selbst applien (wie bei #475).
Nach Apply hat jeder Profile automatisch Default `true` (Opt-out via UI später).

### Tests
17 Unit-Tests in `lib/actions/proben-emails.test.ts`:
- Mocked SMTP via `vi.hoisted` (kein echter Mail-Versand)
- Pro Funktion: success-path, opt-out, fehlende Email, fehlendes Profile, empty IDs, leerer Diff, failed send, Probe nicht gefunden
- Existing Proben-Tests (`proben.test.ts`, `proben-teilnehmer-suggest.test.ts`) mocken `./proben-emails`, damit sie nicht ungewollt auf den Admin-Client gehen

## TODO (separates Issue)

Settings-UI in `/mein-bereich` — User soll `email_neue_einladung` & `email_aenderungsbenachrichtigung` selbst togglen können. Aktuell nur DB-Default (true = aktiv).

## Quality Gates

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test:run` ✅ (156/156 passed)
- `npm run build` ✅

## Test plan

- [ ] Migration applien (`benachrichtigungs_einstellungen.email_neue_einladung` Spalte vorhanden)
- [ ] Probe-Teilnehmer einzeln hinzufügen → Einladungs-Mail an Person mit Profile+Email
- [ ] „Vorschläge bestätigen" mit Mix aus existing + neu → nur neue bekommen Mail
- [ ] Auto-Invite RPC → nur die neu eingefügten bekommen Mail
- [ ] Probe-Datum ändern → alle Teilnehmer bekommen Änderungs-Mail mit Diff
- [ ] Probe-Status auf "abgesagt" setzen → Absage-Mail
- [ ] User opted-out (DB-Update `email_neue_einladung = false`) → keine Einladung, In-App noch aktiv

🤖 Generated with [Claude Code](https://claude.com/claude-code)